### PR TITLE
WFLY-21825: fix channel fork resource operations

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractChannelResourceDefinitionRegistrar.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractChannelResourceDefinitionRegistrar.java
@@ -365,7 +365,7 @@ public abstract class AbstractChannelResourceDefinitionRegistrar<C extends Chann
         ManagementResourceRegistration registration = context.getResourceRegistrationForUpdate();
         if (address.equals(stackAddress)) {
             // This is a fork channel resource, unregister runtime attributes of protocols
-            for (PathElement protocolPath : registration.getChildAddresses(stackAddress)) {
+            for (PathElement protocolPath : registration.getChildAddresses(PathAddress.EMPTY_ADDRESS)) {
                 ManagementResourceRegistration protocolRegistration = registration.getSubModel(PathAddress.pathAddress(protocolPath));
                 for (Map.Entry<String, AttributeAccess> entry : protocolRegistration.getAttributes(PathAddress.EMPTY_ADDRESS).entrySet()) {
                     if (entry.getValue().getStorageType() == AttributeAccess.Storage.RUNTIME) {

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ForkResourceDefinitionRegistrar.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ForkResourceDefinitionRegistrar.java
@@ -158,4 +158,9 @@ public class ForkResourceDefinitionRegistrar extends AbstractChannelResourceDefi
 
         return registration;
     }
+
+    @Override
+    public void addRuntime(OperationContext context, ModelNode model) {
+        // skip
+    }
 }


### PR DESCRIPTION
Issue: [WFLY-21825](https://redhat.atlassian.net/browse/WFLY-21825)

As far as I can see `channel` has runtime-only protocols, while `fork` doesn't so we can skip the whole addRuntime method, rather than adding extra checks there.

Do we/should we have a test for add+remove? The OperationsTestCase wouldn't catch it since it doesn't execute the runtime methods but "can this resource be removed" feels like a test that should be run on everything.

(I will be on PTO from tomorrow until the 11th, if this needs to get into WF 40 someone take over)