### PR TITLE
[WFLY-21913] Upgrade Undertow Core to 2.4.1.Final

### DIFF
--- a/boms/common-ee/pom.xml
+++ b/boms/common-ee/pom.xml
@@ -1256,6 +1256,19 @@
                 <version>${version.io.smallrye.smallrye-mutiny}</version>
             </dependency>
 
+            <!-- TODO (jrp) temporary override until the new version of Undertow is integrated into core and that version of core is integrated here -->
+            <dependency>
+                <groupId>io.undertow</groupId>
+                <artifactId>undertow-core</artifactId>
+                <version>${version.io.undertow}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
             <dependency>
                 <groupId>jakarta.activation</groupId>
                 <artifactId>jakarta.activation-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -460,7 +460,7 @@
         <version.io.smallrye.smallrye-stork>2.7.9</version.io.smallrye.smallrye-stork>
         <version.io.smallrye.smallrye-reactive-messaging>4.32.1</version.io.smallrye.smallrye-reactive-messaging>
         <!-- TODO (jrp) temporary override until the new version of Undertow is integrated into core and that version of core is integrated here -->
-        <version.io.undertow>2.4.0.Final</version.io.undertow>
+        <version.io.undertow>2.4.1.Final</version.io.undertow>
         <version.io.undertow.ee>2.0.0.Final</version.io.undertow.ee>
         <version.io.undertow.jastow>2.3.0.Final</version.io.undertow.jastow>
         <version.io.vertx.vertx>4.5.27</version.io.vertx.vertx>

--- a/pom.xml
+++ b/pom.xml
@@ -459,6 +459,8 @@
         <version.io.smallrye.smallrye-opentelemetry>2.11.2</version.io.smallrye.smallrye-opentelemetry>
         <version.io.smallrye.smallrye-stork>2.7.9</version.io.smallrye.smallrye-stork>
         <version.io.smallrye.smallrye-reactive-messaging>4.32.1</version.io.smallrye.smallrye-reactive-messaging>
+        <!-- TODO (jrp) temporary override until the new version of Undertow is integrated into core and that version of core is integrated here -->
+        <version.io.undertow>2.4.0.Final</version.io.undertow>
         <version.io.undertow.ee>2.0.0.Final</version.io.undertow.ee>
         <version.io.undertow.jastow>2.3.0.Final</version.io.undertow.jastow>
         <version.io.vertx.vertx>4.5.27</version.io.vertx.vertx>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21913

This also reverts commit 8a252601e9bd7ca11560514bdef20527ce44723b / https://redhat.atlassian.net/browse/WFLY-21834 so full WF can control this version for the 40 Final release.

