### PR TITLE
[WFLY-21919] Remove the Elytron Web override as this is controlled in WildFly Core.

### DIFF
--- a/boms/common-ee/pom.xml
+++ b/boms/common-ee/pom.xml
@@ -3296,31 +3296,6 @@
                 </exclusions>
             </dependency>
 
-            <!-- Elytron Web overrides to use development version with setAuthenticationRequired(boolean) -->
-            <dependency>
-                <groupId>org.wildfly.security.elytron-web</groupId>
-                <artifactId>undertow-server</artifactId>
-                <version>${version.org.wildfly.security.elytron-web}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.security.elytron-web</groupId>
-                <artifactId>undertow-server-servlet</artifactId>
-                <version>${version.org.wildfly.security.elytron-web}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
             <dependency>
                 <groupId>org.wildfly.transaction</groupId>
                 <artifactId>wildfly-transaction-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -610,7 +610,6 @@
         <version.org.wildfly.mvc.krazo>2.0.1.Final</version.org.wildfly.mvc.krazo>
         <version.org.wildfly.vertx>1.0.2.Final</version.org.wildfly.vertx>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>
-        <version.org.wildfly.security.elytron-web>4.2.1.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron-mp>2.0.0.Final</version.org.wildfly.security.elytron-mp>
         <version.org.wildfly.security.elytron-tests-common>2.4.2.Final</version.org.wildfly.security.elytron-tests-common>
         <version.org.wildfly.security.jakarta.elytron-ee>4.0.0.Final</version.org.wildfly.security.jakarta.elytron-ee>


### PR DESCRIPTION
This can be merged once we have a WildFly Core with Elytron Web 4.2.1.Final or later.

https://redhat.atlassian.net/browse/WFLY-21919

IMO we don't need to backport for WildFly 40.0.1, Elytron Web upgrades to the micro release are rare and we can still apply it should it be required.