### PR TITLE
[WFLY-21872] - Adding com.sun.xml.bind.external* to the webservices group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,7 @@ updates:
     groups:
       webservices:
         patterns:
+          - 'com.sun.xml.bind.external*'
           - 'com.sun.xml.fastinfoset*'
           - 'net.shibboleth.utilities*'
           - 'org.apache.cxf*'


### PR DESCRIPTION
Adding com.sun.xml.bind.external* to the webservices grroup in the dependabot.yml configuration, to let it be managed in batch with other related Web Services component updates.

Upstream issue: https://redhat.atlassian.net/browse/WFLY-21872