### PR TITLE
[WFLY-21842] Update Maven plugin guide with feature pack

### DIFF
--- a/docs/src/main/asciidoc/WildFly_Maven_Plugin_Guide.adoc
+++ b/docs/src/main/asciidoc/WildFly_Maven_Plugin_Guide.adoc
@@ -81,7 +81,7 @@ Galleon is configured thanks to the Maven plugin ```<configuration>``` element.
 The first required piece of information that Galleon needs is a reference to at least one WildFly Galleon feature-pack.
 A WildFly Galleon feature-pack is a Maven artifact that contains everything needed to dynamically provision a server.
 
-This feature-pack, as well as the feature-packs on which it depends, are deployed in public maven repositories.
+This feature-pack, as well as any feature-packs on which it depends, are deployed in public Maven repositories.
 
 At plugin execution time the WildFly feature-packs are retrieved and their content is assembled to provision a server.
 
@@ -414,7 +414,7 @@ can be found in the https://docs.wildfly.org/quickstart[WildFly Quickstarts].
 You can check https://github.com/wildfly-extras/wildfly-cloud-galleon-pack/blob/main/README.md[this documentation] 
 for more details on the WildFly cloud feature-pack .
 
-== WildFly Galleon feature-packs & layers
+== WildFly Galleon feature-packs and layers
 
 include::_galleon/Galleon_feature_packs.adoc[]
 include::_galleon/Galleon_layers.adoc[]

--- a/docs/src/main/asciidoc/WildFly_Maven_Plugin_Guide.adoc
+++ b/docs/src/main/asciidoc/WildFly_Maven_Plugin_Guide.adoc
@@ -414,7 +414,49 @@ can be found in the https://docs.wildfly.org/quickstart[WildFly Quickstarts].
 You can check https://github.com/wildfly-extras/wildfly-cloud-galleon-pack/blob/main/README.md[this documentation] 
 for more details on the WildFly cloud feature-pack .
 
-== WildFly Galleon feature-packs and layers
+== Feature-packs and layers
 
 include::_galleon/Galleon_feature_packs.adoc[]
+
+The configuration to provision WildFly with EE 10 for a cloud deployment would look like this:
+
+[source,xml]
+----
+<plugin>
+  <groupId>org.wildfly.plugins</groupId>
+  <artifactId>wildfly-maven-plugin</artifactId>
+  <configuration>
+    <feature-packs>
+      <feature-pack>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-ee-10-feature-pack</artifactId>
+        <version>${version.wildfly}</version>
+      </feature-pack>
+      <feature-pack>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-galleon-pack</artifactId>
+        <version>${version.wildfly}</version>
+      </feature-pack>
+      <feature-pack>
+        <groupId>org.wildfly.cloud</groupId>
+        <artifactId>wildfly-cloud-galleon-pack</artifactId>
+        <version>${version.wildfly-cloud}</version>
+      </feature-pack>
+    </feature-packs>
+  </configuration>
+  <executions>
+    <execution>
+      <goals>
+        <goal>package</goal>
+      </goals>
+    </execution>
+  </executions>
+</plugin>
+----
+
+In that example, `wildfly-ee-10-feature-pack` is listed before `wildfly-galleon-pack` to ensure that the EE 10 support is
+properly provisioned.
+Likewise, `wildfly-cloud-galleon-pack` is listed last so that its dependencies have been already been provisioned by `wildfly-ee-10-feature-pack`.
+
+
 include::_galleon/Galleon_layers.adoc[]

--- a/docs/src/main/asciidoc/WildFly_Maven_Plugin_Guide.adoc
+++ b/docs/src/main/asciidoc/WildFly_Maven_Plugin_Guide.adoc
@@ -79,13 +79,16 @@ The WildFly Maven Plugin depends on https://docs.wildfly.org/galleon/[Galleon] t
 Galleon is configured thanks to the Maven plugin ```<configuration>``` element.
 
 The first required piece of information that Galleon needs is a reference to at least one WildFly Galleon feature-pack.
