### PR TITLE
WFLY-21244 Upgrade mod_cluster UndertowEventHandlerAdapterService to SuspendableActivity + WFLY-21276 UndertowEventHandlerAdapterService#suspend is susceptible to ConcurrentModificationException

### DIFF
--- a/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/LocationContext.java
+++ b/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/LocationContext.java
@@ -18,8 +18,8 @@ import org.jboss.modcluster.container.listeners.ServletRequestListener;
  */
 public class LocationContext implements Context {
 
-    private String contextPath;
-    private UndertowHost host;
+    private final String contextPath;
+    private final UndertowHost host;
 
     public LocationContext(String contextPath, UndertowHost host) {
         this.contextPath = contextPath;

--- a/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowContext.java
+++ b/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowContext.java
@@ -5,6 +5,8 @@
 
 package org.wildfly.mod_cluster.undertow;
 
+import java.util.Set;
+
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequestEvent;
 import jakarta.servlet.ServletRequestListener;
@@ -15,9 +17,6 @@ import io.undertow.servlet.api.Deployment;
 import io.undertow.servlet.api.ListenerInfo;
 import io.undertow.servlet.core.ManagedListener;
 import io.undertow.servlet.util.ImmediateInstanceFactory;
-
-import java.util.Set;
-
 import org.jboss.modcluster.container.Context;
 import org.jboss.modcluster.container.Host;
 

--- a/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowEventHandlerAdapterConfiguration.java
+++ b/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowEventHandlerAdapterConfiguration.java
@@ -6,8 +6,7 @@
 package org.wildfly.mod_cluster.undertow;
 
 import java.time.Duration;
-
-import org.jboss.as.server.suspend.SuspendController;
+import org.jboss.as.server.suspend.SuspendableActivityRegistrar;
 import org.jboss.modcluster.container.ContainerEventHandler;
 import org.wildfly.extension.undertow.Server;
 import org.wildfly.extension.undertow.UndertowListener;
@@ -23,7 +22,7 @@ public interface UndertowEventHandlerAdapterConfiguration {
     Duration getStatusInterval();
     UndertowService getUndertowService();
     ContainerEventHandler getContainerEventHandler();
-    SuspendController getSuspendController();
+    SuspendableActivityRegistrar getSuspendableActivityRegistrar();
     UndertowListener getListener();
     Server getServer();
 }

--- a/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowEventHandlerAdapterService.java
+++ b/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowEventHandlerAdapterService.java
@@ -5,16 +5,23 @@
 
 package org.wildfly.mod_cluster.undertow;
 
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
 
-import org.jboss.as.server.suspend.ServerActivity;
-import org.jboss.as.server.suspend.ServerActivityCallback;
-import org.jboss.as.server.suspend.SuspendController;
+import io.undertow.servlet.api.Deployment;
+import org.jboss.as.server.suspend.ServerResumeContext;
+import org.jboss.as.server.suspend.ServerSuspendContext;
+import org.jboss.as.server.suspend.SuspendPriority;
+import org.jboss.as.server.suspend.SuspendableActivity;
+import org.jboss.as.server.suspend.SuspendableActivityRegistration;
+import org.jboss.as.server.suspend.SuspensionStateProvider;
 import org.jboss.logging.Logger;
 import org.jboss.modcluster.container.Connector;
 import org.jboss.modcluster.container.ContainerEventHandler;
@@ -30,22 +37,21 @@ import org.wildfly.extension.undertow.UndertowEventListener;
 import org.wildfly.extension.undertow.UndertowService;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
-import io.undertow.servlet.api.Deployment;
-
 /**
  * Builds a service exposing an Undertow subsystem adapter to mod_cluster's {@link ContainerEventHandler}.
  *
  * @author Paul Ferraro
  * @author Radoslav Husar
  */
-public class UndertowEventHandlerAdapterService implements UndertowEventListener, Service, Runnable, ServerActivity {
+public class UndertowEventHandlerAdapterService implements UndertowEventListener, Service, Runnable, SuspendableActivity {
     // No logger interface for this module and no reason to create one for this class only
     private static final Logger log = Logger.getLogger("org.jboss.mod_cluster.undertow");
     private static final ThreadFactory THREAD_FACTORY = new DefaultThreadFactory(UndertowEventHandlerAdapterService.class, WildFlySecurityManager.getClassLoaderPrivileged(UndertowEventHandlerAdapterService.class));
 
     private final UndertowEventHandlerAdapterConfiguration configuration;
-    private final Set<Context> contexts = new HashSet<>();
+    private final Set<Context> contexts = ConcurrentHashMap.newKeySet();
     private volatile ScheduledExecutorService executor;
+    private volatile SuspendableActivityRegistration suspendableActivityRegistration;
     private volatile Server server;
     private volatile Connector connector;
     private volatile String serverName;
@@ -56,6 +62,10 @@ public class UndertowEventHandlerAdapterService implements UndertowEventListener
 
     @Override
     public void start(StartContext context) {
+        this.executor = Executors.newScheduledThreadPool(1, THREAD_FACTORY);
+
+        this.suspendableActivityRegistration = this.configuration.getSuspendableActivityRegistrar().register(this, SuspendPriority.FIRST);
+
         UndertowService service = this.configuration.getUndertowService();
         ContainerEventHandler eventHandler = this.configuration.getContainerEventHandler();
         this.connector = new UndertowConnector(this.configuration.getListener());
@@ -75,21 +85,22 @@ public class UndertowEventHandlerAdapterService implements UndertowEventListener
         }
 
         // Start the periodic STATUS thread
-        this.executor = Executors.newScheduledThreadPool(1, THREAD_FACTORY);
         this.executor.scheduleWithFixedDelay(this, 0, this.configuration.getStatusInterval().toMillis(), TimeUnit.MILLISECONDS);
-        this.configuration.getSuspendController().registerActivity(this);
     }
 
     @Override
     public void stop(StopContext context) {
-        this.configuration.getSuspendController().unRegisterActivity(this);
         this.configuration.getUndertowService().unregisterListener(this);
+
+        this.suspendableActivityRegistration.close();
 
         this.executor.shutdownNow();
         try {
-            this.executor.awaitTermination(this.configuration.getStatusInterval().toMillis(), TimeUnit.MILLISECONDS);
-        } catch (InterruptedException ignore) {
-            // Move on.
+            if (!this.executor.awaitTermination(this.configuration.getStatusInterval().toNanos(), TimeUnit.NANOSECONDS)) {
+                log.debug("The mod_cluster status executor did not terminate within the status interval while being shut down.");
+            }
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
         }
 
         this.configuration.getContainerEventHandler().stop(this.server);
@@ -103,12 +114,12 @@ public class UndertowEventHandlerAdapterService implements UndertowEventListener
         return new LocationContext(contextPath, new UndertowHost(host, new UndertowEngine(serverName, host.getServer().getValue(), this.configuration.getUndertowService(), this.connector)));
     }
 
-    private synchronized void onStart(Context context) {
+    private void onStart(Context context) {
         ContainerEventHandler handler = this.configuration.getContainerEventHandler();
 
-        SuspendController.State state = this.configuration.getSuspendController().getState();
+        SuspensionStateProvider.State state = this.suspendableActivityRegistration.getState();
 
-        if (state == SuspendController.State.RUNNING) {
+        if (state == SuspensionStateProvider.State.RUNNING) {
             // Normal operation - trigger ENABLE-APP
             handler.start(context);
         } else {
@@ -120,7 +131,7 @@ public class UndertowEventHandlerAdapterService implements UndertowEventListener
         this.contexts.add(context);
     }
 
-    private synchronized void onStop(Context context) {
+    private void onStop(Context context) {
         ContainerEventHandler handler = this.configuration.getContainerEventHandler();
 
         // Trigger STOP-APP with possible session draining
@@ -171,30 +182,32 @@ public class UndertowEventHandlerAdapterService implements UndertowEventListener
                 this.configuration.getContainerEventHandler().status(engine);
             }
         } catch (Throwable e) {
-            log.error(e.getMessage(), e);
+            log.error(e.getLocalizedMessage(), e);
         }
     }
 
-    @Override
-    public synchronized void preSuspend(ServerActivityCallback listener) {
-        try {
-            for (Context context : this.contexts) {
-                this.configuration.getContainerEventHandler().stop(context);
+    private CompletionStage<Void> forEachContextAsync(BiConsumer<ContainerEventHandler, Context> action) {
+        return CompletableFuture.runAsync(() -> this.contexts.forEach(context -> {
+            try {
+                action.accept(this.configuration.getContainerEventHandler(), context);
+            } catch (RuntimeException e) {
+                log.error(e.getLocalizedMessage(), e);
             }
-        } finally {
-            listener.done();
-        }
+        }), this.executor);
     }
 
     @Override
-    public void suspended(ServerActivityCallback listener) {
-        listener.done();
+    public CompletionStage<Void> prepare(ServerSuspendContext serverSuspendContext) {
+        return forEachContextAsync(ContainerEventHandler::stop);
     }
 
     @Override
-    public synchronized void resume() {
-        for (Context context : this.contexts) {
-            this.configuration.getContainerEventHandler().start(context);
-        }
+    public CompletionStage<Void> suspend(ServerSuspendContext serverSuspendContext) {
+        return COMPLETED;
+    }
+
+    @Override
+    public CompletionStage<Void> resume(ServerResumeContext serverResumeContext) {
+        return forEachContextAsync(ContainerEventHandler::start);
     }
 }

--- a/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowEventHandlerAdapterServiceConfigurator.java
+++ b/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowEventHandlerAdapterServiceConfigurator.java
@@ -10,7 +10,7 @@ import java.util.function.Supplier;
 
 import org.jboss.as.clustering.controller.CapabilityServiceConfigurator;
 import org.jboss.as.controller.capability.CapabilityServiceSupport;
-import org.jboss.as.server.suspend.SuspendController;
+import org.jboss.as.server.suspend.SuspendableActivityRegistrar;
 import org.jboss.modcluster.container.ContainerEventHandler;
 import org.jboss.msc.Service;
 import org.jboss.msc.service.ServiceBuilder;
@@ -37,10 +37,9 @@ public class UndertowEventHandlerAdapterServiceConfigurator extends UndertowEven
     private final Duration statusInterval;
 
     private volatile Supplier<ContainerEventHandler> eventHandler;
-    private volatile SupplierDependency<SuspendController> suspendController;
-
     private volatile SupplierDependency<UndertowService> service;
     private volatile SupplierDependency<UndertowListener> listener;
+    private volatile SupplierDependency<SuspendableActivityRegistrar> suspendableActivityRegistrar;
 
     public UndertowEventHandlerAdapterServiceConfigurator(String proxyName, String listenerName, Duration statusInterval) {
         super(proxyName);
@@ -53,14 +52,14 @@ public class UndertowEventHandlerAdapterServiceConfigurator extends UndertowEven
     public ServiceConfigurator configure(CapabilityServiceSupport support) {
         this.service = new ServiceSupplierDependency<>(support.getCapabilityServiceName(Capabilities.CAPABILITY_UNDERTOW));
         this.listener = new ServiceSupplierDependency<>(support.getCapabilityServiceName(Capabilities.CAPABILITY_LISTENER, this.listenerName));
-        this.suspendController = new ServiceSupplierDependency<>(support.getCapabilityServiceName(Capabilities.REF_SUSPEND_CONTROLLER));
+        this.suspendableActivityRegistrar = new ServiceSupplierDependency<>(support.getCapabilityServiceName(SuspendableActivityRegistrar.SERVICE_DESCRIPTOR));
         return this;
     }
 
     @Override
     public ServiceBuilder<?> build(ServiceTarget target) {
         ServiceBuilder<?> builder = new AsyncServiceConfigurator(this.getServiceName()).build(target);
-        new CompositeDependency(this.service, this.listener, this.suspendController).register(builder);
+        new CompositeDependency(this.service, this.listener, this.suspendableActivityRegistrar).register(builder);
         this.eventHandler = builder.requires(ProxyConfigurationResourceDefinition.Capability.SERVICE.getDefinition().getCapabilityServiceName(proxyName));
         Service service = new UndertowEventHandlerAdapterService(this);
         return builder.setInstance(service);
@@ -82,8 +81,8 @@ public class UndertowEventHandlerAdapterServiceConfigurator extends UndertowEven
     }
 
     @Override
-    public SuspendController getSuspendController() {
-        return this.suspendController.get();
+    public SuspendableActivityRegistrar getSuspendableActivityRegistrar() {
+        return this.suspendableActivityRegistrar.get();
     }
 
     @Override

--- a/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowHost.java
+++ b/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowHost.java
@@ -24,8 +24,8 @@ import org.jboss.modcluster.container.Host;
  */
 public class UndertowHost implements Host {
 
-    private org.wildfly.extension.undertow.Host host;
-    private Engine engine;
+    private final org.wildfly.extension.undertow.Host host;
+    private final Engine engine;
 
     public UndertowHost(org.wildfly.extension.undertow.Host host, Engine engine) {
         this.engine = engine;


### PR DESCRIPTION
Replace synchronized iteration over HashSet with ConcurrentHashMap-backed set and migrate from ServerActivity to SuspendableActivity API to perform suspend/resume operations asynchronously via the existing executor Resolves the ConcurrentModificationException race condition
Fixes e.getMessage() calls

Resolves
https://redhat.atlassian.net/browse/WFLY-21244
https://redhat.atlassian.net/browse/WFLY-21276
