### PR TITLE
[WFLY-21816]: Upgrade to Apache Artemis 2.53.0

### DIFF
--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQBroker.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQBroker.java
@@ -5,17 +5,19 @@
 
 package org.wildfly.extension.messaging.activemq;
 
+import java.util.List;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
+import org.apache.activemq.artemis.api.core.management.QueueControl;
 import org.apache.activemq.artemis.core.security.SecurityAuth;
 
 /**
  * Wrapper interface to expose methods from {@link org.apache.activemq.artemis.core.server.ActiveMQServer}
  * and {@link org.apache.activemq.artemis.core.server.management.ManagementService} that are needed by a
- * {@code /subsystem=messaging-activemq/server=*} resource or its children."
-
+ * {@code /subsystem=messaging-activemq/server=*} resource or its children.
+ *
  * @author Emmanuel Hugonnet (c) 2023 Red Hat, Inc.
  */
 public interface ActiveMQBroker {
@@ -32,63 +34,76 @@ public interface ActiveMQBroker {
     SimpleString getNodeID();
 
     /**
-     * Add a connection configuration to the current {@link org.apache.activemq.artemis.core.server.ActiveMQServer}.
-     * @param string: the name of the connector.
-     * @param tc: the trnasport configurartion.
+     * Add a connector configuration to the current {@link org.apache.activemq.artemis.core.server.ActiveMQServer}.
+     * @param string the name of the connector.
+     * @param tc the transport configuration.
      */
     void addConnectorConfiguration(String string, TransportConfiguration tc);
 
     /**
-     * Creates a Queue on the underlying {@link org.apache.activemq.artemis.core.server.ActiveMQServer}.
-     * @param address: the queue address.
-     * @param routingType: the queue routing type (anycast or mulicast).
-     * @param queueName: the name of the queue.
-     * @param filter: the filter.
-     * @param durable
-     * @param temporary
-     * @throws Exception
+     * Creates a queue on the underlying {@link org.apache.activemq.artemis.core.server.ActiveMQServer}.
+     * @param address the queue address.
+     * @param routingType the queue routing type (anycast or multicast).
+     * @param queueName the name of the queue.
+     * @param filter the optional message filter; may be {@code null}.
+     * @param durable whether the queue should survive server restarts.
+     * @param temporary whether the queue is temporary and should be deleted when its creating connection closes.
+     * @throws Exception if the queue cannot be created.
      */
-    void  createQueue(SimpleString address, RoutingType routingType, SimpleString queueName, SimpleString filter,
+    void createQueue(SimpleString address, RoutingType routingType, SimpleString queueName, SimpleString filter,
                      boolean durable, boolean temporary) throws Exception;
 
     /**
      * Destroys a queue from the underlying {@link org.apache.activemq.artemis.core.server.ActiveMQServer}.
-     * @param queueName
-     * @param session
-     * @param checkConsumerCount
-     * @throws Exception
+     * @param queueName the name of the queue to destroy.
+     * @param session the security context used to authorize the operation; may be {@code null}.
+     * @param checkConsumerCount whether to reject the operation if the queue still has active consumers.
+     * @throws Exception if the queue cannot be destroyed.
      */
     void destroyQueue(SimpleString queueName, SecurityAuth session, boolean checkConsumerCount) throws Exception;
 
     /**
-     * Returns the current state of the server: true - if the server is started and active - false otherwise.
-     * @return the current state of the server: true - if the server is started and active - false otherwise.
+     * Returns {@code true} if the server is started and active, {@code false} otherwise.
+     * @return {@code true} if the server is started and active, {@code false} otherwise.
      */
     boolean isActive();
 
     /**
-     * Returns true if the resource exists - false otherwise.
-     * @param resourceName: the name of the reosurce.
-     * @return true if the resource exists - false otherwise.
-     * @see org.apache.activemq.artemis.core.server.management.ManagementService#getResource(java.lang.String).
+     * Returns {@code true} if a management resource with the given name exists, {@code false} otherwise.
+     * @param resourceName the name of the resource.
+     * @return {@code true} if the resource exists, {@code false} otherwise.
+     * @see org.apache.activemq.artemis.core.server.management.ManagementService#getResource(String)
      */
     boolean hasResource(String resourceName);
 
     /**
-     * Returns the untyped resource with the specified name- null if none exists.
-     * @param resourceName: the name of the resource.
-     * @return the untyped resource with the specified name- null if none exists.
-     * @see org.apache.activemq.artemis.core.server.management.ManagementService#getResource(java.lang.String).
+     * Returns the management resource registered under the given name, or {@code null} if none exists.
+     * @param resourceName the name of the resource.
+     * @return the management resource, or {@code null} if none exists.
+     * @see org.apache.activemq.artemis.core.server.management.ManagementService#getResource(String)
      */
     Object getResource(String resourceName);
 
     /**
-     * Returns an untyped array of the resources of this type - an empty arry if none exists.
-     * @param resourceType: the type of resources.
-     * @return an untyped array of the resources of this type - an empty arry if none exists.
-     * @see org.apache.activemq.artemis.core.server.management.ManagementService#getResources(java.lang.Class).
+     * Returns the names of all core addresses known to the underlying
+     * {@link org.apache.activemq.artemis.core.server.ActiveMQServer}.
+     * @return the list of core address names; never {@code null}.
      */
-    Object[] getResources(Class<?> resourceType);
+    List<String> getCoreAddressNames();
+
+    /**
+     * Returns the {@link QueueControl} instances for all queues on the underlying
+     * {@link org.apache.activemq.artemis.core.server.ActiveMQServer}.
+     * @return the list of queue controls; never {@code null}.
+     */
+    List<QueueControl> getQueueControls();
+
+    /**
+     * Returns the names of all queues on the underlying
+     * {@link org.apache.activemq.artemis.core.server.ActiveMQServer}.
+     * @return the set of queue names; never {@code null}.
+     */
+    List<String> getQueueControlNames();
 
     /**
      * Returns the {@link org.apache.activemq.artemis.api.core.management.ActiveMQServerControl} to manage the

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQBrokerImpl.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQBrokerImpl.java
@@ -2,13 +2,16 @@
  * Copyright The WildFly Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-
 package org.wildfly.extension.messaging.activemq;
 
+import java.util.Collections;
+import java.util.List;
+import org.apache.activemq.artemis.api.core.QueueConfiguration;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
+import org.apache.activemq.artemis.api.core.management.QueueControl;
 import org.apache.activemq.artemis.core.security.SecurityAuth;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
@@ -16,10 +19,10 @@ import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 /**
  * Implementation of the wrapper over {@link org.apache.activemq.artemis.core.server.ActiveMQServer} and
  * {@link org.apache.activemq.artemis.core.server.management.ManagementService}.
+ *
  * @author Emmanuel Hugonnet (c) 2023 Red Hat, Inc.
  */
 public class ActiveMQBrokerImpl implements ActiveMQBroker {
-    private static final Object[] EMPTY_ARRAY = new Object[0];
 
     private final ActiveMQServer delegate;
 
@@ -44,7 +47,8 @@ public class ActiveMQBrokerImpl implements ActiveMQBroker {
 
     @Override
     public void createQueue(SimpleString address, RoutingType routingType, SimpleString queueName, SimpleString filter, boolean durable, boolean temporary) throws Exception {
-        delegate.createQueue(address, routingType, queueName, filter, durable, temporary);
+        QueueConfiguration config = QueueConfiguration.of(queueName).setAddress(address).setRoutingType(routingType).setFilterString(filter).setDurable(durable).setTemporary(temporary);
+        delegate.createQueue(config);
     }
 
     @Override
@@ -71,11 +75,27 @@ public class ActiveMQBrokerImpl implements ActiveMQBroker {
     }
 
     @Override
-    public Object[] getResources(Class<?> resourceType) {
+    public List<String> getCoreAddressNames() {
         if (delegate.getManagementService() != null) {
-            return delegate.getManagementService().getResources(resourceType);
+            return delegate.getManagementService().getAddressControlNames();
         }
-        return EMPTY_ARRAY;
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<QueueControl> getQueueControls() {
+        if (delegate.getManagementService() != null) {
+            return delegate.getManagementService().getQueueControls();
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<String> getQueueControlNames() {
+        if (delegate.getManagementService() != null) {
+            return delegate.getManagementService().getQueueControlNames();
+        }
+        return Collections.emptyList();
     }
 
     @Override
@@ -89,6 +109,5 @@ public class ActiveMQBrokerImpl implements ActiveMQBroker {
         settings.merge(delegate.getAddressSettingsRepository().getDefault());
         return ManagementUtil.convertAddressSettingInfosAsJSON(settings.toJSON());
     }
-
 
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerResource.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerResource.java
@@ -2,7 +2,6 @@
  * Copyright The WildFly Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-
 package org.wildfly.extension.messaging.activemq;
 
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.CORE_ADDRESS;
@@ -13,8 +12,6 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import org.apache.activemq.artemis.api.core.management.AddressControl;
-import org.apache.activemq.artemis.api.core.management.QueueControl;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
@@ -67,51 +64,67 @@ public class ActiveMQServerResource implements Resource {
 
     @Override
     public boolean hasChild(PathElement element) {
-        if (CORE_ADDRESS.equals(element.getKey())) {
-            return hasAddressControl(element);
-        } else if (RUNTIME_QUEUE.equals(element.getKey())) {
-            return hasQueueControl(element.getValue());
-        } else {
+        if (null == element.getKey()) {
             return delegate.hasChild(element);
+        }
+        switch (element.getKey()) {
+            case CORE_ADDRESS:
+                return hasAddressControl(element);
+            case RUNTIME_QUEUE:
+                return hasQueueControl(element.getValue());
+            default:
+                return delegate.hasChild(element);
         }
     }
 
     @Override
     public Resource getChild(PathElement element) {
-        if (CORE_ADDRESS.equals(element.getKey())) {
-            return hasAddressControl(element) ? new CoreAddressResource(element.getValue(), getActiveMQBroker()) : null;
-        } else if (RUNTIME_QUEUE.equals(element.getKey())) {
-            return hasQueueControl(element.getValue()) ? PlaceholderResource.INSTANCE : null;
-        } else {
+        if (null == element.getKey()) {
             return delegate.getChild(element);
+        }
+        switch (element.getKey()) {
+            case CORE_ADDRESS:
+                return hasAddressControl(element) ? new CoreAddressResource(element.getValue(), getActiveMQBroker()) : null;
+            case RUNTIME_QUEUE:
+                return hasQueueControl(element.getValue()) ? PlaceholderResource.INSTANCE : null;
+            default:
+                return delegate.getChild(element);
         }
     }
 
     @Override
     public Resource requireChild(PathElement element) {
-        if (CORE_ADDRESS.equals(element.getKey())) {
-            if (hasAddressControl(element)) {
-                return new CoreAddressResource(element.getValue(), getActiveMQBroker());
-            }
-            throw new NoSuchResourceException(element);
-        } else if (RUNTIME_QUEUE.equals(element.getKey())) {
-            if (hasQueueControl(element.getValue())) {
-                return PlaceholderResource.INSTANCE;
-            }
-            throw new NoSuchResourceException(element);
-        } else {
+        if (null == element.getKey()) {
             return delegate.requireChild(element);
+        }
+        switch (element.getKey()) {
+            case CORE_ADDRESS:
+                if (hasAddressControl(element)) {
+                    return new CoreAddressResource(element.getValue(), getActiveMQBroker());
+                }
+                throw new NoSuchResourceException(element);
+            case RUNTIME_QUEUE:
+                if (hasQueueControl(element.getValue())) {
+                    return PlaceholderResource.INSTANCE;
+                }
+                throw new NoSuchResourceException(element);
+            default:
+                return delegate.requireChild(element);
         }
     }
 
     @Override
     public boolean hasChildren(String childType) {
-        if (CORE_ADDRESS.equals(childType)) {
-            return !getChildrenNames(CORE_ADDRESS).isEmpty();
-        } else if (RUNTIME_QUEUE.equals(childType)) {
-            return !getChildrenNames(RUNTIME_QUEUE).isEmpty();
-        } else {
+        if (null == childType) {
             return delegate.hasChildren(childType);
+        }
+        switch (childType) {
+            case CORE_ADDRESS:
+                return !getChildrenNames(CORE_ADDRESS).isEmpty();
+            case RUNTIME_QUEUE:
+                return !getChildrenNames(RUNTIME_QUEUE).isEmpty();
+            default:
+                return delegate.hasChildren(childType);
         }
     }
 
@@ -134,7 +147,7 @@ public class ActiveMQServerResource implements Resource {
 
     @Override
     public Set<String> getChildTypes() {
-        Set<String> result = new HashSet<String>(delegate.getChildTypes());
+        Set<String> result = new HashSet<>(delegate.getChildTypes());
         result.add(CORE_ADDRESS);
         result.add(RUNTIME_QUEUE);
         return result;
@@ -147,39 +160,49 @@ public class ActiveMQServerResource implements Resource {
 
     @Override
     public Set<String> getChildrenNames(String childType) {
-        if (CORE_ADDRESS.equals(childType)) {
-            return getCoreAddressNames();
-        } else if (RUNTIME_QUEUE.equals(childType)) {
-            return getCoreQueueNames();
-        } else {
+        if (null == childType) {
             return delegate.getChildrenNames(childType);
+        }
+        switch (childType) {
+            case CORE_ADDRESS:
+                return getCoreAddressNames();
+            case RUNTIME_QUEUE:
+                return getCoreQueueNames();
+            default:
+                return delegate.getChildrenNames(childType);
         }
     }
 
     @Override
     public Set<ResourceEntry> getChildren(String childType) {
-        if (CORE_ADDRESS.equals(childType)) {
-            Set<ResourceEntry> result = new HashSet<ResourceEntry>();
-            for (String name : getCoreAddressNames()) {
-                result.add(new CoreAddressResource.CoreAddressResourceEntry(name, getActiveMQBroker()));
-            }
-            return result;
-        } else if (RUNTIME_QUEUE.equals(childType)) {
-            Set<ResourceEntry> result = new LinkedHashSet<ResourceEntry>();
-            for (String name : getCoreQueueNames()) {
-                result.add(new PlaceholderResource.PlaceholderResourceEntry(RUNTIME_QUEUE, name));
-            }
-            return result;
-        } else {
+        if (null == childType) {
             return delegate.getChildren(childType);
+        }
+        switch (childType) {
+            case CORE_ADDRESS: {
+                Set<ResourceEntry> result = new HashSet<>();
+                for (String name : getCoreAddressNames()) {
+                    result.add(new CoreAddressResource.CoreAddressResourceEntry(name, getActiveMQBroker()));
+                }
+                return result;
+            }
+            case RUNTIME_QUEUE: {
+                Set<ResourceEntry> result = new LinkedHashSet<ResourceEntry>();
+                for (String name : getCoreQueueNames()) {
+                    result.add(new PlaceholderResource.PlaceholderResourceEntry(RUNTIME_QUEUE, name));
+                }
+                return result;
+            }
+            default:
+                return delegate.getChildren(childType);
         }
     }
 
     @Override
     public void registerChild(PathElement address, Resource resource) {
         String type = address.getKey();
-        if (CORE_ADDRESS.equals(type) ||
-                RUNTIME_QUEUE.equals(type)) {
+        if (CORE_ADDRESS.equals(type)
+                || RUNTIME_QUEUE.equals(type)) {
             throw MessagingLogger.ROOT_LOGGER.canNotRegisterResourceOfType(type);
         } else {
             delegate.registerChild(address, resource);
@@ -194,8 +217,8 @@ public class ActiveMQServerResource implements Resource {
     @Override
     public Resource removeChild(PathElement address) {
         String type = address.getKey();
-        if (CORE_ADDRESS.equals(type) ||
-                RUNTIME_QUEUE.equals(type)) {
+        if (CORE_ADDRESS.equals(type)
+                || RUNTIME_QUEUE.equals(type)) {
             throw MessagingLogger.ROOT_LOGGER.canNotRemoveResourceOfType(type);
         } else {
             return delegate.removeChild(address);
@@ -233,28 +256,16 @@ public class ActiveMQServerResource implements Resource {
         final ActiveMQBroker broker = getActiveMQBroker();
         if (broker == null) {
             return Collections.emptySet();
-        } else {
-            Set<String> result = new HashSet<String>();
-            for (Object obj : broker.getResources(AddressControl.class)) {
-                AddressControl ac = AddressControl.class.cast(obj);
-                result.add(ac.getAddress());
-            }
-            return result;
         }
+        return new HashSet<>(broker.getCoreAddressNames());
     }
 
     private Set<String> getCoreQueueNames() {
         final ActiveMQBroker broker = getActiveMQBroker();
         if (broker == null) {
             return Collections.emptySet();
-        } else {
-            Set<String> result = new HashSet<String>();
-            for (Object obj : broker.getResources(QueueControl.class)) {
-                QueueControl qc = QueueControl.class.cast(obj);
-                result.add(qc.getName());
-            }
-            return result;
         }
+        return new HashSet<>(broker.getQueueControlNames());
     }
 
     private ActiveMQBroker getActiveMQBroker() {

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSServerControlHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSServerControlHandler.java
@@ -326,9 +326,8 @@ public class JMSServerControlHandler extends AbstractRuntimeOnlyHandler {
         }
         Map<String, QueueControl> allDests = new HashMap<>();
 
-        Object[] queueControls = server.getResources(QueueControl.class);
-        for (Object queue : queueControls) {
-            QueueControl queueControl = (QueueControl) queue;
+        List<QueueControl> queueControls = server.getQueueControls();
+        for (QueueControl queueControl : queueControls) {
             allDests.put(queueControl.getAddress(), queueControl);
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -484,7 +484,7 @@
         <version.joda-time>2.12.7</version.joda-time>
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>8.0.0</version.net.shibboleth.utilities.java-support>
-        <version.org.apache.activemq.artemis>2.52.0</version.org.apache.activemq.artemis>
+        <version.org.apache.activemq.artemis>2.53.0</version.org.apache.activemq.artemis>
         <version.org.apache.activemq.artemis.native>2.0.0</version.org.apache.activemq.artemis.native>
         <version.org.apache.avro>1.12.1</version.org.apache.avro>
         <version.org.apache.cxf>4.0.11</version.org.apache.cxf>


### PR DESCRIPTION
* Upgrading to latest Artemis 2.53.0
Release note: https://artemis.apache.org/components/artemis/download/release-notes-2.53.0

* Replacing the call to getResources by direct calls to
        - getAddressControlNames,
        - getQueueControlNames,
        - getQueueControls
    
Issue: https://redhat.atlassian.net/browse/WFLY-21809
Issue: https://redhat.atlassian.net/browse/WFLY-21816