-A WildFly Galleon feature-pack is a maven artifact that contains everything needed to dynamically provision a server.
-This feature-pack, as well as the feature-packs on which it depends,
-are deployed in public maven repositories. 
+A WildFly Galleon feature-pack is a Maven artifact that contains everything needed to dynamically provision a server.
+
+This feature-pack, as well as the feature-packs on which it depends, are deployed in public maven repositories.
 
 At plugin execution time the WildFly feature-packs are retrieved and their content is assembled to provision a server.
 
-Once you have identified a WildFly Galleon feature-pack, you need to select a set of 
+First, you need to identify the set of feature-packs you want to use to provision your server among the available
+link:#WildFly_Galleon_feature-packs[WildFly Galleon feature-packs].
+
+Once you have identified a WildFly Galleon feature-pack, you then need to select a set of
 link:#wildfly_layers[WildFly Layers] that are used to compose the server.
 
 The set of Galleon layers to include is driven by the needs of the application you are developing.
@@ -411,4 +414,7 @@ can be found in the https://docs.wildfly.org/quickstart[WildFly Quickstarts].
 You can check https://github.com/wildfly-extras/wildfly-cloud-galleon-pack/blob/main/README.md[this documentation] 
 for more details on the WildFly cloud feature-pack .
 
+== WildFly Galleon feature-packs & layers
+
+include::_galleon/Galleon_feature_packs.adoc[]
 include::_galleon/Galleon_layers.adoc[]

--- a/docs/src/main/asciidoc/_galleon/Galleon_feature_packs.adoc
+++ b/docs/src/main/asciidoc/_galleon/Galleon_feature_packs.adoc
@@ -13,15 +13,15 @@ The main WildFly project provides the following feature-packs for use with xref:
 |=======================================================================
 |Maven GroupId:ArtifactId |Short name|Use|Requires
 
-|*org.wildfly:wildfly-galleon-pack*|*wildfly*|The feature-pack most WildFly users use. Provisions a standard WildFly installation. Internally depends on the `wildfly-ee` feature-pack, but also provides integration of technologies like MicroProfile, Micrometer and Open Telemetry that are evolving rapidly, possibly in incompatible ways.| *wildfly-ee* (by default) or *wildfly-ee-10* (for EE 10 compatibility)
+|*org.wildfly:wildfly-galleon-pack*|*wildfly*|The feature-pack most WildFly users use. Provisions a standard WildFly installation. Internally depends on the `wildfly-ee` feature-pack, but also provides integration of technologies like MicroProfile, Micrometer and Open Telemetry that are evolving rapidly, possibly in incompatible ways.| *wildfly-ee* (by default) or *wildfly-ee-10* (for EE 10 support)
 
 |*org.wildfly:wildfly-ee-galleon-pack*|*wildfly-ee*|Provisions the most long-term stable functionality of standard WildFly. Does not include MicroProfile or other rapidly evolving technologies that may frequently introduce incompatible changes.| none
 
-|*org.wildfly:wildfly-ee-10-feature-pack*|*wildfly-ee-10*|This alternative to *wildfly-ee* provides a Jakarta EE 10 variant of WildFly for users that want to stay on that version while WildFly moves to a more recent version of the Jakarta EE specifications. This feature pack is released for a limited period of time and users should eventually| none
+|*org.wildfly:wildfly-ee-10-feature-pack*|*wildfly-ee-10*|This alternative to *wildfly-ee* provides a Jakarta EE 10 variant of WildFly for users that want to stay on that version while WildFly moves to a more recent version of the Jakarta EE specifications. This feature pack is released for a limited period of time and users should eventually migrate to EE 11| none
 
-|*org.wildfly.cloud:wildfly-cloud-galleon-pack*|-|Provisions a set of additional features allowing you to better configure a standard WildFly server to work on the cloud. It brings to the server some configuration aspects that are generally expected in a cloud context. See the feature-pack https://github.com/wildfly-extras/wildfly-cloud-galleon-pack/blob/main/doc/index.md[documentation] for more details.| *wildfly* or *wildfly-preview*
+|*org.wildfly.cloud:wildfly-cloud-galleon-pack*|-|Provisions a set of additional features allowing you to better configure a standard WildFly server to work on the cloud. It brings to the server some configuration aspects that are generally expected in a cloud context. See the feature-pack https://github.com/wildfly-extras/wildfly-cloud-galleon-pack/blob/main/doc/index.md[documentation] for more details.| *wildfly-ee*, *wildfly-ee-10* or *wildfly-preview*
 
