### PR TITLE
[WFLY-21903] Upgrade Shibboleth java-support to 8.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -493,7 +493,7 @@
         <version.jboss.jaxbintros>2.0.1</version.jboss.jaxbintros>
         <version.joda-time>2.12.7</version.joda-time>
         <version.net.jcip>1.0</version.net.jcip>
-        <version.net.shibboleth.utilities.java-support>8.0.0</version.net.shibboleth.utilities.java-support>
+        <version.net.shibboleth.utilities.java-support>8.4.2</version.net.shibboleth.utilities.java-support>
         <version.org.apache.activemq.artemis>2.53.0</version.org.apache.activemq.artemis>
         <version.org.apache.activemq.artemis.native>2.0.0</version.org.apache.activemq.artemis.native>
         <version.org.apache.avro>1.12.1</version.org.apache.avro>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21903

This updates from 8.0.0 to 8.4.2. The only dep we have that uses this, opensaml, itself uses 8.4.2 so we are quite behind with 8.0.0.