### PR TITLE
WFLY-21895 Add workaround for UNDERTOW-2764 which otherwise causes recreated sessions to never complete.

### DIFF
--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionManager.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionManager.java
@@ -18,6 +18,8 @@ import io.undertow.server.session.SessionListeners;
 import io.undertow.util.AttachmentKey;
 
 import org.jboss.logging.Logger;
+import org.wildfly.clustering.function.BiConsumer;
+import org.wildfly.clustering.function.BiFunction;
 import org.wildfly.clustering.function.Consumer;
 import org.wildfly.clustering.function.Function;
 import org.wildfly.clustering.function.Predicate;
@@ -54,8 +56,8 @@ public class DistributableSessionManager implements UndertowSessionManager {
     private final RecordableSessionManagerStatistics statistics;
     private final StampedLock lifecycleLock = new StampedLock();
     private final AtomicLong lifecycleStamp = new AtomicLong(0L);
-    private final Function<String, Session<Map<String, Object>>> createSession;
-    private final Function<String, Session<Map<String, Object>>> findSession;
+    private final BiFunction<SessionConfig, HttpServerExchange, Session<Map<String, Object>>> createSession;
+    private final BiFunction<SessionConfig, HttpServerExchange, Session<Map<String, Object>>> findSession;
 
     // Matches io.undertow.server.session.InMemorySessionManager
     private volatile int defaultSessionTimeout = 30 * 60;
@@ -66,10 +68,16 @@ public class DistributableSessionManager implements UndertowSessionManager {
         this.listeners = config.getSessionListeners();
         this.statistics = config.getStatistics();
 
-        UnaryOperator<String> validateIdentifier = UnaryOperator.when(VALID_IDENTIFIER, UnaryOperator.identity(), UnaryOperator.of(Consumer.of(), this.manager.getIdentifierFactory()));
-        this.createSession = validateIdentifier.thenApply(Function.of(this.manager::createSession, REQUIRE_SESSION));
+        Function<String, Session<Map<String, Object>>> createSession = this.manager::createSession;
+        // Ignore SessionConfig and return identifier from factory
+        BiFunction<SessionConfig, HttpServerExchange, String> createSessionId = BiConsumer.<SessionConfig, HttpServerExchange>of().thenReturn(this.manager.getIdentifierFactory());
+        this.createSession = createSession.thenApply(REQUIRE_SESSION).composeBinary(createSessionId);
 
-        this.findSession = Function.when(VALID_IDENTIFIER, Function.of(this.manager::findSession, VALIDATE_SESSION), Function.of(null));
+        Function<String, Session<Map<String, Object>>> findSession = this.manager::findSession;
+        // Use identifier from SessionConfig
+        BiFunction<SessionConfig, HttpServerExchange, String> requestSessionId = SessionConfig::findSessionId;
+        // If session identifier from SessionConfig is invalid just return null
+        this.findSession = Function.when(VALID_IDENTIFIER, findSession.thenApply(VALIDATE_SESSION), Function.of(null)).composeBinary(requestSessionId);
     }
 
     @Override
@@ -160,13 +168,13 @@ public class DistributableSessionManager implements UndertowSessionManager {
         return this.getSession(exchange, config, this.findSession);
     }
 
-    private io.undertow.server.session.Session getSession(HttpServerExchange exchange, SessionConfig config, Function<String, Session<Map<String, Object>>> sessionFactory) {
+    private io.undertow.server.session.Session getSession(HttpServerExchange exchange, SessionConfig config, BiFunction<SessionConfig, HttpServerExchange, Session<Map<String, Object>>> sessionFactory) {
         if (config == null) {
             throw UndertowMessages.MESSAGES.couldNotFindSessionCookieConfig();
         }
         Consumer<HttpServerExchange> closeTask = this.getSessionCloseTask();
         try {
-            Session<Map<String, Object>> session = sessionFactory.apply(config.findSessionId(exchange));
+            Session<Map<String, Object>> session = sessionFactory.apply(config, exchange);
             try {
                 if ((session == null) || !session.isValid()) {
                     try {

--- a/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/DistributableSessionManagerTestCase.java
+++ b/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/DistributableSessionManagerTestCase.java
@@ -137,7 +137,7 @@ public class DistributableSessionManagerTestCase {
     }
 
     @Test
-    public void createSessionNoSessionId() {
+    public void createSession() {
         HttpServerExchange exchange = new HttpServerExchange(null);
         SessionConfig config = mock(SessionConfig.class);
         Session<Map<String, Object>> session = mock(Session.class);
@@ -149,6 +149,7 @@ public class DistributableSessionManagerTestCase {
         when(session.getId()).thenReturn(sessionId);
         when(session.isValid()).thenReturn(true);
         when(session.getMetaData()).thenReturn(metaData);
+        when(config.findSessionId(exchange)).thenReturn("unexpected");
 
         io.undertow.server.session.Session sessionAdapter = this.adapter.createSession(exchange, config);
 
@@ -163,56 +164,6 @@ public class DistributableSessionManagerTestCase {
 
         String result = sessionAdapter.getId();
         assertSame(expected, result);
-    }
-
-    @Test
-    public void createSessionSpecifiedSessionId() {
-        HttpServerExchange exchange = new HttpServerExchange(null);
-        SessionConfig config = mock(SessionConfig.class);
-        Session<Map<String, Object>> session = mock(Session.class);
-        SessionMetaData metaData = mock(SessionMetaData.class);
-        String sessionId = "session";
-
-        when(config.findSessionId(exchange)).thenReturn(sessionId);
-        when(this.manager.createSession(sessionId)).thenReturn(session);
-        when(session.isValid()).thenReturn(true);
-        when(session.getId()).thenReturn(sessionId);
-        when(session.getMetaData()).thenReturn(metaData);
-
-        io.undertow.server.session.Session sessionAdapter = this.adapter.createSession(exchange, config);
-
-        assertNotNull(sessionAdapter);
-
-        verify(this.listener).sessionCreated(sessionAdapter, exchange);
-        verify(this.statistics).record(metaData);
-        verifyNoInteractions(this.identifierFactory);
-
-        String expected = "expected";
-        when(session.getId()).thenReturn(expected);
-
-        String result = sessionAdapter.getId();
-        assertSame(expected, result);
-    }
-
-    @Test
-    public void createSessionAlreadyExists() {
-        HttpServerExchange exchange = new HttpServerExchange(null);
-        SessionConfig config = mock(SessionConfig.class);
-        String sessionId = "session";
-
-        when(config.findSessionId(exchange)).thenReturn(sessionId);
-        when(this.manager.createSession(sessionId)).thenReturn(null);
-
-        IllegalStateException exception = null;
-        try {
-            this.adapter.createSession(exchange, config);
-        } catch (IllegalStateException e) {
-            exception = e;
-        }
-
-        assertNotNull(exception);
-
-        verifyNoInteractions(this.identifierFactory);
     }
 
     @Test

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/cdi/webapp/CDIServlet.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/cdi/webapp/CDIServlet.java
@@ -4,10 +4,7 @@
  */
 package org.jboss.as.test.clustering.cluster.cdi.webapp;
 
-import java.io.IOException;
-
 import jakarta.inject.Inject;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
@@ -29,30 +26,26 @@ public class CDIServlet extends SimpleServlet {
     private Incrementor incrementor;
 
     @Override
-    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) {
         this.increment(request, response);
     }
 
     @Override
-    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) {
         this.increment(request, response);
     }
 
-    private void increment(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    private void increment(HttpServletRequest request, HttpServletResponse response) {
         HttpSession session = request.getSession(true);
         response.addHeader(SESSION_ID_HEADER, session.getId());
 
         int value = this.incrementor.increment();
 
         response.setIntHeader(VALUE_HEADER, value);
-
-        this.getServletContext().log(request.getRequestURI() + ", value = " + value);
-
-        response.getWriter().write("Success");
     }
 
     @Override
-    protected void doPut(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    protected void doPut(HttpServletRequest request, HttpServletResponse response) {
         HttpSession session = request.getSession(true);
         response.addHeader(SESSION_ID_HEADER, session.getId());
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/SessionExpirationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/SessionExpirationTestCase.java
@@ -332,7 +332,9 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
             try (CloseableHttpResponse response = client.execute(new HttpGet(SessionOperationServlet.createSetURI(baseURL2, "a", "6")))) {
                 assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                 assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                String previousSessionId = sessionId;
                 sessionId = response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue();
+                assertNotEquals(previousSessionId, sessionId);
                 assertTrue(response.containsHeader(SessionOperationServlet.CREATED_SESSIONS));
                 assertFalse(response.containsHeader(SessionOperationServlet.DESTROYED_SESSIONS));
                 assertTrue(response.containsHeader(SessionOperationServlet.ADDED_ATTRIBUTES));

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/SessionOperationServlet.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/SessionOperationServlet.java
@@ -150,9 +150,6 @@ public class SessionOperationServlet extends HttpServlet {
 
         String targetSessionId = req.getParameter(TARGET_SESSION_ID);
         if (targetSessionId == null) {
-            targetSessionId = req.getRequestedSessionId();
-        }
-        if (targetSessionId == null) {
             targetSessionId = session.getId();
         }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/SimpleServlet.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/SimpleServlet.java
@@ -57,7 +57,7 @@ public class SimpleServlet extends HttpServlet {
     }
 
     @Override
-    protected void doHead(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    protected void doHead(HttpServletRequest request, HttpServletResponse response) {
         HttpSession session = request.getSession(false);
         if (session != null) {
             response.addHeader(SESSION_ID_HEADER, session.getId());
@@ -65,14 +65,16 @@ public class SimpleServlet extends HttpServlet {
     }
 
     @Override
-    protected void doPut(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    protected void doPut(HttpServletRequest request, HttpServletResponse response) {
         HttpSession session = request.getSession(true);
+        session.invalidate();
+        session = request.getSession(true);
         response.addHeader(SESSION_ID_HEADER, session.getId());
         session.removeAttribute(ATTRIBUTE);
     }
 
     @Override
-    protected void doDelete(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    protected void doDelete(HttpServletRequest request, HttpServletResponse response) {
         HttpSession session = request.getSession(false);
         if (session != null) {
             session.invalidate();
@@ -80,7 +82,13 @@ public class SimpleServlet extends HttpServlet {
     }
 
     @Override
-    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    protected void doPatch(HttpServletRequest request, HttpServletResponse response) {
+        this.doDelete(request, response);
+        this.doGet(request, response);
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) {
         Function<HttpSession, Mutable> accessor = session -> {
             Mutable mutable = (Mutable) session.getAttribute(ATTRIBUTE);
             if (mutable == null) {
@@ -93,7 +101,7 @@ public class SimpleServlet extends HttpServlet {
     }
 
     @Override
-    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) {
         Function<HttpSession, Mutable> accessor = session -> {
             Mutable mutable = (Mutable) session.getAttribute(ATTRIBUTE);
             if (mutable == null) {
@@ -104,7 +112,7 @@ public class SimpleServlet extends HttpServlet {
         this.increment(request, response, accessor);
     }
 
-    private void increment(HttpServletRequest request, HttpServletResponse response, Function<HttpSession, Mutable> accessor) throws IOException {
+    private void increment(HttpServletRequest request, HttpServletResponse response, Function<HttpSession, Mutable> accessor) {
         HttpSession session = request.getSession(true);
         response.addHeader(SESSION_ID_HEADER, session.getId());
         Mutable mutable = accessor.apply(session);
@@ -134,7 +142,5 @@ public class SimpleServlet extends HttpServlet {
                 Thread.currentThread().interrupt();
             }
         }
-
-        response.getWriter().write("Success");
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/SimpleServlet.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/SimpleServlet.java
@@ -53,7 +53,12 @@ public class SimpleServlet extends HttpServlet {
     protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         String query = request.getQueryString();
         this.getServletContext().log(String.format("[%s] %s%s", request.getMethod(), request.getRequestURI(), (query != null) ? '?' + query : ""));
-        super.service(request, response);
+        // Servlet 6.0 workaround
+        if (request.getMethod().equals("PATCH")) {
+            this.doPatch(request, response);
+        } else {
+            super.service(request, response);
+        }
     }
 
     @Override
@@ -81,7 +86,8 @@ public class SimpleServlet extends HttpServlet {
         }
     }
 
-    @Override
+    // Servlet 6.0 workaround
+    // @Override
     protected void doPatch(HttpServletRequest request, HttpServletResponse response) {
         this.doDelete(request, response);
         this.doGet(request, response);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/SimpleWebTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/SimpleWebTestCase.java
@@ -9,12 +9,13 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.net.URI;
 import java.net.URL;
+import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.utils.HttpClientUtils;
+import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
@@ -68,23 +69,30 @@ public class SimpleWebTestCase {
         URI uri = SimpleServlet.createURI(baseURL);
 
         try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
-            HttpResponse response = client.execute(new HttpGet(uri));
-            try {
+            AtomicReference<String> sessionId = new AtomicReference<>();
+            try (CloseableHttpResponse response = client.execute(new HttpGet(uri))) {
                 assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                assertEquals(1, Integer.parseInt(response.getFirstHeader("value").getValue()));
-                assertFalse(Boolean.parseBoolean(response.getFirstHeader("serialized").getValue()));
-            } finally {
-                HttpClientUtils.closeQuietly(response);
+                assertEquals(1, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
+                assertFalse(Boolean.parseBoolean(response.getFirstHeader(SimpleServlet.HEADER_SERIALIZED).getValue()));
+                sessionId.setPlain(response.getFirstHeader(SimpleServlet.SESSION_ID_HEADER).getValue());
             }
 
-            response = client.execute(new HttpGet(uri));
-            try {
+            try (CloseableHttpResponse response = client.execute(new HttpGet(uri))) {
                 assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                assertEquals(2, Integer.parseInt(response.getFirstHeader("value").getValue()));
+                assertEquals(2, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
                 // This won't be true unless we have somewhere to which to replicate or session persistence is configured (current default)
-                assertFalse(Boolean.parseBoolean(response.getFirstHeader("serialized").getValue()));
-            } finally {
-                HttpClientUtils.closeQuietly(response);
+                assertFalse(Boolean.parseBoolean(response.getFirstHeader(SimpleServlet.HEADER_SERIALIZED).getValue()));
+                assertEquals(sessionId.getPlain(), response.getFirstHeader(SimpleServlet.SESSION_ID_HEADER).getValue());
+            }
+
+            // Invalidate and recreate session
+            try (CloseableHttpResponse response = client.execute(new HttpPatch(uri))) {
+                assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                assertEquals(1, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
+                // This won't be true unless we have somewhere to which to replicate or session persistence is configured (current default)
+                assertFalse(Boolean.parseBoolean(response.getFirstHeader(SimpleServlet.HEADER_SERIALIZED).getValue()));
+                // Verify that session ID of recreated session is not the same as the previous one
+                assertNotEquals(sessionId.getPlain(), response.getFirstHeader(SimpleServlet.SESSION_ID_HEADER).getValue());
             }
         }
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/ControlPointDeploymentInfoConfigurator.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/ControlPointDeploymentInfoConfigurator.java
@@ -401,6 +401,11 @@ public class ControlPointDeploymentInfoConfigurator implements UnaryOperator<Dep
         @Override
         public void invalidate(HttpServerExchange exchange) {
             this.session.invalidate(exchange);
+            // UNDERTOW-2764 workaround
+            ServletRequestContext context = (exchange != null) ? exchange.getAttachment(ServletRequestContext.ATTACHMENT_KEY) : null;
+            if (context != null) {
+                context.setSession(null);
+            }
         }
 
         @Override


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21895

Includes https://redhat.atlassian.net/browse/WFLY-21894
Distributed session manager reuses session ID for recreated sessions

Updates SimpleWebTestCase to validate session invalidation followed by recreation in same request.