-|*org.wildfly:wildfly-datasources-galleon-pack*|-|Easy integration of popular JDBC drivers and associated datasources into a standard WildFly installation. See the feature-pack project https://github.com/wildfly-extras/wildfly-datasources-galleon-pack/blob/main/README.md[README] for more details.|*wildfly* or *wildfly-preview*
+|*org.wildfly:wildfly-datasources-galleon-pack*|-|Easy integration of popular JDBC drivers and associated datasources into a standard WildFly installation. See the feature-pack project https://github.com/wildfly-extras/wildfly-datasources-galleon-pack/blob/main/README.md[README] for more details.|*wildfly-ee*, *wildfly-ee-10* or *wildfly-preview*
 
 |*org.wildfly:wildfly-myfaces-feature-pack*|-|Provides MyFaces support for WildFly. See the feature-pack project https://github.com/wildfly-extras/wildfly-myfaces-feature-pack/blob/master/README.md[README] for more details.|*wildfly* or *wildfly-preview*|
 |=======================================================================
@@ -48,5 +48,5 @@ A specific feature pack must be listed before a feature pack that would use anot
 For example, the *wildfly-ee-10* feature-pack provides a Jakarta EE 10 variant of *wildfly-ee*.
 
 To provision WildFly with that EE 10 variant, this `org.wildfly:wildfly-ee-10-feature-pack` feature pack must be listed *before* the
-`org.wildfly:wildfly-galleon-pack` feature-pack (that would require *wildfly-ee* otherwise) in the provisioning tool (such as the WildFly Maven Plug-in).
+`org.wildfly:wildfly-galleon-pack` feature-pack (that would require *wildfly-ee* otherwise) in the provisioning tool.
 ====

--- a/docs/src/main/asciidoc/_galleon/Galleon_feature_packs.adoc
+++ b/docs/src/main/asciidoc/_galleon/Galleon_feature_packs.adoc
@@ -9,16 +9,21 @@ their content is assembled to create an installation.
 
 The main WildFly project provides the following feature-packs for use with xref:WildFly_and_WildFly_Preview.adoc[standard WildFly]:
 
-[cols="~,~,~",options="header"]
+[cols="~,~,~,~",options="header"]
 |=======================================================================
-|Maven GroupId:ArtifactId |Short name|Use
+|Maven GroupId:ArtifactId |Short name|Use|Requires
 
