### PR TITLE
[WFLY-21875][WFLY-21834] Upgrade WildFly Core to 32.0.0.Final and remove Undertow override

### DIFF
--- a/boms/common-ee/pom.xml
+++ b/boms/common-ee/pom.xml
@@ -1256,19 +1256,6 @@
                 <version>${version.io.smallrye.smallrye-mutiny}</version>
             </dependency>
 
-            <!-- TODO (jrp) temporary override until the new version of Undertow is integrated into core and that version of core is integrated here -->
-            <dependency>
-                <groupId>io.undertow</groupId>
-                <artifactId>undertow-core</artifactId>
-                <version>${version.io.undertow}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
             <dependency>
                 <groupId>jakarta.activation</groupId>
                 <artifactId>jakarta.activation-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -446,8 +446,6 @@
         <version.io.smallrye.smallrye-opentelemetry>2.11.2</version.io.smallrye.smallrye-opentelemetry>
         <version.io.smallrye.smallrye-stork>2.7.9</version.io.smallrye.smallrye-stork>
         <version.io.smallrye.smallrye-reactive-messaging>4.32.1</version.io.smallrye.smallrye-reactive-messaging>
-        <!-- TODO (jrp) temporary override until the new version of Undertow is integrated into core and that version of core is integrated here -->
-        <version.io.undertow>2.4.0.Final</version.io.undertow>
         <version.io.undertow.ee>2.0.0.Final</version.io.undertow.ee>
         <version.io.undertow.jastow>2.3.0.Final</version.io.undertow.jastow>
         <version.io.vertx.vertx>4.5.26</version.io.vertx.vertx>

--- a/pom.xml
+++ b/pom.xml
@@ -588,7 +588,7 @@
         <!--
             Maintain separation between these two frequently updated artifacts to avoid merge conflicts.
         -->
-        <version.org.wildfly.core>32.0.0.Beta7</version.org.wildfly.core>
+        <version.org.wildfly.core>32.0.0.Final</version.org.wildfly.core>
         <!--
             Maintain separation between these two frequently updated artifacts to avoid merge conflicts.
         -->


### PR DESCRIPTION
Jira issue: https://redhat.atlassian.net/browse/WFLY-21875

Includes: https://redhat.atlassian.net/browse/WFLY-21834
Note: I removed the override, but since Preview is still using the same Undertow version than core, I did not add the changes that allow Preview to override the Undertow version. I assume we will add those changes as soon as we run into the specific need in WildFly Preview.

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/32.0.0.Final
Diff: https://github.com/wildfly/wildfly-core/compare/32.0.0.Beta7...32.0.0.Final

---

<details>
<div class="csg-wrapper" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif; font-size: 14px; font-weight: 400; line-height: 24px; vertical-align: baseline;"><h1 class="csg-h1" style="font-style: inherit; color: #172B4D; font-weight: 600; margin-bottom: 0; font-size: 29px; line-height: 1.10; margin-top: 40px; letter-spacing: -0.01em;">Release notes - WildFly Core - 32.0.0.Final</h1><h3 class="csg-h3" style="font-style: inherit; color: #172B4D; font-weight: 600; margin-bottom: 0; font-size: 20px; line-height: 1.20; font-weight: 500; letter-spacing: -0.008em;">Release</h3><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7585" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7585</a> Downgrade Elytron EE to 3.2.0.Final</p><h3 class="csg-h3" style="font-style: inherit; color: #172B4D; font-weight: 600; margin-bottom: 0; font-size: 20px; line-height: 1.20; font-weight: 500; letter-spacing: -0.008em;">Component Upgrade</h3><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7549" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7549</a> Upgrade to Undertow Core 2.4.0.Final</p><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7563" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7563</a> Upgrade Elytron EE to version 3.2.1.CR3</p><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7567" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7567[CVE-2025-14813][CVE-2026-0636][CVE-2026-3505][CVE-2026-5588][CVE-2026-5598]</a> Upgrade BouncyCastle from 1.83 to 1.84</p><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7568" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7568</a> Upgrade Elytron Web to 4.2.0.CR1</p><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7575" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7575</a> Upgrade Elytron EE to 3.2.1.CR4</p><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7579" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7579</a> Upgrade Elytron Web to 4.2.0.Final</p><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7582" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7582</a> Upgrade WildFly Elytron to 2.9.0.CR2</p><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7584" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7584</a> Upgrade to Galleon plugins 8.1.3.Final</p><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7586" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7586</a> Upgrade WildFly Elytron to 2.9.0.Final</p><h3 class="csg-h3" style="font-style: inherit; color: #172B4D; font-weight: 600; margin-bottom: 0; font-size: 20px; line-height: 1.20; font-weight: 500; letter-spacing: -0.008em;">Enhancement</h3><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7545" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7545</a> Add auto-population of the resource model to RestartParentResourceAddHandler</p><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7562" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7562</a> DomainTestUtils returns silently after an InterruptedException</p><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7583" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7583</a> Fix article typo in audit logging descriptions</p><h3 class="csg-h3" style="font-style: inherit; color: #172B4D; font-weight: 600; margin-bottom: 0; font-size: 20px; line-height: 1.20; font-weight: 500; letter-spacing: -0.008em;">Bug</h3><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7534" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7534</a> Subsystem tests unable to download artifacts from authenticated repositories</p><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7552" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7552</a> GC_LOG broken for Semeru JDK on Windows with space in path</p><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7569" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7569</a> Unable to run WildFly Core testsuite due to local settings.xml profile activation.</p><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7572" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7572</a> ElytronRemove doesn't remove the org.wildfly.security.jakarta-authorization capability</p><h3 class="csg-h3" style="font-style: inherit; color: #172B4D; font-weight: 600; margin-bottom: 0; font-size: 20px; line-height: 1.20; font-weight: 500; letter-spacing: -0.008em;">Task</h3><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7415" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7415</a> Undeprecate kernel resources that have no clear replacement plan</p><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7570" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7570</a> Make DynamicSSLContextTestCase target default stability instead of community stability</p><h3 class="csg-h3" style="font-style: inherit; color: #172B4D; font-weight: 600; margin-bottom: 0; font-size: 20px; line-height: 1.20; font-weight: 500; letter-spacing: -0.008em;">Sub-task</h3><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7580" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7580</a> Undeprecate the core-service=management/management-interface=* resources</p></div>
</details>

