### PR TITLE
WFLY-21029 Move -proc:full compiler arg to pluginManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1550,6 +1550,16 @@
                         <ignorePropertiesPrefixedWith>legacy.</ignorePropertiesPrefixedWith>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <compilerArgs combine.children="append">
+                            <!-- Note: this requires Java SE 17.0.11 or later. Update your environment if this causes a problem. -->
+                            <arg>-proc:full</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -1721,26 +1731,6 @@
             </modules>
         </profile>
 
-        <profile>
-            <id>jdk23</id>
-            <activation>
-                <jdk>[23,)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <compilerArgs combine.children="append">
-                                <!-- SE 23+ requires explicit config to turn on annotation processing -->
-                                <arg>-proc:full</arg>
-                            </compilerArgs>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
         <profile>
             <id>docs</id>
             <activation>


### PR DESCRIPTION
Java 23 changed the default annotation processing behaviour: processors no longer run unless explicitly requested via -proc:full (or -proc:only). The existing fix used a profile activated on [23,), but profiles activated by JDK version are not applied during reactor resolution, so child modules that re-declare maven-compiler-plugin configuration could silently lose the argument.

Moving the arg to the root guarantees that every module inherits it unconditionally and that combine.children="append" semantics compose correctly with any local overrides.

Note: -proc:full was backported to JDK 17.0.11 and JDK 21.0.3; builds on older patch releases of those JDKs will need to upgrade.

Tested locally with Java 17.0.19, 21, and 25 — all 112 smoke tests pass.

Fixes: https://issues.redhat.com/browse/WFLY-21029

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21029](https://redhat.atlassian.net/browse/WFLY-21029)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)