-|*org.wildfly:wildfly-galleon-pack*|*wildfly*|The feature-pack most WildFly users use. Provisions a standard WildFly installation. Internally depends on the `wildfly-ee` feature-pack, but also provides integration of technologies like MicroProfile, Micrometer and Open Telemetry that are evolving rapidly, possibly in incompatible ways.
-|*org.wildfly:wildfly-ee-galleon-pack*|*wildfly-ee*|Provisions the most long-term stable functionality of standard WildFly. Does not include MicroProfile or other rapidly evolving technologies that may frequently introduce incompatible changes.
-|*org.wildfly:wildfly-ee-10-feature-pack*|*wildfly-ee10*|This alternative to the `wildfly-ee-galleon-pack` provides a Jakarta EE10 variant of WildFly for users that want to stay on that version while WildFly moves to a more recent version of the Jakarta EE specifications. This feature pack is released for a limited period of time and users should eventually
-|*org.wildfly.cloud:wildfly-cloud-galleon-pack*|-|Provisions a set of additional features allowing you to better configure a standard WildFly server to work on the cloud. It brings to the server some configuration aspects that are generally expected in a cloud context. See the feature-pack https://github.com/wildfly-extras/wildfly-cloud-galleon-pack/blob/main/doc/index.md[documentation] for more details.
-|*org.wildfly:wildfly-datasources-galleon-pack*|-|Easy integration of popular JDBC drivers and associated datasources into a standard WildFly installation. See the feature-pack project https://github.com/wildfly-extras/wildfly-datasources-galleon-pack/blob/main/README.md[README] for more details.
-|*org.wildfly:wildfly-myfaces-feature-pack*|-|Provides MyFaces support for standard WildFly. See the feature-pack project https://github.com/wildfly-extras/wildfly-myfaces-feature-pack/blob/master/README.md[README] for more details.|
+|*org.wildfly:wildfly-galleon-pack*|*wildfly*|The feature-pack most WildFly users use. Provisions a standard WildFly installation. Internally depends on the `wildfly-ee` feature-pack, but also provides integration of technologies like MicroProfile, Micrometer and Open Telemetry that are evolving rapidly, possibly in incompatible ways.| *wildfly-ee* (by default) or *wildfly-ee-10* (for EE 10 compatibility)
+
+|*org.wildfly:wildfly-ee-galleon-pack*|*wildfly-ee*|Provisions the most long-term stable functionality of standard WildFly. Does not include MicroProfile or other rapidly evolving technologies that may frequently introduce incompatible changes.| none
+
+|*org.wildfly:wildfly-ee-10-feature-pack*|*wildfly-ee-10*|This alternative to *wildfly-ee* provides a Jakarta EE 10 variant of WildFly for users that want to stay on that version while WildFly moves to a more recent version of the Jakarta EE specifications. This feature pack is released for a limited period of time and users should eventually| none
+
+|*org.wildfly.cloud:wildfly-cloud-galleon-pack*|-|Provisions a set of additional features allowing you to better configure a standard WildFly server to work on the cloud. It brings to the server some configuration aspects that are generally expected in a cloud context. See the feature-pack https://github.com/wildfly-extras/wildfly-cloud-galleon-pack/blob/main/doc/index.md[documentation] for more details.| *wildfly* or *wildfly-preview*
+
+|*org.wildfly:wildfly-datasources-galleon-pack*|-|Easy integration of popular JDBC drivers and associated datasources into a standard WildFly installation. See the feature-pack project https://github.com/wildfly-extras/wildfly-datasources-galleon-pack/blob/main/README.md[README] for more details.|*wildfly* or *wildfly-preview*
+
+|*org.wildfly:wildfly-myfaces-feature-pack*|-|Provides MyFaces support for WildFly. See the feature-pack project https://github.com/wildfly-extras/wildfly-myfaces-feature-pack/blob/master/README.md[README] for more details.|*wildfly* or *wildfly-preview*|
 |=======================================================================
 
 The main WildFly project also provides a feature-pack for xref:WildFly_and_WildFly_Preview.adoc[WildFly Preview]:
@@ -34,3 +39,14 @@ There are also a number of feature-packs of varying levels of stability availabl
 
 In most cases, people working with WildFly are using the `wildfly` feature-pack, so that is the one used in most of the examples in this document.
 
+[IMPORTANT]
+.Order of feature-packs.
+====
+When feature packs are used to provision WildFly, *their* order is significant if they have requirements.
+A specific feature pack must be listed before a feature pack that would use another default feature pack.
+
+For example, the *wildfly-ee-10* feature-pack provides a Jakarta EE 10 variant of *wildfly-ee*.
+
+To provision WildFly with that EE 10 variant, this `org.wildfly:wildfly-ee-10-feature-pack` feature pack must be listed *before* the
+`org.wildfly:wildfly-galleon-pack` feature-pack (that would require *wildfly-ee* otherwise) in the provisioning tool (such as the WildFly Maven Plug-in).
+====

