### PR TITLE
[WFLY-21909] Fix assembly source path for legacy-ee distribution modules

### DIFF
--- a/legacy/ee-feature-pack/dist/assembly-src.xml
+++ b/legacy/ee-feature-pack/dist/assembly-src.xml
@@ -16,7 +16,7 @@
 
     <fileSets>
         <fileSet>
-            <directory>..</directory>
+            <directory>../../..</directory>
             <outputDirectory>${server.output.dir.prefix}-${legacy.ee.output.qualifier}${server.output.dir.version}-src</outputDirectory>
             <includes>
                 <include>**/*.xml</include>

--- a/legacy/ee-feature-pack/ee-dist/assembly-src.xml
+++ b/legacy/ee-feature-pack/ee-dist/assembly-src.xml
@@ -16,7 +16,7 @@
 
     <fileSets>
         <fileSet>
-            <directory>..</directory>
+            <directory>../../..</directory>
             <outputDirectory>${server.output.dir.prefix}-${legacy.ee.output.qualifier}${server.output.dir.version}-src</outputDirectory>
             <includes>
                 <include>**/*.xml</include>


### PR DESCRIPTION
Jira issue: https://redhat.atlassian.net/browse/WFLY-21909

