### PR TITLE
[WFLY-21762] Remove requirement for the wildfly channel to the wildfly-ee channel

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -65,8 +65,22 @@
         <!-- Depends on the org.wildfly.channels:wildfly artifact to ensure
              that this channel is built first before the distribution is created -->
         <dependency>
-            <groupId>org.wildfly.channels</groupId>
+            <groupId>${channels.maven.groupId}</groupId>
             <artifactId>wildfly</artifactId>
+            <version>${full.maven.version}</version>
+            <classifier>manifest</classifier>
+            <type>yaml</type>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>${channels.maven.groupId}</groupId>
+            <artifactId>wildfly-ee</artifactId>
             <version>${full.maven.version}</version>
             <classifier>manifest</classifier>
             <type>yaml</type>
@@ -135,6 +149,16 @@
                                     <manifest>
                                         <groupId>${channels.maven.groupId}</groupId>
                                         <artifactId>wildfly</artifactId>
+                                        <version>${full.maven.version}</version>
+                                    </manifest>
+                                </channel>
+                                <!-- WFLY-21762 - Add the org.wildfly.channels:wildfly-ee channel -->
+                                <!-- since the org.wildfly.channels:wildfly no longer requires it -->
+                                <channel>
+                                    <name>wildfly-ee</name>
+                                    <manifest>
+                                        <groupId>${channels.maven.groupId}</groupId>
+                                        <artifactId>wildfly-ee</artifactId>
                                         <version>${full.maven.version}</version>
                                     </manifest>
                                 </channel>

--- a/galleon-pack/channel/pom.xml
+++ b/galleon-pack/channel/pom.xml
@@ -173,14 +173,15 @@
                     <manifestId>${project.groupId}:${project.artifactId}</manifestId>
                     <manifestDescription>Manifest for WildFly feature pack.</manifestDescription>
                     <manifestLogicalVersion>WildFly ${project.version}</manifestLogicalVersion>
-                    <manifestRequirements>
-                        <manifestRequirement>
-                            <id>${project.groupId}:wildfly-ee</id>
-                            <groupId>${project.groupId}</groupId>
-                            <artifactId>wildfly-ee</artifactId>
-                            <version>${project.version}</version>
-                        </manifestRequirement>
-                    </manifestRequirements>
+                    <!-- Do not require the org.wildfly.channels:wildfly-ee channel -->
+                    <!-- <manifestRequirements>                                     -->
+                    <!--     <manifestRequirement>                                  -->
+                    <!--         <id>${project.groupId}:wildfly-ee</id>             -->
+                    <!--         <groupId>${project.groupId}</groupId>              -->
+                    <!--         <artifactId>wildfly-ee</artifactId>                -->
+                    <!--         <version>${project.version}</version>              -->
+                    <!--     </manifestRequirement>                                 -->
+                    <!-- </manifestRequirements>                                    -->
                 </configuration>
             </plugin>
         </plugins>

--- a/galleon-pack/galleon-feature-pack/pom.xml
+++ b/galleon-pack/galleon-feature-pack/pom.xml
@@ -241,6 +241,9 @@
                             <release-name>${full.dist.product.release.name}</release-name>
                             <fork-embedded>${galleon.fork.embedded}</fork-embedded>
                             <generate-channel-manifest>true</generate-channel-manifest>
+                            <!-- Do not bring any dependent feature pack (such as org.wildfly:wildfly-ee-galleon-pack) -->
+                            <!-- as a manifest requirement -->
+                            <add-feature-packs-as-required-manifests>false</add-feature-packs-as-required-manifests>
                             <deploy-channel-manifest>false</deploy-channel-manifest>
                             <generate-complete-model>true</generate-complete-model>
                             <copyright>${copyright}</copyright>


### PR DESCRIPTION
When the channel is generated (in galleon-pack/galleon-feature-pack), do not add a requirement for the org.wildfly:wildfly-ee-galleon-pack feature pack.

When the channel is edited (in galleon-pack/channel) before it is attached to the the project, do not add a requirement for the org.wildfly.channels:wildfly-ee channel.

This fixes https://redhat.atlassian.net/browse/WFLY-21762.