--- a/docs/src/main/asciidoc/_galleon/Galleon_feature_packs.adoc
+++ b/docs/src/main/asciidoc/_galleon/Galleon_feature_packs.adoc
@@ -1,0 +1,37 @@
+[[WildFly_Galleon_feature-packs]]
+=== WildFly Galleon feature-packs
+
+The WildFly project provides a number of Galleon https://docs.wildfly.org/galleon/#_feature_packs[feature-pack] maven artifacts. A feature-pack is a zipped file that contains everything needed to dynamically provision a server.
+These feature-packs are deployed in public maven repositories.
+
+When Galleon is used to install WildFly, the desired WildFly feature-packs are retrieved and
+their content is assembled to create an installation.
+
+The main WildFly project provides the following feature-packs for use with xref:WildFly_and_WildFly_Preview.adoc[standard WildFly]:
+
+[cols="~,~,~",options="header"]
+|=======================================================================
+|Maven GroupId:ArifactId |Short name|Use
+
+|*org.wildfly:wildfly-galleon-pack*|*wildfly*|The feature-pack most WildFly users use. Provisions a standard WildFly installation. Internally depends on the `wildfly-ee` feature-pack, but also provides integration of technologies like MicroProfile, Micrometer and Open Telemetry that are evolving rapidly, possibly in incompatible ways.
+|*org.wildfly:wildfly-ee-galleon-pack*|*wildfly-ee*|Provisions the most long-term stable functionality of standard WildFly. Does not include MicroProfile or other rapidly evolving technologies that may frequently introduce incompatible changes.
+|*org.wildfly:wildfly-ee-10-feature-pack*|*wildfly-ee10*|This feature pack provides a Jakarta EE10 variant of WildFly for users that want to stay on that version while WildFly moves to a more recent version of the Jakarta EE specifications. This feature pack is released for a limited period of time and users should eventually
+upgrade their applications to "move back" to `wildfly-ee`.|
+|*org.wildfly.cloud:wildfly-cloud-galleon-pack*|-|Provisions a set of additional features allowing you to better configure a standard WildFly server to work on the cloud. It brings to the server some configuration aspects that are generally expected in a cloud context. See the feature-pack https://github.com/wildfly-extras/wildfly-cloud-galleon-pack/blob/main/doc/index.md[documentation] for more details.
+|*org.wildfly:wildfly-datasources-galleon-pack*|-|Easy integration of popular JDBC drivers and associated datasources into a standard WildFly installation. See the feature-pack project https://github.com/wildfly-extras/wildfly-datasources-galleon-pack/blob/main/README.md[README] for more details.
+|*org.wildfly:wildfly-myfaces-feature-pack*|-|Provides MyFaces 4.x support for standard WildFly. See the feature-pack project https://github.com/wildfly-extras/wildfly-myfaces-feature-pack/blob/master/README.md[README] for more details.
+|=======================================================================
+
+The main WildFly project also provide a feature-pack for xref:WildFly_and_WildFly_Preview.adoc[WildFly Preview]:
+
+[cols="~,~,~",options="header"]
+|=======================================================================
+|Maven GroupId:ArifactId |Short name|Use
+
+|*org.wildfly:wildfly-preview-feature-pack*|*wildfly-preview*|Provides a technology preview of things that may be coming in standard WildFly. Likely to have significant incompatible changes with every release.
+|=======================================================================
+
+There are also a number of feature-packs of varying levels of stability available from the https://github.com/orgs/wildfly-extras/repositories[*wildfly-extras* GitHub organization].
+
+In most cases, people working with WildFly are using the `wildfly` feature-pack, so that is the one used in most of the examples in this document.
+

--- a/docs/src/main/asciidoc/_galleon/Galleon_feature_packs.adoc
+++ b/docs/src/main/asciidoc/_galleon/Galleon_feature_packs.adoc
@@ -23,7 +23,7 @@ The main WildFly project provides the following feature-packs for use with xref:
 
 |*org.wildfly:wildfly-datasources-galleon-pack*|-|Easy integration of popular JDBC drivers and associated datasources into a standard WildFly installation. See the feature-pack project https://github.com/wildfly-extras/wildfly-datasources-galleon-pack/blob/main/README.md[README] for more details.|*wildfly-ee*, *wildfly-ee-10* or *wildfly-preview*
 
-|*org.wildfly:wildfly-myfaces-feature-pack*|-|Provides MyFaces support for WildFly. See the feature-pack project https://github.com/wildfly-extras/wildfly-myfaces-feature-pack/blob/master/README.md[README] for more details.|*wildfly* or *wildfly-preview*|
+|*org.wildfly:wildfly-myfaces-feature-pack*|-|Provides MyFaces support for WildFly. See the feature-pack project https://github.com/wildfly-extras/wildfly-myfaces-feature-pack/blob/master/README.md[README] for more details.|*wildfly-ee* or *wildfly-preview* (for Jakarta Faces 4.1) or *wildfly-ee-10* (for Faces 4.0)|
 |=======================================================================
 
 The main WildFly project also provides a feature-pack for xref:WildFly_and_WildFly_Preview.adoc[WildFly Preview]:

