### PR TITLE
WFLY-21029 Move -proc:full compiler arg to pluginManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1550,6 +1550,15 @@
                         <ignorePropertiesPrefixedWith>legacy.</ignorePropertiesPrefixedWith>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <compilerArgs combine.children="append">
+                            <arg>-proc:full</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -1721,26 +1730,6 @@
             </modules>
         </profile>
 
-        <profile>
-            <id>jdk23</id>
-            <activation>
-                <jdk>[23,)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <compilerArgs combine.children="append">
-                                <!-- SE 23+ requires explicit config to turn on annotation processing -->
-                                <arg>-proc:full</arg>
-                            </compilerArgs>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
         <profile>
             <id>docs</id>
             <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -1555,6 +1555,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
                         <compilerArgs combine.children="append">
+                              <!-- Note: this requires Java SE 17+11 or later. Update your environment if this causes a problem. -->
                             <arg>-proc:full</arg>
                         </compilerArgs>
                     </configuration>


### PR DESCRIPTION
Change related to https://issues.redhat.com/browse/WFLY-21029

Tested locally with Java 17.0.19, 21, and 25 — all 112 smoke tests pass.

Note: -proc:full was backported to JDK 17.0.11 and JDK 21.0.3; builds on older patch releases of those JDKs will need to upgrade.

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21029](https://redhat.atlassian.net/browse/WFLY-21029)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)