### PR TITLE
[WFLY-21878] Upgrade to Hibernate ORM 7.4.0.Final Search 8.4.0.Final

### DIFF
--- a/boms/standard-preview-ee/pom.xml
+++ b/boms/standard-preview-ee/pom.xml
@@ -58,7 +58,7 @@
         <version.org.glassfish.expressly>6.0.0</version.org.glassfish.expressly>
         <version.org.glassfish.jakarta.faces>4.1.7</version.org.glassfish.jakarta.faces>
         <version.org.glassfish.soteria>4.0.2</version.org.glassfish.soteria>
-        <version.org.hibernate.search>8.3.0.Final</version.org.hibernate.search>
+        <version.org.hibernate.search>8.4.0.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>9.1.0.Final</version.org.hibernate.validator>
         <!-- The ORM version is controlled in the root pom because we need to use its value in contexts not controlled by this bom -->
         <version.org.hibernate>${standard.version.org.hibernate}</version.org.hibernate>

--- a/pom.xml
+++ b/pom.xml
@@ -416,7 +416,7 @@
         <version.com.github.fge.msg-simple>1.1</version.com.github.fge.msg-simple>
         <version.com.github.luben.zstd-jni>1.5.7-9</version.com.github.luben.zstd-jni>
         <version.com.google.api.grpc>2.0.1</version.com.google.api.grpc>
-        <version.com.google.code.gson>2.13.2</version.com.google.code.gson>
+        <version.com.google.code.gson>2.14.0</version.com.google.code.gson>
         <version.com.google.guava>33.0.0-jre</version.com.google.guava>
         <version.com.google.guava.failureaccess>1.0.3</version.com.google.guava.failureaccess>
         <version.com.google.protobuf>4.28.3</version.com.google.protobuf>
@@ -522,7 +522,7 @@
         <legacy.version.org.hibernate>6.6.49.Final</legacy.version.org.hibernate>
         <!-- We need to use this value in configuring maven plugins, so simply overriding version.org.hibernate
              in boms/standard-preview-ee is inadequate. So we'll declare the value here and reference it in boms/standard-preview-ee. -->
-        <standard.version.org.hibernate>7.3.2.Final</standard.version.org.hibernate>
+        <standard.version.org.hibernate>7.4.0.Final</standard.version.org.hibernate>
         <version.org.hibernate.models>1.1.1</version.org.hibernate.models>
         <version.org.hornetq>2.4.11.Final</version.org.hornetq>
         <version.org.infinispan>16.0.11</version.org.infinispan>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21878

Upgrade to https://github.com/hibernate/hibernate-orm/releases/tag/7.4.0.CR1 with changes https://hibernate.atlassian.net/issues/?jql=project%20%3D%20HHH%20AND%20fixVersion%20%3D%207.4.0.CR1 + https://docs.hibernate.org/orm/7.4/migration-guide/#_annotation_changes

Details on the Search upgrade are at https://github.com/hibernate/hibernate-search/releases/tag/8.4.0.CR1