--- a/docs/src/main/asciidoc/_galleon/Galleon_feature_packs.adoc
+++ b/docs/src/main/asciidoc/_galleon/Galleon_feature_packs.adoc
@@ -1,8 +1,8 @@
 [[WildFly_Galleon_feature-packs]]
-=== WildFly Galleon feature-packs
+=== WildFly Galleon Feature-packs
 
 The WildFly project provides a number of Galleon https://docs.wildfly.org/galleon/#_feature_packs[feature-pack] maven artifacts. A feature-pack is a zipped file that contains everything needed to dynamically provision a server.
-These feature-packs are deployed in public maven repositories.
+These feature-packs are deployed in public Maven repositories.
 
 When Galleon is used to install WildFly, the desired WildFly feature-packs are retrieved and
 their content is assembled to create an installation.
@@ -11,13 +11,13 @@ The main WildFly project provides the following feature-packs for use with xref:
 
 [cols="~,~,~,~",options="header"]
 |=======================================================================
-|Maven GroupId:ArtifactId |Short name|Use|Requires
+|Maven groupId:artifactId |Short name|Use|Requires
 
 |*org.wildfly:wildfly-galleon-pack*|*wildfly*|The feature-pack most WildFly users use. Provisions a standard WildFly installation. Internally depends on the `wildfly-ee` feature-pack, but also provides integration of technologies like MicroProfile, Micrometer and Open Telemetry that are evolving rapidly, possibly in incompatible ways.| *wildfly-ee* (by default) or *wildfly-ee-10* (for EE 10 support)
 
 |*org.wildfly:wildfly-ee-galleon-pack*|*wildfly-ee*|Provisions the most long-term stable functionality of standard WildFly. Does not include MicroProfile or other rapidly evolving technologies that may frequently introduce incompatible changes.| none
 
-|*org.wildfly:wildfly-ee-10-feature-pack*|*wildfly-ee-10*|This alternative to *wildfly-ee* provides a Jakarta EE 10 variant of WildFly for users that want to stay on that version while WildFly moves to a more recent version of the Jakarta EE specifications. This feature pack is released for a limited period of time and users should eventually migrate to EE 11| none
+|*org.wildfly:wildfly-ee-10-feature-pack*|*wildfly-ee-10*|This alternative to *wildfly-ee* provides a Jakarta EE 10 variant of WildFly for users that want to stay on that version while WildFly moves to a more recent version of the Jakarta EE specifications. This feature-pack is released for a limited period of time and users should eventually migrate to EE 11| none
 
 |*org.wildfly.cloud:wildfly-cloud-galleon-pack*|-|Provisions a set of additional features allowing you to better configure a standard WildFly server to work on the cloud. It brings to the server some configuration aspects that are generally expected in a cloud context. See the feature-pack https://github.com/wildfly-extras/wildfly-cloud-galleon-pack/blob/main/doc/index.md[documentation] for more details.| *wildfly-ee*, *wildfly-ee-10* or *wildfly-preview*
 
@@ -30,7 +30,7 @@ The main WildFly project also provides a feature-pack for xref:WildFly_and_WildF
 
 [cols="~,~,~",options="header"]
 |=======================================================================
-|Maven GroupId:ArtifactId |Short name|Use
+|Maven groupId:artifactId |Short name|Use
 
 |*org.wildfly:wildfly-preview-feature-pack*|*wildfly-preview*|Provides a technology preview of things that may be coming in standard WildFly. Likely to have significant incompatible changes with every release.
 |=======================================================================
@@ -39,14 +39,14 @@ There are also a number of feature-packs of varying levels of stability availabl
 
 In most cases, people working with WildFly are using the `wildfly` feature-pack, so that is the one used in most of the examples in this document.
 
-[IMPORTANT]
-.Order of feature-packs.
-====
-When feature packs are used to provision WildFly, *their* order is significant if they have requirements.
-A specific feature pack must be listed before a feature pack that would use another default feature pack.
+==== Order of Feature-packs.
+
+When feature-packs are used to provision WildFly, *their order is significant if they have requirements*.
+A specific feature-pack must be listed before a feature-pack that would use another default feature-pack.
 
 For example, the *wildfly-ee-10* feature-pack provides a Jakarta EE 10 variant of *wildfly-ee*.
