### PR TITLE
WFLY-21744 Transactional invalidation caches use too many segments

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/DistributedCacheResourceDefinitionRegistrar.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/DistributedCacheResourceDefinitionRegistrar.java
@@ -33,7 +33,7 @@ import org.wildfly.subsystem.service.capture.FunctionExecutorRegistry;
  * Registers a resource definition for a distributed cache.
  * @author Paul Ferraro
  */
-public class DistributedCacheResourceDefinitionRegistrar extends SegmentedCacheResourceDefinitionRegistrar {
+public class DistributedCacheResourceDefinitionRegistrar extends SharedStateCacheResourceDefinitionRegistrar {
 
     static final DurationAttributeDefinition L1_LIFESPAN = DurationAttributeDefinition.builder("l1-lifespan", ChronoUnit.MILLIS).setDefaultValue(Duration.ZERO).build();
 

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemModel.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemModel.java
@@ -39,9 +39,10 @@ public enum InfinispanSubsystemModel implements SubsystemModel {
     VERSION_18_0_0(18, 0, 0), // WildFly 30-34
     VERSION_19_0_0(19, 0, 0), // WildFly 35-36, EAP 8.1
     VERSION_20_0_0(20, 0, 0), // WildFly 37-38
-    VERSION_21_0_0(21, 0, 0), // WildFly 39-present
+    VERSION_21_0_0(21, 0, 0), // WildFly 39
+    VERSION_22_0_0(22, 0, 0), // WildFly 40-present
     ;
-    static final InfinispanSubsystemModel CURRENT = VERSION_21_0_0;
+    static final InfinispanSubsystemModel CURRENT = VERSION_22_0_0;
 
     private final ModelVersion version;
 

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemSchema.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemSchema.java
@@ -241,13 +241,13 @@ public enum InfinispanSubsystemSchema implements SubsystemResourceXMLSchema<Infi
     }
 
     private ResourceRegistrationXMLElement invalidationCacheElement() {
-        return this.clusteredCacheElementBuilder(CacheResourceRegistration.INVALIDATION)
+        return (this.since(VERSION_16_0) ? this.segmentedCacheElementBuilder(CacheResourceRegistration.INVALIDATION) : this.clusteredCacheElementBuilder(CacheResourceRegistration.INVALIDATION))
                 .withContent(this.cacheElementContentBuilder().build())
                 .build();
     }
 
     private ResourceRegistrationXMLElement replicatedCacheElement() {
-        return this.clusteredCacheElementBuilder(CacheResourceRegistration.REPLICATED)
+        return (this.since(VERSION_16_0) ? this.segmentedCacheElementBuilder(CacheResourceRegistration.REPLICATED) : this.clusteredCacheElementBuilder(CacheResourceRegistration.REPLICATED))
                 .withContent(this.sharedStateCacheElementContentBuilder().build())
                 .build();
     }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemSchema.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemSchema.java
@@ -76,9 +76,10 @@ public enum InfinispanSubsystemSchema implements SubsystemResourceXMLSchema<Infi
     VERSION_12_0(12, 0), // WildFly 23, EAP 7.4
     VERSION_13_0(13, 0), // WildFly 24-26
     VERSION_14_0(14, 0), // WildFly 27-35
-    VERSION_15_0(15, 0), // WildFly 36-present
+    VERSION_15_0(15, 0), // WildFly 36-39
+    VERSION_16_0(16, 0), // WildFly 40-present
     ;
-    static final InfinispanSubsystemSchema CURRENT = VERSION_15_0;
+    static final InfinispanSubsystemSchema CURRENT = VERSION_16_0;
 
     private final ResourceXMLParticleFactory factory = ResourceXMLParticleFactory.newInstance(this);
     private final VersionedNamespace<IntVersion, InfinispanSubsystemSchema> namespace;

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InvalidationCacheResourceDefinitionRegistrar.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InvalidationCacheResourceDefinitionRegistrar.java
@@ -8,7 +8,7 @@ package org.jboss.as.clustering.infinispan.subsystem;
  * Registers a resource definition for an invalidation cache.
  * @author Paul Ferraro
  */
-public class InvalidationCacheResourceDefinitionRegistrar extends ClusteredCacheResourceDefinitionRegistrar {
+public class InvalidationCacheResourceDefinitionRegistrar extends SegmentedCacheResourceDefinitionRegistrar {
 
     InvalidationCacheResourceDefinitionRegistrar() {
         super(CacheResourceRegistration.INVALIDATION);

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InvalidationCacheResourceTransformer.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InvalidationCacheResourceTransformer.java
@@ -5,6 +5,9 @@
 
 package org.jboss.as.clustering.infinispan.subsystem;
 
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
+import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 
 /**
@@ -15,5 +18,17 @@ public class InvalidationCacheResourceTransformer extends ClusteredCacheResource
 
     InvalidationCacheResourceTransformer(ResourceTransformationDescriptionBuilder parent) {
         super(parent.addChildResource(CacheResourceRegistration.INVALIDATION.getPathElement()));
+    }
+
+    @Override
+    public void accept(ModelVersion version) {
+        super.accept(version);
+
+        if (InfinispanSubsystemModel.VERSION_22_0_0.requiresTransformation(version)) {
+            this.builder.getAttributeBuilder()
+                    .setDiscard(DiscardAttributeChecker.UNDEFINED, SegmentedCacheResourceDefinitionRegistrar.SEGMENTS)
+                    .addRejectCheck(RejectAttributeChecker.DEFINED, SegmentedCacheResourceDefinitionRegistrar.SEGMENTS)
+                    .end();
+        }
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ReplicatedCacheResourceTransformer.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ReplicatedCacheResourceTransformer.java
@@ -5,6 +5,9 @@
 
 package org.jboss.as.clustering.infinispan.subsystem;
 
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
+import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 
 /**
@@ -15,5 +18,17 @@ public class ReplicatedCacheResourceTransformer extends SharedStateCacheResource
 
     ReplicatedCacheResourceTransformer(ResourceTransformationDescriptionBuilder parent) {
         super(parent.addChildResource(CacheResourceRegistration.REPLICATED.getPathElement()));
+    }
+
+    @Override
+    public void accept(ModelVersion version) {
+        super.accept(version);
+
+        if (InfinispanSubsystemModel.VERSION_22_0_0.requiresTransformation(version)) {
+            this.builder.getAttributeBuilder()
+                    .setDiscard(DiscardAttributeChecker.UNDEFINED, SegmentedCacheResourceDefinitionRegistrar.SEGMENTS)
+                    .addRejectCheck(RejectAttributeChecker.DEFINED, SegmentedCacheResourceDefinitionRegistrar.SEGMENTS)
+                    .end();
+        }
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ScatteredCacheResourceDefinitionRegistrar.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ScatteredCacheResourceDefinitionRegistrar.java
@@ -23,7 +23,7 @@ import org.wildfly.subsystem.service.capture.FunctionExecutorRegistry;
  * Registers a resource definition for a scattered cache.
  * @author Paul Ferraro
  */
-public class ScatteredCacheResourceDefinitionRegistrar extends SegmentedCacheResourceDefinitionRegistrar {
+public class ScatteredCacheResourceDefinitionRegistrar extends SharedStateCacheResourceDefinitionRegistrar {
 
     static final DurationAttributeDefinition BIAS_LIFESPAN = DurationAttributeDefinition.builder("bias-lifespan", ChronoUnit.MILLIS)
             .setDefaultValue(Duration.ofMinutes(5))

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/SegmentedCacheResourceDefinitionRegistrar.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/SegmentedCacheResourceDefinitionRegistrar.java
@@ -7,7 +7,6 @@ package org.jboss.as.clustering.infinispan.subsystem;
 import java.util.List;
 import java.util.function.UnaryOperator;
 
-import org.infinispan.Cache;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -19,13 +18,12 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.subsystem.resource.ResourceDescriptor;
 import org.wildfly.subsystem.service.ServiceDependency;
-import org.wildfly.subsystem.service.capture.FunctionExecutorRegistry;
 
 /**
  * Registers a resource definition for a segmented cache configuration.
  * @author Paul Ferraro
  */
-public class SegmentedCacheResourceDefinitionRegistrar extends SharedStateCacheResourceDefinitionRegistrar {
+public class SegmentedCacheResourceDefinitionRegistrar extends ClusteredCacheResourceDefinitionRegistrar {
 
     static final AttributeDefinition SEGMENTS = new SimpleAttributeDefinitionBuilder("segments", ModelType.INT)
             .setAllowExpression(true)
@@ -35,8 +33,8 @@ public class SegmentedCacheResourceDefinitionRegistrar extends SharedStateCacheR
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
 
-    SegmentedCacheResourceDefinitionRegistrar(CacheResourceRegistration registration, FunctionExecutorRegistry<Cache<?, ?>> executors) {
-        super(registration, executors);
+    SegmentedCacheResourceDefinitionRegistrar(CacheResourceRegistration registration) {
+        super(registration);
     }
 
     @Override

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/SharedStateCacheResourceDefinitionRegistrar.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/SharedStateCacheResourceDefinitionRegistrar.java
@@ -28,7 +28,7 @@ import org.wildfly.subsystem.service.capture.FunctionExecutorRegistry;
  * Registers a resource definition for a shared state cache configuration.
  * @author Paul Ferraro
  */
-public class SharedStateCacheResourceDefinitionRegistrar extends ClusteredCacheResourceDefinitionRegistrar {
+public class SharedStateCacheResourceDefinitionRegistrar extends SegmentedCacheResourceDefinitionRegistrar {
 
     private final FunctionExecutorRegistry<Cache<?, ?>> executors;
 

--- a/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_16_0.xsd
+++ b/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_16_0.xsd
@@ -353,15 +353,27 @@
         </xs:complexContent>
     </xs:complexType>
 
+    <xs:complexType name="segmented-cache" abstract="true">
+        <xs:complexContent>
+            <xs:extension base="tns:clustered-cache">
+                <xs:attribute name="segments" type="xs:int" default="128">
+                    <xs:annotation>
+                        <xs:documentation>Number of hash space segments (per cluster).</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
     <xs:complexType name="invalidation-cache">
         <xs:complexContent>
-            <xs:extension base="tns:clustered-cache"/>
+            <xs:extension base="tns:segmented-cache"/>
         </xs:complexContent>
     </xs:complexType>
 
     <xs:complexType name="shared-state-cache" abstract="true">
         <xs:complexContent>
-            <xs:extension base="tns:clustered-cache">
+            <xs:extension base="tns:segmented-cache">
                 <xs:sequence>
                     <xs:element name="partition-handling" type="tns:partition-handling" minOccurs="0">
                         <xs:annotation>
@@ -391,21 +403,9 @@
         </xs:complexContent>
     </xs:complexType>
 
-    <xs:complexType name="segmented-cache" abstract="true">
-        <xs:complexContent>
-            <xs:extension base="tns:shared-state-cache">
-                <xs:attribute name="segments" type="xs:int" default="256">
-                    <xs:annotation>
-                        <xs:documentation>Number of hash space segments (per cluster).</xs:documentation>
-                    </xs:annotation>
-                </xs:attribute>
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-
     <xs:complexType name="distributed-cache">
         <xs:complexContent>
-            <xs:extension base="tns:segmented-cache">
+            <xs:extension base="tns:shared-state-cache">
                 <xs:attribute name="owners" type="xs:int" default="2">
                     <xs:annotation>
                         <xs:documentation>Number of cluster-wide replicas for each cache entry.</xs:documentation>
@@ -427,7 +427,7 @@
 
     <xs:complexType name="scattered-cache">
         <xs:complexContent>
-            <xs:extension base="tns:segmented-cache">
+            <xs:extension base="tns:shared-state-cache">
                 <xs:attribute name="bias-lifespan" type="xs:long" default="300000">
                     <xs:annotation>
                         <xs:documentation>When greater than zero, specifies the duration (in ms) that a cache entry will be cached on a non-owner following a write operation.</xs:documentation>

--- a/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_16_0.xsd
+++ b/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_16_0.xsd
@@ -1,0 +1,1341 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+<xs:schema targetNamespace="urn:jboss:domain:infinispan:16.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="urn:jboss:domain:infinispan:16.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="16.0">
+
+    <xs:element name="subsystem" type="tns:subsystem">
+        <xs:annotation>
+            <xs:documentation>Enumerates the cache containers available to the registry.</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <xs:complexType name="subsystem">
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="cache-container" type="tns:cache-container">
+                <xs:annotation>
+                    <xs:documentation>Defines an embedded cache container.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="remote-cache-container" type="tns:remote-cache-container">
+                <xs:annotation>
+                    <xs:documentation>Defines a remote cache container.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="cache-container">
+        <xs:sequence>
+            <xs:element name="transport" type="tns:transport" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Overrides the transport characteristics for this cache container.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="blocking-thread-pool" type="tns:thread-pool" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Defines a thread pool used for blocking operations.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="listener-thread-pool" type="tns:thread-pool" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Defines a thread pool used for asynchronous cache listener notifications.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="non-blocking-thread-pool" type="tns:thread-pool" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Defines a thread pool used for non-blocking operations.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="expiration-thread-pool" type="tns:scheduled-thread-pool" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Defines a scheduled thread pool used for expiration.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:choice maxOccurs="unbounded">
+                <xs:element name="local-cache" type="tns:local-cache">
+                    <xs:annotation>
+                        <xs:documentation>Defines a local mode cache.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="replicated-cache" type="tns:replicated-cache">
+                    <xs:annotation>
+                        <xs:documentation>Defines a replication mode cache.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="invalidation-cache" type="tns:invalidation-cache">
+                    <xs:annotation>
+                        <xs:documentation>Defines an invalidation mode cache.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="distributed-cache" type="tns:distributed-cache">
+                    <xs:annotation>
+                        <xs:documentation>Defines a distribution mode cache.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="scattered-cache" type="tns:scattered-cache">
+                    <xs:annotation>
+                        <xs:documentation>Defines a scattered mode cache.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>Uniquely identifies this cache container.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="aliases" type="tns:list">
+            <xs:annotation>
+                <xs:documentation>A set of aliases by which this cache container may also be referenced.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="default-cache" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>Indicates the default cache for this cache container.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="marshaller" type="tns:marshaller" default="LEGACY">
+            <xs:annotation>
+                <xs:documentation>Defines the marshalling implementation used to marshal cache entries.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="modules" type="tns:list" default="org.jboss.as.clustering.infinispan">
+            <xs:annotation>
+                <xs:documentation>Defines the set of modules associated with this cache container.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="statistics-enabled" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>Determines whether or not the cache container should collect statistics.  Keep disabled for optimal performance.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="transport">
+        <xs:attribute name="channel" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>Defines the channel used for this transport.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="stack" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>Defines the jgroups stack used by the transport.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="lock-timeout" type="xs:long" default="240000">
+            <xs:annotation>
+                <xs:documentation>
+                    Infinispan uses a distributed lock to maintain a coherent transaction log during state transfer or rehashing, which means that only one cache can be doing state transfer or rehashing at the same time.
+                    This constraint is in place because more than one cache could be involved in a transaction.
+                    This timeout controls the time to wait to acquire acquire a lock on the distributed lock.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="cache" abstract="true">
+        <xs:sequence>
+            <xs:element name="locking" type="tns:locking" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>The locking configuration of the cache.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="transaction" type="tns:transaction" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>The cache transaction configuration.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:choice minOccurs="0">
+                <xs:element name="heap-memory" type="tns:heap-memory">
+                    <xs:annotation>
+                        <xs:documentation>The cache memory configuration.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="off-heap-memory" type="tns:off-heap-memory">
+                    <xs:annotation>
+                        <xs:documentation>The cache memory configuration.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+            <xs:element name="expiration" type="tns:expiration" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>The cache expiration configuration.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:choice minOccurs="0">
+                <xs:element name="store" type="tns:custom-store">
+                    <xs:annotation>
+                        <xs:documentation>Defines a custom cache store.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="file-store" type="tns:file-store">
+                    <xs:annotation>
+                        <xs:documentation>Defines a file-based cache store.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="jdbc-store" type="tns:jdbc-store">
+                    <xs:annotation>
+                        <xs:documentation>Defines a database cache store accessed via JDBC using string-based keys.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="remote-store" type="tns:remote-store">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Defines a remote cache store accessed via HotRod.
+                            Nested properties will be treated as HotRod client properties.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="hotrod-store" type="tns:hotrod-store">
+                    <xs:annotation>
+                        <xs:documentation>
+                            HotRod-based store using Infinispan Server instance to store data.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>Uniquely identifies this cache within its cache container.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="modules" type="tns:list">
+            <xs:annotation>
+                <xs:documentation>
+                    Defines the set of modules associated with cache, if different from the enclosing cache container.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="statistics-enabled" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>Determines whether or not the cache should collect statistics.  Keep disabled for optimal performance.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="local-cache">
+        <xs:complexContent>
+            <xs:extension base="tns:cache"/>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="locking">
+        <xs:attribute name="isolation" type="tns:isolation" default="READ_COMMITTED">
+            <xs:annotation>
+                <xs:documentation>Sets the cache locking isolation level.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="striping" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    If true, a pool of shared locks is maintained for all entries that need to be locked.
+                    Otherwise, a lock is created per entry in the cache.
+                    Lock striping helps control memory footprint but may reduce concurrency in the system.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="acquire-timeout" type="xs:long" default="15000">
+            <xs:annotation>
+                <xs:documentation>Maximum time to attempt a particular lock acquisition.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="concurrency-level" type="xs:int" default="1000">
+            <xs:annotation>
+                <xs:documentation>Deprecated. This attribute has no effect.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="transaction">
+        <xs:attribute name="mode" type="tns:transaction-mode" default="NONE">
+            <xs:annotation>
+                <xs:documentation>Defines the transaction mode of the cache.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="stop-timeout" type="xs:long" default="10000">
+            <xs:annotation>
+                <xs:documentation>
+                    If there are any ongoing transactions when a cache is stopped, Infinispan waits for ongoing remote and local transactions to finish.
+                    The amount of time to wait for is defined by the cache stop timeout.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="locking" type="tns:locking-mode" default="PESSIMISTIC">
+            <xs:annotation>
+                <xs:documentation>The locking mode for this cache, one of OPTIMISTIC or PESSIMISTIC.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="complete-timeout" type="xs:long" default="60000">
+            <xs:annotation>
+                <xs:documentation>
+                    The default duration (in ms) after which idle transactions are rolled back.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="memory">
+        <xs:attribute name="size" type="xs:long">
+            <xs:annotation>
+                <xs:documentation>Maximum size of this cache.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="heap-memory">
+        <xs:complexContent>
+            <xs:extension base="tns:memory">
+                <xs:attribute name="size-unit" type="tns:size-unit" fixed="ENTRIES">
+                    <xs:annotation>
+                        <xs:documentation>Describes the unit of measurement for the size attribute.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="off-heap-memory">
+        <xs:complexContent>
+            <xs:extension base="tns:memory">
+                <xs:attribute name="size-unit" type="tns:size-unit" default="ENTRIES">
+                    <xs:annotation>
+                        <xs:documentation>Describes the unit of measurement for the size attribute.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="expiration">
+        <xs:attribute name="max-idle" type="xs:long">
+            <xs:annotation>
+                <xs:documentation>
+                    Maximum idle time a cache entry will be maintained in the cache, in milliseconds.
+                    If the idle time is exceeded, the entry will be expired cluster-wide.
+                    If undefined, idle cache entries will not auto-expire.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="lifespan" type="xs:long">
+            <xs:annotation>
+                <xs:documentation>
+                    Maximum lifespan of a cache entry, after which the entry is expired cluster-wide, in milliseconds.
+                    If undefined, cache entries will not auto-expire.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="interval" type="xs:long" default="5000">
+            <xs:annotation>
+                <xs:documentation>
+                    Interval (in milliseconds) between subsequent runs to purge expired entries from memory and any cache stores.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="clustered-cache" abstract="true">
+        <xs:complexContent>
+            <xs:extension base="tns:cache">
+                <xs:attribute name="remote-timeout" type="xs:long">
+                    <xs:annotation>
+                        <xs:documentation>The timeout (in ms) used to wait for an acknowledgment when making a remote call, after which the call is aborted and an exception is thrown.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="invalidation-cache">
+        <xs:complexContent>
+            <xs:extension base="tns:clustered-cache"/>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="shared-state-cache" abstract="true">
+        <xs:complexContent>
+            <xs:extension base="tns:clustered-cache">
+                <xs:sequence>
+                    <xs:element name="partition-handling" type="tns:partition-handling" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>The partition handling configuration for distributed and replicated caches.</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="state-transfer" type="tns:state-transfer" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>The state transfer configuration for distributed and replicated caches.</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:sequence minOccurs="0">
+                        <xs:element name="backups" type="tns:backups" minOccurs="0">
+                            <xs:annotation>
+                                <xs:documentation>A list of backup sites for this cache (for use with cross-site replication).</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="replicated-cache">
+        <xs:complexContent>
+            <xs:extension base="tns:shared-state-cache"/>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="segmented-cache" abstract="true">
+        <xs:complexContent>
+            <xs:extension base="tns:shared-state-cache">
+                <xs:attribute name="segments" type="xs:int" default="256">
+                    <xs:annotation>
+                        <xs:documentation>Number of hash space segments (per cluster).</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="distributed-cache">
+        <xs:complexContent>
+            <xs:extension base="tns:segmented-cache">
+                <xs:attribute name="owners" type="xs:int" default="2">
+                    <xs:annotation>
+                        <xs:documentation>Number of cluster-wide replicas for each cache entry.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="l1-lifespan" type="xs:long" default="0">
+                    <xs:annotation>
+                        <xs:documentation>Maximum lifespan in milliseconds of an entry placed in the L1 cache.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="capacity-factor" type="xs:float" default="1.0">
+                    <xs:annotation>
+                        <xs:documentation>Controls the proportion of entries that will reside on the local node, compared to the other nodes in the cluster.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="scattered-cache">
+        <xs:complexContent>
+            <xs:extension base="tns:segmented-cache">
+                <xs:attribute name="bias-lifespan" type="xs:long" default="300000">
+                    <xs:annotation>
+                        <xs:documentation>When greater than zero, specifies the duration (in ms) that a cache entry will be cached on a non-owner following a write operation.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="invalidation-batch-size" type="xs:int" default="128">
+                    <xs:annotation>
+                        <xs:documentation>The threshold after which batched invalidations are sent.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="store" abstract="true">
+        <xs:sequence>
+            <xs:element name="write-behind" type="tns:write-behind" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Configures a cache store as write-behind instead of write-through.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="property" type="tns:property" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>A cache store property with name and value.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="max-batch-size" type="xs:int" default="100">
+            <xs:annotation>
+                <xs:documentation>
+                    The maximum size of a batch to be inserted/deleted from the store.
+                    If the value is less than one, then no upper limit is placed on the number of operations in a batch.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="shared" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    This setting should be set to true when multiple cache instances share the same cache store, e.g. multiple nodes in a cluster using a JDBC-based CacheStore pointing to the same shared database.
+                    Setting this to true avoids multiple cache instances writing the same modification multiple times.
+                    If enabled, only the node where the modification originated will write to the cache store.
+                    If disabled, each individual cache reacts to a potential remote update by storing the data to the cache store.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="preload" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    If true, when the cache starts, data stored in the cache store will be pre-loaded into memory.
+                    This is particularly useful when data in the cache store will be needed immediately after startup and you want to avoid cache operations being delayed as a result of loading this data lazily.
+                    Can be used to provide a 'warm-cache' on startup, however there is a performance penalty as startup time is affected by this process.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="passivation" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    If true, data is only written to the cache store when it is evicted from memory, a phenomenon known as 'passivation'.
+                    Next time the data is requested, it will be 'activated' which means that data will be brought back to memory and removed from the persistent store.
+                    If false, the cache store contains a copy of the contents in memory, so writes to cache result in cache store writes.
+                    This essentially gives you a 'write-through' configuration.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="fetch-state" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>If true, fetch persistent state when joining a cluster.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="purge" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>If true, purges this cache store when it starts up.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="segmented" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>Indicates whether or not the cache store is segmented. The number of segments is defined by the segments attribute of the associated cache resource.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="write-behind">
+        <xs:attribute name="modification-queue-size" type="xs:int" default="1024">
+            <xs:annotation>
+                <xs:documentation>
+                    Maximum number of entries in the asynchronous queue. When the queue is full, the store becomes write-through.
+                    until it can accept new entries
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="custom-store">
+        <xs:complexContent>
+            <xs:extension base="tns:store">
+                <xs:attribute name="class" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>The class name of the cache store implementation.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="file-store">
+        <xs:complexContent>
+            <xs:extension base="tns:store">
+                <xs:attribute name="relative-to" type="xs:string" default="jboss.server.data.dir">
+                    <xs:annotation>
+                        <xs:documentation>The base directory in which to store the cache state.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="path" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The path within "relative-to" in which to store the cache state.
+                            If undefined, the path defaults to the cache container name.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="remote-store">
+        <xs:complexContent>
+            <xs:extension base="tns:store">
+                <xs:attribute name="remote-servers" type="tns:list" use="required">
+                    <xs:annotation>
+                        <xs:documentation>A list of outbound socket bindings.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="cache" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>The name of the remote cache.  If undefined, the default cache will be used.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="socket-timeout" type="xs:long" default="60000">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Enable/disable SO_TIMEOUT on socket connections to remote Hot Rod servers with the specified timeout, in milliseconds.
+                            A timeout of zero is interpreted as an infinite timeout.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="tcp-no-delay" type="xs:boolean" default="true">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Enable/disable TCP_NODELAY on socket connections to remote Hot Rod servers.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="hotrod-store">
+        <xs:complexContent>
+            <xs:extension base="tns:store">
+                <xs:attribute name="cache-configuration" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Name of the cache configuration template defined in Infinispan Server to create caches from.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="remote-cache-container" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to a container-managed remote-cache-container.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="jdbc-store">
+        <xs:complexContent>
+            <xs:extension base="tns:store">
+                <xs:sequence>
+                    <xs:element name="table" type="tns:string-table" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Defines the table used to store cache entries.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute name="data-source" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>References the pool name of a data source.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="dialect" type="tns:dialect" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>Defines the JDBC dialect.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="string-table">
+        <xs:complexContent>
+            <xs:extension base="tns:table">
+                <xs:attribute name="prefix" type="xs:string" default="ispn_entry">
+                    <xs:annotation>
+                        <xs:documentation>Defines the prefix prepended to the cache name used when composing the name of the cache entry table.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="table">
+        <xs:sequence>
+            <xs:element name="id-column" type="tns:id-column" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Defines the column in which to store the cache key or bucket id.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="data-column" type="tns:data-column" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Defines the column in which to store the cache entry or bucket.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="segment-column" type="tns:segment-column" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Defines the column in which to store the entry segment.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="timestamp-column" type="tns:timestamp-column" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Defines the column in which to store the timestamp of the cache entry or bucket.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="fetch-size" type="xs:int" default="100">
+            <xs:annotation>
+                <xs:documentation>The fetch size used when querying from this table.  Used to avoid heap memory exhaustion when query is large.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="create-on-start" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>Indicates whether the store should create this database table when the cache starts.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="drop-on-stop" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>Indicates whether the store should drop this database table when the cache stops.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="id-column">
+        <xs:attribute name="name" type="xs:string" default="id">
+            <xs:annotation>
+                <xs:documentation>The name of the column used to store the cache key.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="type" type="xs:string" default="VARCHAR">
+            <xs:annotation>
+                <xs:documentation>The type of the column used to store the cache key.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="data-column">
+        <xs:attribute name="name" type="xs:string" default="datum">
+            <xs:annotation>
+                <xs:documentation>The name of the column used to store the cache entry.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="type" type="xs:string" default="BINARY">
+            <xs:annotation>
+                <xs:documentation>The type of the column used to store the cache entry.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="segment-column">
+        <xs:attribute name="name" type="xs:string" default="segment">
+            <xs:annotation>
+                <xs:documentation>The name of the column used to store the cache entry segment.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="type" type="xs:string" default="INTEGER">
+            <xs:annotation>
+                <xs:documentation>The type of the column used to store the cache entry segment.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="timestamp-column">
+        <xs:attribute name="name" type="xs:string" default="version">
+            <xs:annotation>
+                <xs:documentation>The name of the column used to store the cache entry timestamp.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="type" type="xs:string" default="BIGINT">
+            <xs:annotation>
+                <xs:documentation>The type of the column used to store the cache entry timestamp.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="partition-handling">
+        <xs:attribute name="when-split" type="tns:when-split" default="ALLOW_READ_WRITES">
+            <xs:annotation>
+                <xs:documentation>Defines the availability of cache entries after a network partition is detected.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="merge-policy" type="tns:merge-policy" default="NONE">
+            <xs:annotation>
+                <xs:documentation>Defines the policy for resolving cache entry conflicts when merging partitions.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="state-transfer">
+        <xs:attribute name="timeout" type="xs:long" default="240000">
+            <xs:annotation>
+                <xs:documentation>
+                    The maximum amount of time (in ms) to wait for state from neighboring caches, before throwing an exception and aborting startup.
+                    A timeout of 0 means the cache will be available immediately after joining, and initial state transfer is non-blocking.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="chunk-size" type="xs:integer" default="512">
+            <xs:annotation>
+                <xs:documentation>The number of cache entries to batch in each transfer.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="backups">
+        <xs:sequence>
+            <xs:element name="backup" type="tns:backup" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>A backup site for this cache.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="backup">
+        <xs:sequence>
+            <xs:element name="take-offline" type="tns:take-offline" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Control when to take this backup site offline.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="site" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>The name of this remote site.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="strategy" type="tns:mode" default="ASYNC">
+            <xs:annotation>
+                <xs:documentation>The backup strategy for this cache.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="failure-policy" type="tns:backup-failure-policy" default="WARN">
+            <xs:annotation>
+                <xs:documentation>The policy to follow when connectivity to the backup site fails.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="timeout" type="xs:long" default="10000">
+            <xs:annotation>
+                <xs:documentation>The timeout for replicating to the backup site.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enabled" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>Indicates whether or not this backup site is enabled.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="take-offline">
+        <xs:attribute name="after-failures" type="xs:int" default="0">
+            <xs:annotation>
+                <xs:documentation>Indicates the number of failures after which this backup site should go offline.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="min-wait" type="xs:long" default="0">
+            <xs:annotation>
+                <xs:documentation>Indicates the minimum time (in milliseconds) to wait after the max number of failures is reached, after which this backup site should go offline.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="property">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="name" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>Defines the name of a property.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:simpleType name="isolation">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="NONE">
+                <xs:annotation>
+                    <xs:documentation>
+                        No locking isolation will be performed. This is only valid in local mode. In clustered mode, READ_COMMITTED will be used instead.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="READ_UNCOMMITTED">
+                <xs:annotation>
+                    <xs:documentation>
+                        Unsupported. Actually configures READ_COMMITTED.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="READ_COMMITTED">
+                <xs:annotation>
+                    <xs:documentation>
+                        Read committed is an isolation level that guarantees that any data read is committed at the moment it is read. However, depending on the outcome of other transactions, successive reads may return different results.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="REPEATABLE_READ">
+                <xs:annotation>
+                    <xs:documentation>
+                        Repeatable read is an isolation level that guarantees that any data read is committed at the moment it is read and that, within a transaction, successive reads will always return the same data.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SERIALIZABLE">
+                <xs:annotation>
+                    <xs:documentation>
+                        Unsupported. Actually configures REPEATABLE_READ.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="transaction-mode">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="NONE">
+                <xs:annotation>
+                    <xs:documentation>Cache will be non-transactional.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BATCH">
+                <xs:annotation>
+                    <xs:documentation>Cache will support batching of operations.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NON_XA">
+                <xs:annotation>
+                    <xs:documentation>Cache will enlist within transactions as a javax.transaction.Synchronization</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NON_DURABLE_XA">
+                <xs:annotation>
+                    <xs:documentation>Cache will enlist within transactions as a javax.transaction.xa.XAResource, without recovery.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="FULL_XA">
+                <xs:annotation>
+                    <xs:documentation>Cache will enlist within transactions as a javax.transaction.xa.XAResource, with recovery.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="mode">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="ASYNC">
+                <xs:annotation>
+                    <xs:documentation>
+                        Enables asynchronous mode.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SYNC">
+                <xs:annotation>
+                    <xs:documentation>
+                        Enables synchronous mode.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="locking-mode">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="OPTIMISTIC">
+                <xs:annotation>
+                    <xs:documentation>
+                        Enables Optimistic locking.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="PESSIMISTIC">
+                <xs:annotation>
+                    <xs:documentation>
+                        Enables Pessimistic locking.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="list">
+        <xs:list itemType="xs:string"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="backup-failure-policy">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="IGNORE">
+                <xs:annotation>
+                    <xs:documentation>
+                        Ignore backup failures.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="WARN">
+                <xs:annotation>
+                    <xs:documentation>
+                        Warn of backup failures.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="FAIL">
+                <xs:annotation>
+                    <xs:documentation>
+                        Fail local operations when a backup failure occurs.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="dialect">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="ACCESS"/>
+            <xs:enumeration value="DB2"/>
+            <xs:enumeration value="DB2_390"/>
+            <xs:enumeration value="DERBY"/>
+            <xs:enumeration value="FIREBIRD"/>
+            <xs:enumeration value="H2"/>
+            <xs:enumeration value="HSQL"/>
+            <xs:enumeration value="INFORMIX"/>
+            <xs:enumeration value="INTERBASE"/>
+            <xs:enumeration value="MARIA_DB"/>
+            <xs:enumeration value="MYSQL"/>
+            <xs:enumeration value="ORACLE"/>
+            <xs:enumeration value="POSTGRES"/>
+            <xs:enumeration value="SQL_SERVER"/>
+            <xs:enumeration value="SQLITE"/>
+            <xs:enumeration value="SYBASE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="size-unit">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="ENTRIES"/>
+            <xs:enumeration value="BYTES"/>
+            <xs:enumeration value="KB"/>
+            <xs:enumeration value="KiB"/>
+            <xs:enumeration value="MB"/>
+            <xs:enumeration value="MiB"/>
+            <xs:enumeration value="GB"/>
+            <xs:enumeration value="GiB"/>
+            <xs:enumeration value="GB"/>
+            <xs:enumeration value="GiB"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="marshaller">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="LEGACY">
+                <xs:annotation>
+                    <xs:documentation>Deprecated. Selects the marshaller dynamically based on the associated modules.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="JBOSS">
+                <xs:annotation>
+                    <xs:documentation>Marshals cache entries using JBoss Marshalling using externalizers loaded from modules associated with this container.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="PROTOSTREAM">
+                <xs:annotation>
+                    <xs:documentation>
+                        Marshals cache entries using ProtoStream configured to use schemas/marshallers loaded from modules associated with this container.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="thread-pool">
+        <xs:attribute name="min-threads" type="xs:int" use="optional">
+            <xs:annotation>
+                <xs:documentation>Minimum thread pool size for the thread pool.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-threads" type="xs:int" use="optional">
+            <xs:annotation>
+                <xs:documentation>Maximum thread pool size for the thread pool.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="queue-length" type="xs:int" use="optional">
+            <xs:annotation>
+                <xs:documentation>Maximum queue length for the thread pool.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="keepalive-time" type="xs:long" use="optional">
+            <xs:annotation>
+                <xs:documentation>Timeout in milliseconds to remove idle thread from the pool.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="scheduled-thread-pool">
+        <xs:attribute name="min-threads" type="xs:int" use="optional">
+            <xs:annotation>
+                <xs:documentation>Fixed thread pool size for the scheduled thread pool.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="keepalive-time" type="xs:long" use="optional">
+            <xs:annotation>
+                <xs:documentation>Timeout in milliseconds to remove idle thread from the scheduled thread pool.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="remote-cache-container">
+        <xs:sequence>
+            <xs:element name="async-thread-pool" type="tns:thread-pool" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Configuration for the executor service used for asynchronous work on the Transport,
+                        including asynchronous marshalling and Cache async operations such as RemoteCache.putAsync().
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="connection-pool" type="tns:connection-pool" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Deprecated. Ignored if defined.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="property" type="tns:property" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        A property with name and value.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="remote-clusters" type="tns:remote-clusters" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Configures remote server clusters for Hot Rod client to connect to.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="security" type="tns:security" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Security configuration.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="connection-timeout" type="xs:int" default="60000">
+            <xs:annotation>
+                <xs:documentation>
+                    Defines the maximum socket connect timeout before giving up connecting to the server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="default-remote-cluster" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies the default remote server cluster.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="key-size-estimate" type="xs:int" default="64">
+            <xs:annotation>
+                <xs:documentation>
+                    This hint allows sizing of byte buffers when serializing and deserializing keys, to minimize array resizing.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-retries" type="xs:int" default="10">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets the maximum number of retries for each request. A valid value should be greater or equals than 0.
+                    Value of 0 means no retry will made in case of a network failure.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="marshaller" type="tns:marshaller" default="LEGACY">
+            <xs:annotation>
+                <xs:documentation>Defines the marshalling implementation used to marshal cache entries.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="modules" type="tns:list" default="org.jboss.as.clustering.infinispan">
+            <xs:annotation>
+                <xs:documentation>Defines the set of modules associated with the configuration of the remote cache container.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Uniquely identifies this remote cache container.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="protocol-version" type="tns:protocol-version" default="3.1">
+            <xs:annotation>
+                <xs:documentation>
+                    Defines the protocol version that this client should use.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="socket-timeout" type="xs:long" default="60000">
+            <xs:annotation>
+                <xs:documentation>
+                    Enable or disable SO_TIMEOUT on socket connections to remote Hot Rod servers with the specified timeout, in milliseconds.
+                    A timeout of 0 is interpreted as an infinite timeout.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="statistics-enabled" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Enables statistics gathering for this remote cache.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="tcp-no-delay" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Enable or disable TCP_NODELAY on socket connections to remote Hot Rod servers.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="tcp-keep-alive" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Configures TCP keepalive on the TCP stack.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="transaction-timeout" type="xs:long" default="60000">
+            <xs:annotation>
+                <xs:documentation>
+                    The default duration (in ms) after which idle transactions are rolled back.
+                    Only applies to transactional remote caches.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="value-size-estimate" type="xs:int" default="512">
+            <xs:annotation>
+                <xs:documentation>
+                    This hint allows sizing of byte buffers when serializing and deserializing values, to minimize array resizing.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="remote-clusters">
+        <xs:choice>
+            <xs:element name="remote-cluster" type="tns:remote-cluster" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>Defines remote server cluster.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="remote-cluster">
+        <xs:attribute name="name" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>Name of remote server cluster.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="socket-bindings">
+            <xs:annotation>
+                <xs:documentation>List of socket bindings of remote servers.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:list itemType="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="connection-pool">
+        <xs:attribute name="exhausted-action" type="tns:exhausted-action" default="WAIT">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies what happens when asking for a connection from a server's pool, and that pool is exhausted.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-active" type="xs:int">
+            <xs:annotation>
+                <xs:documentation>
+                    Controls the maximum number of connections per server that are allocated (checked out to client threads, or idle in the pool) at one time.
+                    When undefined, there is no limit to the number of connections per server.
+                    When maxActive is reached, the connection pool for that server is said to be exhausted.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-wait" type="xs:int">
+            <xs:annotation>
+                <xs:documentation>
+                    The amount of time in milliseconds to wait for a connection to become available when the exhausted action is ExhaustedAction.WAIT,
+                    after which a java.util.NoSuchElementException will be thrown.
+                    If undefined, the pool will block indefinitely.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="min-evictable-idle-time" type="xs:long" default="1800000">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies the minimum amount of time that an connection may sit idle in the pool before it is eligible for eviction due to idle time.
+                    When non-positive, no connection will be dropped from the pool due to idle time alone.
+                    This setting has no effect unless timeBetweenEvictionRunsMillis > 0.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="min-idle" type="xs:int" default="1">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets a target value for the minimum number of idle connections (per server) that should always be available.
+                    If this parameter is set to a positive number and timeBetweenEvictionRunsMillis > 0, each time the idle connection eviction thread runs,
+                    it will try to create enough idle instances so that there will be minIdle idle instances available for each server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="exhausted-action">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="EXCEPTION">
+                <xs:annotation>
+                    <xs:documentation>
+                        An exception will be thrown to the calling user.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="WAIT">
+                <xs:annotation>
+                    <xs:documentation>
+                        The caller will block by invoking waits until a new or idle connections is available.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CREATE_NEW">
+                <xs:annotation>
+                    <xs:documentation>
+                        A new persistent connection will be created and returned thus rendering maxActive meaningless.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="protocol-version">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="3.0"/>
+            <xs:enumeration value="3.1"/>
+            <xs:enumeration value="4.0"/>
+            <xs:enumeration value="4.1"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="when-split">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="ALLOW_READS"/>
+            <xs:enumeration value="ALLOW_READ_WRITES"/>
+            <xs:enumeration value="DENY_READ_WRITES"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="merge-policy">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="NONE"/>
+            <xs:enumeration value="PREFERRED_ALWAYS"/>
+            <xs:enumeration value="PREFERRED_NON_NULL"/>
+            <xs:enumeration value="REMOVE_ALL"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="security">
+        <xs:attribute name="ssl-context" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the Elytron-managed SSLContext to be used for connecting to the remote cluster.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+</xs:schema>

--- a/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanTransformersTestCase.java
+++ b/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanTransformersTestCase.java
@@ -264,6 +264,11 @@ public class InfinispanTransformersTestCase extends AbstractSubsystemTest {
         PathAddress remoteContainerAddress = subsystemAddress.append(RemoteCacheContainerResourceDefinitionRegistrar.REGISTRATION.getPathElement());
         List<String> rejectedRemoteContainerAttributes = new LinkedList<>();
 
+        if (InfinispanSubsystemModel.VERSION_22_0_0.requiresTransformation(this.subsystemVersion)) {
+            config.addFailedAttribute(containerAddress.append(CacheResourceRegistration.REPLICATED.pathElement("repl")), new FailedOperationTransformationConfig.NewAttributesConfig(SegmentedCacheResourceDefinitionRegistrar.SEGMENTS));
+            config.addFailedAttribute(containerAddress.append(CacheResourceRegistration.INVALIDATION.pathElement("invalid")), new FailedOperationTransformationConfig.NewAttributesConfig(SegmentedCacheResourceDefinitionRegistrar.SEGMENTS));
+        }
+
         if (InfinispanSubsystemModel.VERSION_16_0_0.requiresTransformation(this.subsystemVersion)) {
             config.addFailedAttribute(containerAddress.append(CacheResourceRegistration.REPLICATED.pathElement("repl"), ComponentResourceRegistration.PARTITION_HANDLING.getPathElement()), new FailedOperationTransformationConfig.NewAttributesConfig(PartitionHandlingResourceDefinitionRegistrar.MERGE_POLICY));
             config.addFailedAttribute(containerAddress.append(CacheResourceRegistration.DISTRIBUTED.pathElement("dist"), ComponentResourceRegistration.PARTITION_HANDLING.getPathElement()), new FailedOperationTransformationConfig.NewAttributesConfig(PartitionHandlingResourceDefinitionRegistrar.WHEN_SPLIT));

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-16.0.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-16.0.xml
@@ -31,7 +31,7 @@
                 <write-behind modification-queue-size="2048"/>
             </file-store>
         </local-cache>
-        <invalidation-cache name="invalid" modules="org.infinispan" statistics-enabled="true">
+        <invalidation-cache name="invalid" modules="org.infinispan" statistics-enabled="true" segments="2">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
             <transaction mode="NON_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <off-heap-memory size="20000" size-unit="BYTES"/>
@@ -44,7 +44,7 @@
         <invalidation-cache name="invalidation-hotrod">
             <hotrod-store cache-configuration="transactional" remote-cache-container="my-remote-container"/>
         </invalidation-cache>
-        <replicated-cache name="repl" statistics-enabled="true">
+        <replicated-cache name="repl" statistics-enabled="true" segments="2">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="SERIALIZABLE" striping="true"/>
             <transaction mode="NON_DURABLE_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <off-heap-memory size="20000" size-unit="BYTES"/>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-16.0.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-16.0.xml
@@ -3,57 +3,74 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 <subsystem xmlns="urn:jboss:domain:infinispan:16.0">
-    <!-- Don't specify statistics-enabled="false" here so that we test undefined values too -->
-    <cache-container name="minimal" default-cache="local">
+    <cache-container name="minimal" default-cache="local" marshaller="JBOSS">
         <local-cache name="local"/>
     </cache-container>
-    <cache-container name="maximal" aliases="alias1 alias2" default-cache="local" modules="org.infinispan" statistics-enabled="false">
+    <cache-container name="maximal" aliases="alias1 alias2" default-cache="local" marshaller="PROTOSTREAM" modules="org.infinispan org.infinispan.commons" statistics-enabled="true">
         <transport channel="maximal-channel" lock-timeout="120000"/>
-        <local-cache name="local" modules="org.infinispan" statistics-enabled="false">
+        <blocking-thread-pool min-threads="11"
+                              max-threads="12"
+                              queue-length="13"
+                              keepalive-time="14"/>
+        <listener-thread-pool min-threads="21"
+                              max-threads="22"
+                              queue-length="23"
+                              keepalive-time="24"/>
+        <non-blocking-thread-pool min-threads="31"
+                              max-threads="32"
+                              queue-length="33"
+                              keepalive-time="34"/>
+        <expiration-thread-pool min-threads="41"
+                                keepalive-time="42"/>
+        <local-cache name="local" modules="org.infinispan org.infinispan.commons" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="NONE" striping="true"/>
-            <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
+            <transaction mode="BATCH" stop-timeout="60000" locking="OPTIMISTIC" complete-timeout="60000"/>
             <heap-memory size="20000"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <file-store fetch-state="false" passivation="false" path="path" preload="true" purge="false" relative-to="jboss.server.temp.dir" shared="true">
                 <write-behind modification-queue-size="2048"/>
             </file-store>
         </local-cache>
-        <invalidation-cache name="invalid" statistics-enabled="false">
+        <invalidation-cache name="invalid" modules="org.infinispan" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
             <transaction mode="NON_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
-            <heap-memory size="20000"/>
+            <off-heap-memory size="20000" size-unit="BYTES"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <remote-store cache="default" remote-servers="hotrod-server-1 hotrod-server-2" socket-timeout="60000" tcp-no-delay="true" fetch-state="false" passivation="false" preload="true" purge="false" shared="false">
+            <remote-store cache="default" remote-servers="hotrod-server-1 hotrod-server-2" socket-timeout="60000" tcp-no-delay="true" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" segmented="false">
                 <write-behind modification-queue-size="2048"/>
                 <property name="valueSizeEstimate">100</property>
             </remote-store>
         </invalidation-cache>
-        <replicated-cache name="repl" statistics-enabled="false">
+        <invalidation-cache name="invalidation-hotrod">
+            <hotrod-store cache-configuration="transactional" remote-cache-container="my-remote-container"/>
+        </invalidation-cache>
+        <replicated-cache name="repl" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="SERIALIZABLE" striping="true"/>
             <transaction mode="NON_DURABLE_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
-            <off-heap-memory size="20000"/>
-            <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <store class="org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder" fetch-state="true" passivation="true" preload="false" purge="true" shared="false">
-                <write-behind modification-queue-size="2048"/>
-                <property name="location">location</property>
-                <property name="property2">location2</property>
-            </store>
-            <partition-handling merge-policy="REMOVE_ALL"/>
-            <state-transfer timeout="0" chunk-size="10000"/>
-            <backups>
-                <backup site="NYC" failure-policy="WARN" strategy="SYNC" timeout="12000" enabled="false"/>
-                <backup site="SFO" failure-policy="WARN" strategy="SYNC" timeout="12000" enabled="true"/>
-                <backup site="LON" failure-policy="WARN" strategy="SYNC" timeout="12000" enabled="true">
-                    <take-offline after-failures="3" min-wait="10000"/>
-                </backup>
-            </backups>
-        </replicated-cache>
-        <distributed-cache name="dist" l1-lifespan="1200000" owners="4" remote-timeout="35000" segments="12" statistics-enabled="false">
-            <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>
-            <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <off-heap-memory size="20000" size-unit="BYTES"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <partition-handling when-split="ALLOW_READS"/>
+            <store class="org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder" fetch-state="true" passivation="true" preload="false" purge="true" shared="false" segmented="false">
+                <write-behind modification-queue-size="2048"/>
+                <property name="location">${java.io.tmpdir}</property>
+            </store>
+            <partition-handling when-split="ALLOW_READS" merge-policy="REMOVE_ALL"/>
+            <state-transfer timeout="0" chunk-size="10000"/>
+        </replicated-cache>
+        <distributed-cache name="dist" l1-lifespan="1200000" owners="4" remote-timeout="35000" segments="2" capacity-factor="1.0" statistics-enabled="true">
+            <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>
+            <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
+            <heap-memory size="100"/>
+            <expiration interval="10000" lifespan="10" max-idle="10"/>
+            <jdbc-store data-source="ExampleDS" dialect="MARIA_DB" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" max-batch-size="100">
+                <write-behind modification-queue-size="2048"/>
+                <table prefix="foo" fetch-size="100" create-on-start="false" drop-on-stop="true">
+                    <id-column name="id" type="VARCHAR"/>
+                    <data-column name="datum" type="BINARY"/>
+                    <segment-column name="segment" type="INTEGER"/>
+                    <timestamp-column name="version" type="BIGINT"/>
+                </table>
+            </jdbc-store>
+            <partition-handling when-split="DENY_READ_WRITES"/>
             <state-transfer timeout="60000" chunk-size="10000"/>
             <backups>
                 <backup site="NYC" failure-policy="WARN" strategy="SYNC" timeout="12000" enabled="false"/>
@@ -63,36 +80,27 @@
                 </backup>
             </backups>
         </distributed-cache>
-        <scattered-cache name="scattered" remote-timeout="35000" segments="2" invalidation-batch-size="100" bias-lifespan="60000" statistics-enabled="true">
+        <scattered-cache name="scattered" remote-timeout="35000" segments="2" invalidation-batch-size="100" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>
             <heap-memory size="20000"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
+            <partition-handling merge-policy="PREFERRED_NON_NULL"/>
             <state-transfer timeout="60000" chunk-size="10000"/>
         </scattered-cache>
-        <local-cache name="database-persistence">
-            <jdbc-store data-source="ExampleDS">
-                <table prefix="foo">
-                    <id-column name="id" type="VARCHAR"/>
-                    <data-column name="datum" type="BINARY"/>
-                    <segment-column name="segment" type="INTEGER"/>
-                    <timestamp-column name="version" type="BIGINT"/>
-                </table>
-            </jdbc-store>
-        </local-cache>
     </cache-container>
     <remote-cache-container connection-timeout="1000"
                             default-remote-cluster="primary-site"
                             key-size-estimate="512"
                             max-retries="2"
-                            marshaller="PROTOSTREAM"
+                            marshaller="JBOSS"
                             modules="org.infinispan org.infinispan.commons"
                             name="my-remote-container"
                             protocol-version="3.0"
                             socket-timeout="1000"
                             tcp-no-delay="false"
                             tcp-keep-alive="true"
-                            value-size-estimate="1234"
-                            statistics-enabled="true">
+                            transaction-timeout="1000"
+                            value-size-estimate="1234">
         <async-thread-pool min-threads="90"
                            max-threads="100"
                            queue-length="500"

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-reject.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-reject.xml
@@ -18,7 +18,7 @@
                 <write-behind modification-queue-size="2048"/>
             </file-store>
         </local-cache>
-        <invalidation-cache name="invalid" statistics-enabled="false">
+        <invalidation-cache name="invalid" statistics-enabled="false" segments="256">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
             <transaction mode="NON_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <heap-memory size="20000"/>
@@ -28,7 +28,7 @@
                 <property name="valueSizeEstimate">100</property>
             </remote-store>
         </invalidation-cache>
-        <replicated-cache name="repl" statistics-enabled="false">
+        <replicated-cache name="repl" statistics-enabled="false" segments="256">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="SERIALIZABLE" striping="true"/>
             <transaction mode="NON_DURABLE_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <off-heap-memory size="20000"/>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transform-14.0.0.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transform-14.0.0.xml
@@ -2,7 +2,7 @@
   ~ Copyright The WildFly Authors
   ~ SPDX-License-Identifier: Apache-2.0
   -->
-<subsystem xmlns="urn:jboss:domain:infinispan:15.0">
+<subsystem xmlns="urn:jboss:domain:infinispan:16.0">
     <cache-container name="minimal" default-cache="local" marshaller="LEGACY" modules="org.wildfly.clustering.singleton.server org.wildfly.clustering.server.infinispan">
         <local-cache name="local"/>
     </cache-container>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transform-17.1.0.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transform-17.1.0.xml
@@ -2,7 +2,7 @@
   ~ Copyright The WildFly Authors
   ~ SPDX-License-Identifier: Apache-2.0
   -->
-<subsystem xmlns="urn:jboss:domain:infinispan:15.0">
+<subsystem xmlns="urn:jboss:domain:infinispan:16.0">
     <cache-container name="minimal" default-cache="local" marshaller="LEGACY" modules="org.wildfly.clustering.singleton.server org.wildfly.clustering.server.infinispan">
         <local-cache name="local"/>
     </cache-container>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transform-19.0.0.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transform-19.0.0.xml
@@ -2,7 +2,7 @@
   ~ Copyright The WildFly Authors
   ~ SPDX-License-Identifier: Apache-2.0
   -->
-<subsystem xmlns="urn:jboss:domain:infinispan:15.0">
+<subsystem xmlns="urn:jboss:domain:infinispan:16.0">
     <cache-container name="minimal" default-cache="local" marshaller="LEGACY" modules="org.wildfly.clustering.singleton.server org.wildfly.clustering.server.infinispan">
         <local-cache name="local"/>
     </cache-container>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21744

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21744](https://issues.redhat.com/browse/WFLY-21744)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)