### PR TITLE
Fix for WFLY-21882, Allow use of a settings file in testsuite/galleon/update

### DIFF
--- a/testsuite/galleon/update/pom.xml
+++ b/testsuite/galleon/update/pom.xml
@@ -30,6 +30,8 @@
         <wildfly-ee.update.phase>compile</wildfly-ee.update.phase>
         <wildfly.update.phase>compile</wildfly.update.phase>
         <wildfly-preview.update.phase>none</wildfly-preview.update.phase>
+        <!-- The pathto the settings has to be provided as a property, otherwise no settings file used -->
+        <wildfly.galleon.test.settings.path></wildfly.galleon.test.settings.path>
     </properties>
 
     <profiles>
@@ -86,6 +88,7 @@
                                             <env key="WILDFLY_PRODUCER" value="wildfly-ee"/>
                                             <env key="WILDFLY_CHANNEL" value="${galleon.minor.channel}"/>
                                             <env key="GALLEON_LAYERS" value="jaxrs-server"/>
+                                            <env key="GALLEON_MAVEN_SETTINGS_PATH" value="${wildfly.galleon.test.settings.path}"/>
                                         </exec>
                                     </target>
                                 </configuration>
@@ -106,6 +109,7 @@
                                             <env key="WILDFLY_PRODUCER" value="wildfly"/>
                                             <env key="WILDFLY_CHANNEL" value="${galleon.minor.channel}"/>
                                             <env key="GALLEON_LAYERS" value="cloud-server"/>
+                                            <env key="GALLEON_MAVEN_SETTINGS_PATH" value="${wildfly.galleon.test.settings.path}"/>
                                         </exec>
                                     </target>
                                 </configuration>
@@ -126,6 +130,7 @@
                                             <env key="WILDFLY_PRODUCER" value="wildfly-preview"/>
                                             <env key="WILDFLY_CHANNEL" value="${galleon.minor.channel}"/>
                                             <env key="GALLEON_LAYERS" value="cloud-server,microprofile-platform,-microprofile-fault-tolerance"/>
+                                            <env key="GALLEON_MAVEN_SETTINGS_PATH" value="${wildfly.galleon.test.settings.path}"/>
                                         </exec>
                                     </target>
                                 </configuration>

--- a/testsuite/galleon/update/run-test.sh
+++ b/testsuite/galleon/update/run-test.sh
@@ -27,6 +27,11 @@ echo "Using ${MAVEN_LOCAL_REPO} as Maven local cache"
 
 "${BASE_DIR}"/target/galleon/galleon-${GALLEON_VERSION}/bin/galleon.sh maven set-local-repository "${MAVEN_LOCAL_REPO}"
 
+if [ -n "${GALLEON_MAVEN_SETTINGS_PATH}" ]; then
+  echo "Using ${GALLEON_MAVEN_SETTINGS_PATH} as settings file"
+  "${BASE_DIR}"/target/galleon/galleon-${GALLEON_VERSION}/bin/galleon.sh maven set-settings-file "${GALLEON_MAVEN_SETTINGS_PATH}"
+fi
+
 # Full install update
 echo "Testing update of ${WILDFLY_PRODUCER} from ${WF_BASE_VERSION} to ${WILDFLY_PRODUCER} latest SNAPSHOT"
 wildflyDir="${BASE_DIR}"/target/${WILDFLY_PRODUCER}


### PR DESCRIPTION
ISSUE: https://redhat.atlassian.net/browse/WFLY-21882
In the WildFly CI configuration we would have to set: `-Dwildfly.galleon.test.settings.path=~/.m2/settings.xml`