-
-To provision WildFly with that EE 10 variant, this `org.wildfly:wildfly-ee-10-feature-pack` feature pack must be listed *before* the
+To provision WildFly with that EE 10 variant, this `org.wildfly:wildfly-ee-10-feature-pack` feature-pack must be listed *before* the
 `org.wildfly:wildfly-galleon-pack` feature-pack (that would require *wildfly-ee* otherwise) in the provisioning tool.
-====
+
+// In the WildFLy Maven Plugin Guide, the inclusion of this section is followed by an example (wildfly-ee-10 + wildfly + wildfly-cloud-galleon-pack).
+// Please bear this in mind before adding any content below this comment.

--- a/docs/src/main/asciidoc/_galleon/Galleon_feature_packs.adoc
+++ b/docs/src/main/asciidoc/_galleon/Galleon_feature_packs.adoc
@@ -11,22 +11,21 @@ The main WildFly project provides the following feature-packs for use with xref:
 
 [cols="~,~,~",options="header"]
 |=======================================================================
-|Maven GroupId:ArifactId |Short name|Use
+|Maven GroupId:ArtifactId |Short name|Use
 
 |*org.wildfly:wildfly-galleon-pack*|*wildfly*|The feature-pack most WildFly users use. Provisions a standard WildFly installation. Internally depends on the `wildfly-ee` feature-pack, but also provides integration of technologies like MicroProfile, Micrometer and Open Telemetry that are evolving rapidly, possibly in incompatible ways.
 |*org.wildfly:wildfly-ee-galleon-pack*|*wildfly-ee*|Provisions the most long-term stable functionality of standard WildFly. Does not include MicroProfile or other rapidly evolving technologies that may frequently introduce incompatible changes.
-|*org.wildfly:wildfly-ee-10-feature-pack*|*wildfly-ee10*|This feature pack provides a Jakarta EE10 variant of WildFly for users that want to stay on that version while WildFly moves to a more recent version of the Jakarta EE specifications. This feature pack is released for a limited period of time and users should eventually
-upgrade their applications to "move back" to `wildfly-ee`.|
+|*org.wildfly:wildfly-ee-10-feature-pack*|*wildfly-ee10*|This alternative to the `wildfly-ee-galleon-pack` provides a Jakarta EE10 variant of WildFly for users that want to stay on that version while WildFly moves to a more recent version of the Jakarta EE specifications. This feature pack is released for a limited period of time and users should eventually
 |*org.wildfly.cloud:wildfly-cloud-galleon-pack*|-|Provisions a set of additional features allowing you to better configure a standard WildFly server to work on the cloud. It brings to the server some configuration aspects that are generally expected in a cloud context. See the feature-pack https://github.com/wildfly-extras/wildfly-cloud-galleon-pack/blob/main/doc/index.md[documentation] for more details.
 |*org.wildfly:wildfly-datasources-galleon-pack*|-|Easy integration of popular JDBC drivers and associated datasources into a standard WildFly installation. See the feature-pack project https://github.com/wildfly-extras/wildfly-datasources-galleon-pack/blob/main/README.md[README] for more details.
-|*org.wildfly:wildfly-myfaces-feature-pack*|-|Provides MyFaces 4.x support for standard WildFly. See the feature-pack project https://github.com/wildfly-extras/wildfly-myfaces-feature-pack/blob/master/README.md[README] for more details.
+|*org.wildfly:wildfly-myfaces-feature-pack*|-|Provides MyFaces support for standard WildFly. See the feature-pack project https://github.com/wildfly-extras/wildfly-myfaces-feature-pack/blob/master/README.md[README] for more details.|
 |=======================================================================
 
-The main WildFly project also provide a feature-pack for xref:WildFly_and_WildFly_Preview.adoc[WildFly Preview]:
+The main WildFly project also provides a feature-pack for xref:WildFly_and_WildFly_Preview.adoc[WildFly Preview]:
 
 [cols="~,~,~",options="header"]
 |=======================================================================
-|Maven GroupId:ArifactId |Short name|Use
+|Maven GroupId:ArtifactId |Short name|Use
 
 |*org.wildfly:wildfly-preview-feature-pack*|*wildfly-preview*|Provides a technology preview of things that may be coming in standard WildFly. Likely to have significant incompatible changes with every release.
 |=======================================================================

