### PR TITLE
WFLY-21892 - Update Eclipse Mojarra to 4.0.18

### DIFF
--- a/boms/legacy-ee/pom.xml
+++ b/boms/legacy-ee/pom.xml
@@ -56,7 +56,7 @@
         <version.org.bytebuddy>1.17.8</version.org.bytebuddy>
         <version.org.glassfish.expressly>5.0.0</version.org.glassfish.expressly>
         <version.org.glassfish.jakarta.enterprise.concurrent>3.0.2</version.org.glassfish.jakarta.enterprise.concurrent>
-        <version.org.glassfish.jakarta.faces>4.0.17</version.org.glassfish.jakarta.faces>
+        <version.org.glassfish.jakarta.faces>4.0.18</version.org.glassfish.jakarta.faces>
         <version.org.glassfish.soteria>3.0.3</version.org.glassfish.soteria>
         <version.org.jboss.resteasy>6.2.16.Final</version.org.jboss.resteasy>
         <version.org.jboss.spec.jakarta.el.jboss-el-api_5.0_spec>4.0.2.Final</version.org.jboss.spec.jakarta.el.jboss-el-api_5.0_spec>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21892

Version bump