### PR TITLE
WFLY-21740 Upgrade wildfly-clustering to 10.0.5.Final

### DIFF
--- a/clustering/infinispan/client/service/pom.xml
+++ b/clustering/infinispan/client/service/pom.xml
@@ -51,6 +51,10 @@
             <artifactId>infinispan-client-hotrod</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.clustering</groupId>
+            <artifactId>wildfly-clustering-function</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-subsystem</artifactId>
         </dependency>

--- a/clustering/infinispan/client/service/src/main/java/org/wildfly/clustering/infinispan/client/service/RemoteCacheConfigurationServiceInstallerFactory.java
+++ b/clustering/infinispan/client/service/src/main/java/org/wildfly/clustering/infinispan/client/service/RemoteCacheConfigurationServiceInstallerFactory.java
@@ -11,6 +11,7 @@ import java.util.function.Supplier;
 
 import org.infinispan.client.hotrod.configuration.RemoteCacheConfiguration;
 import org.infinispan.client.hotrod.configuration.RemoteCacheConfigurationBuilder;
+import org.infinispan.client.hotrod.configuration.TransactionMode;
 import org.jboss.as.controller.management.Capabilities;
 import org.wildfly.clustering.infinispan.client.RemoteCacheContainer;
 import org.wildfly.clustering.server.service.BinaryServiceConfiguration;