--- a/docs/src/main/asciidoc/_galleon/Galleon_provisioning.adoc
+++ b/docs/src/main/asciidoc/_galleon/Galleon_provisioning.adoc
@@ -21,42 +21,7 @@ Releases of the Galleon command line tool are available on the Galleon link:http
 
 Download and unzip the release zip and add the `bin` dir to your system path. Use `galleon.sh` or `galleon.bat` to launch the tool.
 
-[[WildFly_Galleon_feature-packs]]
-== WildFly Galleon feature-packs
-
-The WildFly project provides a number of Galleon https://docs.wildfly.org/galleon/#_feature_packs[feature-pack] maven artifacts. A feature-pack is a zipped file that contains everything needed to dynamically provision a server.
-These feature-packs are deployed in public maven repositories.
-
-When Galleon is used to install WildFly, the desired WildFly feature-packs are retrieved and
-their content is assembled to create an installation.
-
-The main WildFly project provides the following feature-packs for use with xref:WildFly_and_WildFly_Preview.adoc[standard WildFly]:
-
-[cols="~,~,~",options="header"]
-|=======================================================================
-|Maven GroupId:ArifactId |Short name|Use
-
-|*org.wildfly:wildfly-galleon-pack*|*wildfly*|The feature-pack most WildFly users use. Provisions a standard WildFly installation. Internally depends on the `wildfly-ee` feature-pack, but also provides integration of technologies like MicroProfile, Micrometer and Open Telemetry that are evolving rapidly, possibly in incompatible ways.
-|*org.wildfly:wildfly-ee-galleon-pack*|*wildfly-ee*|Provisions the most long-term stable functionality of standard WildFly. Does not include MicroProfile or other rapidly evolving technologies that may frequently introduce incompatible changes.
-|*org.wildfly.cloud:wildfly-cloud-galleon-pack*|-|Provisions a set of additional features allowing you to better configure a standard WildFly server to work on the cloud. It brings to the server some configuration aspects that are generally expected in a cloud context. See the feature-pack https://github.com/wildfly-extras/wildfly-cloud-galleon-pack/blob/main/doc/index.md[documentation] for more details.
-|*org.wildfly:wildfly-datasources-galleon-pack*|-|Easy integration of popular JDBC drivers and associated datasources into a standard WildFly installation. See the feature-pack project https://github.com/wildfly-extras/wildfly-datasources-galleon-pack/blob/main/README.md[README] for more details.
-|*org.wildfly:wildfly-myfaces-feature-pack*|-|Provides MyFaces 4.x support for standard WildFly. See the feature-pack project https://github.com/wildfly-extras/wildfly-myfaces-feature-pack/blob/master/README.md[README] for more details.
-|=======================================================================
-
-The main WildFly project also provides feature-packs for use with xref:WildFly_and_WildFly_Preview.adoc[WildFly Preview]:
-
-[cols="~,~,~",options="header"]
-|=======================================================================
-|Maven GroupId:ArifactId |Short name|Use
-
-|*org.wildfly:wildfly-preview-feature-pack*|*wildfly-preview*|Provides a technology preview of things that may be coming in standard WildFly. Likely to have significant incompatible changes with every release.
-|*org.wildfly.cloud:wildfly-preview-cloud-galleon-pack*|-|WildFly Preview analogue to *wildfly-cloud-galleon-pack*.
-|*org.wildfly:wildfly-datasources-preview-galleon-pack*|-|WildFly Preview analogue to *wildfly-datasources-galleon-pack*.
-|=======================================================================
-
-There are also a number of feature-packs of varying levels of stability available from the https://github.com/orgs/wildfly-extras/repositories[*wildfly-extras* GitHub organization].
-
-In most cases, people working with WildFly are using the `wildfly` feature-pack, so that is the one used in most of the examples in this document.
+include::./Galleon_feature_packs.adoc[]
 
 == Installing WildFly using Galleon
 


### PR DESCRIPTION
* Add information about `org.wildfly:wildfly-ee-10-feature-pack` to the list of Galleon feature-packs
* Moved that list to the Galleon_feature_packs.adoc file
* Include it in the WildFly Maven Plug-in Guide.

JIRA: https://redhat.atlassian.net/browse/WFLY-21842
