### PR TITLE
[WFLY-21789] Export expressly from the Hibernate Validator module

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/validator/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/validator/main/module.xml
@@ -19,7 +19,9 @@
     <module name="jakarta.persistence.api"/>
     <module name="jakarta.validation.api"/>
     <module name="jakarta.xml.bind.api"/>
-    <module name="org.glassfish.expressly"/>
+    <!-- Export so the Jakarta EL FactoryFinder can find the EL impl
+         when this module's CL is the TCCL -->
+    <module name="org.glassfish.expressly" export="true"/>
     <module name="org.jboss.logging"/>
     <module name="org.jboss.weld.core"/>
     <module name="org.jboss.weld.spi"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module.xml
@@ -13,8 +13,6 @@
 
     <dependencies>
         <module name="java.xml"/>
-        <!-- TODO https://redhat.atlassian.net/browse/WFLY-21789 -->
-        <module name="org.glassfish.expressly"/>
         <module name="jakarta.jms.api"/>
         <module name="jakarta.resource.api"/>
         <module name="jakarta.validation.api"/>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21789

I'm not thrilled with how classloading for Jakarta EL works, but this kind of thing seems necessary. (I beat my head against the wall trying to find other solutions for hours.)

A bunch of other modules, including jakarta.enterprise.api, jakarta.servlet.jsp.api and jakarta.faces.api also depend on and export expressly. And the EE subsystem's JavaEEDependencyProcessor add it as a dep to every deployment. So it's already being made visible to lots of things. This just exposes it to more static modules -- mostly WF extension modules, most of which probably already have it exposed via jakarta.enterprise.api deps