@@ -22,6 +23,7 @@ import org.wildfly.subsystem.service.ServiceInstaller;
  * @author Paul Ferraro
  */
 public class RemoteCacheConfigurationServiceInstallerFactory implements Function<BinaryServiceConfiguration, ServiceInstaller> {
+    private static final Consumer<RemoteCacheConfigurationBuilder> DISABLE_TRANSACTIONS = builder -> builder.transactionMode(TransactionMode.NONE);
 
     private final Consumer<RemoteCacheConfigurationBuilder> configurator;
 
@@ -31,13 +33,15 @@ public class RemoteCacheConfigurationServiceInstallerFactory implements Function
 
     @Override
     public ServiceInstaller apply(BinaryServiceConfiguration configuration) {
-        Consumer<RemoteCacheConfigurationBuilder> configurator = this.configurator;
+        java.util.function.Consumer<RemoteCacheConfigurationBuilder> configurator = this.configurator;
         ServiceDependency<RemoteCacheContainer> container = configuration.getServiceDependency(HotRodServiceDescriptor.REMOTE_CACHE_CONTAINER);
         String cacheName = configuration.getChildName();
         Supplier<RemoteCacheConfiguration> cacheConfiguration = new Supplier<>() {
             @Override
             public RemoteCacheConfiguration get() {
-                return container.get().getConfiguration().addRemoteCache(cacheName, configurator);
+                RemoteCacheContainer manager = container.get();
+                // Disable client transactions if remote cache already exists but is not transactional.
+                return container.get().getConfiguration().addRemoteCache(cacheName, manager.getCacheNames().contains(cacheName) && !manager.isTransactional(cacheName) ? configurator.andThen(DISABLE_TRANSACTIONS) : configurator);
             }
         };
         Consumer<RemoteCacheConfiguration> remove = new Consumer<>() {

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/client/ManagedRemoteCache.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/client/ManagedRemoteCache.java
@@ -9,7 +9,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.UnaryOperator;
 
 import org.infinispan.client.hotrod.RemoteCache;
-import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.impl.InternalRemoteCache;
 import org.wildfly.clustering.cache.infinispan.remote.RemoteCacheDecorator;
 import org.wildfly.clustering.infinispan.client.RemoteCacheContainer;
@@ -25,17 +24,13 @@ public class ManagedRemoteCache<K, V> extends RemoteCacheDecorator<K, V> impleme
 
     private final Registrar<String> registrar;
     private final AtomicReference<Registration> registration;
-    private final RemoteCacheContainer container;
-    private final RemoteCacheManager manager;
 
-    public ManagedRemoteCache(RemoteCacheContainer container, RemoteCacheManager manager, RemoteCache<K, V> cache, Registrar<String> registrar) {
-        this(container, manager, (InternalRemoteCache<K, V>) cache, registrar, new AtomicReference<>());
+    public ManagedRemoteCache(RemoteCacheContainer container, RemoteCache<K, V> cache, Registrar<String> registrar) {
+        this(container, (InternalRemoteCache<K, V>) cache, registrar, new AtomicReference<>());
     }
 
-    private ManagedRemoteCache(RemoteCacheContainer container, RemoteCacheManager manager, InternalRemoteCache<K, V> cache, Registrar<String> registrar, AtomicReference<Registration> registration) {
-        super(cache, decorated -> new ManagedRemoteCache<>(container, manager, decorated, registrar, registration));
-        this.container = container;
-        this.manager = manager;
+    private ManagedRemoteCache(RemoteCacheContainer container, InternalRemoteCache<K, V> cache, Registrar<String> registrar, AtomicReference<Registration> registration) {
+        super(container, cache, decorated -> new ManagedRemoteCache<>(container, decorated, registrar, registration));
         this.registrar = registrar;
         this.registration = registration;
     }
@@ -59,16 +54,5 @@ public class ManagedRemoteCache<K, V> extends RemoteCacheDecorator<K, V> impleme
                 super.stop();
             }
         }
-    }
-
-    @Override
-    public RemoteCacheContainer getRemoteCacheContainer() {
-        return this.container;
-    }
-
-    @Deprecated
-    @Override
-    public RemoteCacheManager getRemoteCacheManager() {
-        return this.manager;
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/client/ManagedRemoteCacheContainer.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/client/ManagedRemoteCacheContainer.java
@@ -69,7 +69,7 @@ public class ManagedRemoteCacheContainer extends RemoteCacheContainerDecorator i
             synchronized (configurations) {
                 // If remote cache configuration is undefined, auto-create
                 if (!configurations.containsKey(cacheName)) {
-                    Marshaller marshaller = UserMarshallerFactory.forMediaType(this.container.getMarshaller().mediaType()).createUserMarshaller(this.loader, List.of(loader));
+                    Marshaller marshaller = UserMarshallerFactory.forMediaType(this.container.getConfiguration().marshaller().mediaType()).createUserMarshaller(this.loader, List.of(loader));
                     // If this is a protostream marshaller, additionally auto-register deployment-specific schemas with server
                     if (marshaller.mediaType().equals(MediaType.APPLICATION_PROTOSTREAM)) {
                         RemoteSchemasAdmin admin = this.container.administration().schemas();
@@ -93,7 +93,7 @@ public class ManagedRemoteCacheContainer extends RemoteCacheContainerDecorator i
         }
 
         RemoteCache<K, V> cache = this.container.getCache(cacheName);
-        return (cache != null) ? new ManagedRemoteCache<>(this, this.container, cache, this.registrar) {
+        return (cache != null) ? new ManagedRemoteCache<>(this, cache, this.registrar) {
             @Override
             public void stop() {
                 super.stop();

--- a/clustering/web/extension/src/main/java/org/wildfly/extension/clustering/web/HotRodSessionManagementResourceTransformer.java
+++ b/clustering/web/extension/src/main/java/org/wildfly/extension/clustering/web/HotRodSessionManagementResourceTransformer.java
@@ -30,7 +30,7 @@ public class HotRodSessionManagementResourceTransformer extends SessionManagemen
         this.accept(version, builder);
 
         builder.getAttributeBuilder()
-                .setDiscard(DiscardAttributeChecker.ALWAYS, HotRodSessionManagementResourceDefinitionRegistrar.EXPIRATION_THREAD_POOL_SIZE.getName())
+                .setDiscard(DiscardAttributeChecker.ALWAYS, HotRodSessionManagementResourceDefinitionRegistrar.EXPIRATION_THREAD_POOL_SIZE)
                 .end();
     }
 }

--- a/clustering/web/extension/src/main/java/org/wildfly/extension/clustering/web/JBossMarshallingVersion.java
+++ b/clustering/web/extension/src/main/java/org/wildfly/extension/clustering/web/JBossMarshallingVersion.java
@@ -32,6 +32,7 @@ public enum JBossMarshallingVersion implements Function<Module, MarshallingConfi
         }
     },
     VERSION_3() {
+        @SuppressWarnings("deprecation")
         @Override
         public MarshallingConfiguration apply(Module module) {
             MarshallingConfigurationBuilder builder = MarshallingConfigurationBuilder.newInstance(ModularClassResolver.getInstance(module.getModuleLoader())).load(module.getClassLoader());

--- a/clustering/web/extension/src/main/java/org/wildfly/extension/clustering/web/session/hotrod/HotRodSessionManagementProvider.java
+++ b/clustering/web/extension/src/main/java/org/wildfly/extension/clustering/web/session/hotrod/HotRodSessionManagementProvider.java
@@ -15,6 +15,7 @@ import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.configuration.NearCacheMode;
 import org.infinispan.client.hotrod.configuration.RemoteCacheConfigurationBuilder;
 import org.infinispan.client.hotrod.configuration.TransactionMode;
+import org.infinispan.client.hotrod.transaction.lookup.RemoteTransactionManagerLookup;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.marshall.Marshaller;
 import org.jboss.as.server.deployment.DeploymentUnit;
@@ -56,6 +57,9 @@ public class HotRodSessionManagementProvider extends AbstractSessionManagementPr
                 "media-type" : "application/octet-stream"
             }
         },
+        "locking" : {
+            "isolation" : "REPEATABLE_READ"
+        },
         "mode" : "SYNC",
         "transaction" : {
             "mode" : "NON_XA",
@@ -78,8 +82,7 @@ public class HotRodSessionManagementProvider extends AbstractSessionManagementPr
         Consumer<RemoteCacheConfigurationBuilder> configurator = new Consumer<>() {
             @Override
             public void accept(RemoteCacheConfigurationBuilder builder) {
-                // Near caching not compatible with max-idle expiration.
-                builder.forceReturnValues(false).marshaller(marshaller).nearCacheMode(NearCacheMode.DISABLED).transactionMode(TransactionMode.NONE);
+                builder.forceReturnValues(false).marshaller(marshaller).nearCacheMode(NearCacheMode.DISABLED).transactionMode(TransactionMode.NON_XA).transactionManagerLookup(RemoteTransactionManagerLookup.getInstance());
                 if (templateName != null) {
                     builder.templateName(templateName);
                 } else {

--- a/clustering/web/extension/src/main/java/org/wildfly/extension/clustering/web/sso/hotrod/HotRodUserManagementProvider.java
+++ b/clustering/web/extension/src/main/java/org/wildfly/extension/clustering/web/sso/hotrod/HotRodUserManagementProvider.java
@@ -16,6 +16,7 @@ import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.configuration.NearCacheMode;
 import org.infinispan.client.hotrod.configuration.RemoteCacheConfigurationBuilder;
 import org.infinispan.client.hotrod.configuration.TransactionMode;
+import org.infinispan.client.hotrod.transaction.lookup.RemoteTransactionManagerLookup;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.marshall.Marshaller;
 import org.jboss.as.controller.ServiceNameFactory;
@@ -52,6 +53,9 @@ public class HotRodUserManagementProvider implements DistributableUserManagement
                 "media-type" : "application/octet-stream"
             }
         },
+        "locking" : {
+            "isolation" : "REPEATABLE_READ"
+        },
         "mode" : "SYNC",
         "transaction" : {
             "mode" : "NON_XA",
@@ -76,7 +80,7 @@ public class HotRodUserManagementProvider implements DistributableUserManagement
             @Override
             public void accept(RemoteCacheConfigurationBuilder builder) {
                 // Near caching not compatible with max-idle expiration.
-                builder.forceReturnValues(false).marshaller(marshaller).nearCacheMode(NearCacheMode.DISABLED).transactionMode(TransactionMode.NONE);
+                builder.forceReturnValues(false).marshaller(marshaller).nearCacheMode(NearCacheMode.DISABLED).transactionMode(TransactionMode.NON_XA).transactionManagerLookup(RemoteTransactionManagerLookup.getInstance());
                 if (templateName != null) {
                     builder.templateName(templateName);
                 } else {

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/cache/infinispan/common/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/cache/infinispan/common/main/module.xml
@@ -23,6 +23,7 @@
         <module name="org.wildfly.clustering.cache.spi"/>
         <module name="org.wildfly.clustering.context"/>
         <module name="org.wildfly.clustering.function"/>
+        <module name="org.wildfly.clustering.marshalling.protostream"/>
         <module name="org.wildfly.clustering.marshalling.spi"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/cache/infinispan/embedded/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/cache/infinispan/embedded/main/module.xml
@@ -26,7 +26,7 @@
         <module name="org.jgroups" optional="true"/>
         <module name="org.reactivestreams"/>
         <module name="org.wildfly.clustering.cache.caffeine"/>
-        <module name="org.wildfly.clustering.cache.infinispan.common"/>
+        <module name="org.wildfly.clustering.cache.infinispan.common" services="import"/>
         <module name="org.wildfly.clustering.cache.spi"/>
         <module name="org.wildfly.clustering.context"/>
         <module name="org.wildfly.clustering.function"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/cache/infinispan/persistence/remote/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/cache/infinispan/persistence/remote/main/module.xml
@@ -23,6 +23,7 @@
         <module name="org.infinispan.commons"/>
         <module name="org.infinispan.core"/>
         <module name="org.reactivestreams"/>
+        <module name="org.wildfly.clustering.cache.infinispan.common"/>
         <module name="org.wildfly.clustering.cache.infinispan.remote"/>
         <module name="org.wildfly.clustering.cache.spi"/>
         <module name="org.wildfly.clustering.context"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/cache/infinispan/remote/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/cache/infinispan/remote/main/module.xml
@@ -21,8 +21,11 @@
         <module name="com.github.ben-manes.caffeine"/>
         <module name="org.infinispan.client.hotrod"/>
         <module name="org.infinispan.commons"/>
-        <module name="org.wildfly.clustering.cache.infinispan.common"/>
+        <module name="org.infinispan.protostream"/>
+        <module name="org.wildfly.clustering.cache.infinispan.common" services="import"/>
         <module name="org.wildfly.clustering.cache.spi"/>
+        <module name="org.wildfly.clustering.context"/>
         <module name="org.wildfly.clustering.function"/>
+        <module name="org.wildfly.clustering.marshalling.protostream"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ejb/infinispan/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ejb/infinispan/main/module.xml
@@ -35,7 +35,7 @@
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="org.wildfly.clustering.context"/>
-        <module name="org.wildfly.clustering.cache.infinispan.common"/>
+        <module name="org.wildfly.clustering.cache.infinispan.common" services="import"/>
         <module name="org.wildfly.clustering.cache.infinispan.embedded" services="import"/>
         <module name="org.wildfly.clustering.cache.spi" services="import"/>
         <module name="org.wildfly.clustering.ejb.cache" services="import"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/infinispan/client/service/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/infinispan/client/service/main/module.xml
@@ -19,6 +19,7 @@
         <module name="org.infinispan.client.hotrod"/>
         <module name="org.infinispan.commons"/>
         <module name="org.jboss.as.controller"/>
+        <module name="org.wildfly.clustering.function"/>
         <module name="org.wildfly.clustering.infinispan.client.api"/>
         <module name="org.wildfly.clustering.server.service"/>
         <module name="org.wildfly.service"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/server/infinispan/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/server/infinispan/main/module.xml
@@ -23,7 +23,7 @@
         <module name="org.infinispan.protostream"/>
         <module name="org.jboss.marshalling"/>
         <module name="org.jgroups"/>
-        <module name="org.wildfly.clustering.cache.infinispan.common"/>
+        <module name="org.wildfly.clustering.cache.infinispan.common" services="import"/>
         <module name="org.wildfly.clustering.cache.infinispan.embedded" services="import"/>
         <module name="org.wildfly.clustering.cache.spi" services="import"/>
         <module name="org.wildfly.clustering.context"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/session/infinispan/embedded/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/session/infinispan/embedded/main/module.xml
@@ -21,7 +21,7 @@
         <module name="org.infinispan.commons"/>
         <module name="org.infinispan.core"/>
         <module name="org.infinispan.protostream"/>
-        <module name="org.wildfly.clustering.cache.infinispan.common"/>
+        <module name="org.wildfly.clustering.cache.infinispan.common" services="import"/>
         <module name="org.wildfly.clustering.cache.infinispan.embedded" services="import"/>
         <module name="org.wildfly.clustering.cache.spi" services="import"/>
         <module name="org.wildfly.clustering.context"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/session/infinispan/remote/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/session/infinispan/remote/main/module.xml
@@ -23,8 +23,8 @@
         <module name="org.infinispan.client.hotrod"/>
         <module name="org.infinispan.commons"/>
         <module name="org.infinispan.protostream"/>
-        <module name="org.wildfly.clustering.cache.infinispan.common"/>
-        <module name="org.wildfly.clustering.cache.infinispan.remote"/>
+        <module name="org.wildfly.clustering.cache.infinispan.common" services="import"/>
+        <module name="org.wildfly.clustering.cache.infinispan.remote" services="import"/>
         <module name="org.wildfly.clustering.cache.spi" services="import"/>
         <module name="org.wildfly.clustering.context"/>
         <module name="org.wildfly.clustering.function"/>

--- a/pom.xml
+++ b/pom.xml
@@ -397,7 +397,7 @@
         <version.com.carrotsearch.hppc>0.10.0</version.com.carrotsearch.hppc>
         <version.com.fasterxml.classmate>1.7.1</version.com.fasterxml.classmate>
         <version.com.fasterxml.jackson>2.21.2</version.com.fasterxml.jackson>
-        <version.com.github.ben-manes.caffeine>3.2.3</version.com.github.ben-manes.caffeine>
+        <version.com.github.ben-manes.caffeine>3.2.4</version.com.github.ben-manes.caffeine>
         <version.com.github.fge.btf>1.2</version.com.github.fge.btf>
         <version.com.github.fge.jackson-coreutils>1.8</version.com.github.fge.jackson-coreutils>
         <version.com.github.fge.json-patch>1.9</version.com.github.fge.json-patch>
@@ -537,7 +537,7 @@
         <version.org.hibernate.search>8.3.0.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>9.1.0.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.11.Final</version.org.hornetq>
-        <version.org.infinispan>16.0.9</version.org.infinispan>
+        <version.org.infinispan>16.0.11</version.org.infinispan>
         <version.org.jasypt>1.9.3</version.org.jasypt>
         <version.org.jberet>3.1.0.Final</version.org.jberet>
         <version.org.jboss.activemq.artemis.integration>2.0.4.Final</version.org.jboss.activemq.artemis.integration>
@@ -584,7 +584,7 @@
         <version.org.opensaml.opensaml>4.3.2</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.9.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.clustering>10.0.1.Final</version.org.wildfly.clustering>
+        <version.org.wildfly.clustering>10.0.5.Final</version.org.wildfly.clustering>
         <!--
             Maintain separation between these two frequently updated artifacts to avoid merge conflicts.
         -->

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/infinispan/xml/InfinispanXMLConfigurationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/infinispan/xml/InfinispanXMLConfigurationTestCase.java
@@ -66,7 +66,8 @@ public class InfinispanXMLConfigurationTestCase {
                         new ReflectPermission("suppressAccessChecks"),
                         new RuntimePermission("accessDeclaredMembers"),
                         new RuntimePermission("getClassLoader"),
-                        new RuntimePermission("setContextClassLoader")
+                        new RuntimePermission("setContextClassLoader"),
+                        new RuntimePermission("accessClassInPackage.sun.misc")
                 ), "permissions.xml");
     }
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21740

Includes:
* Upgrade Infinspan to 16.0.11
  https://redhat.atlassian.net/browse/WFLY-21742
* Upgrade JGroups to 5.5.5.Final
  https://redhat.atlassian.net/browse/WFLY-21847

Resolves:
* Session X does not expire until null
  https://redhat.atlassian.net/browse/WFLY-21731
* Foreign MemorySegment warnings logged with JDK22+
  https://redhat.atlassian.net/browse/WFLY-21856
