### PR TITLE
[WFLY-21850] Fix duplicate htmlunit dependency declaration

### DIFF
--- a/boms/standard-test/pom.xml
+++ b/boms/standard-test/pom.xml
@@ -385,13 +385,6 @@
                 <version>${version.org.wildfly.glow}</version>
             </dependency>
 
-            <dependency>
-                <groupId>org.htmlunit</groupId>
-                <artifactId>htmlunit</artifactId>
-                <version>${version.org.htmlunit}</version>
-                <scope>test</scope>
-            </dependency>
-
             <!-- The below BOM's are imported last as to not override any dependencies above -->
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -356,7 +356,7 @@
         <version.org.eclipse.krazo>3.0.1</version.org.eclipse.krazo>
         <version.org.hamcrest>2.2</version.org.hamcrest>
         <version.org.hamcrest.legacy>1.3</version.org.hamcrest.legacy>
-        <version.org.htmlunit>4.10.0</version.org.htmlunit>
+        <version.org.htmlunit.htmlunit>4.21.0</version.org.htmlunit.htmlunit>
         <version.org.javassist>3.29.2-GA</version.org.javassist>
         <version.org.jboss.arquillian.core>1.10.1.Final</version.org.jboss.arquillian.core>
         <version.org.jboss.arquillian.jakarta>10.0.0.Final</version.org.jboss.arquillian.jakarta>
@@ -375,7 +375,6 @@
         <version.org.junit>5.14.4</version.org.junit>
         <version.org.keycloak>25.0.6</version.org.keycloak>
         <version.org.mockito>5.21.0</version.org.mockito>
-        <version.org.htmlunit.htmlunit>4.21.0</version.org.htmlunit.htmlunit>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testcontainers>2.0.5</version.org.testcontainers>
         <version.org.testng>7.8.0</version.org.testng>


### PR DESCRIPTION
- From the duplicates, remove the lower version 4.10.0 and use 4.21.0 which is the latest

Jira issue: https://redhat.atlassian.net/browse/WFLY-21850
