### PR TITLE
[WFLY-21926] Extract properties from root pom.xml to specific bom

### DIFF
--- a/boms/legacy-ee/pom.xml
+++ b/boms/legacy-ee/pom.xml
@@ -63,7 +63,7 @@
         <version.org.jboss.weld.weld>5.1.7.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>5.0.SP3</version.org.jboss.weld.weld-api>
         <!-- The ORM version is controlled in the root pom because we need to use its value in contexts not controlled by this bom -->
-        <version.org.hibernate>${version.org.hibernate.legacy}</version.org.hibernate>
+        <version.org.hibernate>${legacy.version.org.hibernate}</version.org.hibernate>
         <version.org.hibernate.search>7.2.5.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.3.Final</version.org.hibernate.validator>
         <version.org.wildfly.security.jakarta.elytron-ee>3.2.1.Final</version.org.wildfly.security.jakarta.elytron-ee>

--- a/boms/legacy-test/pom.xml
+++ b/boms/legacy-test/pom.xml
@@ -50,13 +50,13 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
                 <!-- use the Netty version required by HornetQ 2.4.7.Final -->
-                <version>${legacy.version.io.netty}</version>
+                <version>${test.legacy.version.io.netty}</version>
             </dependency>
 
             <dependency>
                 <groupId>jakarta.enterprise</groupId>
                 <artifactId>jakarta.enterprise.cdi-api</artifactId>
-                <version>${legacy.version.jakarta.enterprise}</version>
+                <version>${test.legacy.version.jakarta.enterprise}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -68,7 +68,7 @@
             <dependency>
                 <groupId>jakarta.inject</groupId>
                 <artifactId>jakarta.inject-api</artifactId>
-                <version>${legacy.version.jakarta.inject.jakarta.inject-api}</version>
+                <version>${test.legacy.version.jakarta.inject.jakarta.inject-api}</version>
             </dependency>
 
             <dependency>
@@ -110,7 +110,7 @@
             <dependency>
                 <groupId>org.jboss.spec.javax.jms</groupId>
                 <artifactId>jboss-jms-api_2.0_spec</artifactId>
-                <version>${legacy.version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec}</version>
+                <version>${test.legacy.version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -122,7 +122,7 @@
             <dependency>
                 <groupId>org.wildfly</groupId>
                 <artifactId>wildfly-naming-client</artifactId>
-                <version>${legacy.version.org.wildfly.naming-client}</version>
+                <version>${test.legacy.version.org.wildfly.naming-client}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.remoting3</groupId>

--- a/boms/standard-preview-ee/pom.xml
+++ b/boms/standard-preview-ee/pom.xml
@@ -60,7 +60,8 @@
         <version.org.glassfish.soteria>4.0.2</version.org.glassfish.soteria>
         <version.org.hibernate.search>8.3.0.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>9.1.0.Final</version.org.hibernate.validator>
-        <version.org.hibernate>7.3.2.Final</version.org.hibernate>
+        <!-- The ORM version is controlled in the root pom because we need to use its value in contexts not controlled by this bom -->
+        <version.org.hibernate>${standard.version.org.hibernate}</version.org.hibernate>
         <version.org.jboss.resteasy>7.0.2.Final</version.org.jboss.resteasy>
         <version.org.jboss.weld.weld>6.0.4.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>6.0.Final</version.org.jboss.weld.weld-api>

--- a/boms/standard-preview-ee/pom.xml
+++ b/boms/standard-preview-ee/pom.xml
@@ -32,6 +32,41 @@
 
     <name>WildFly: Shared Standard and Preview Dependency Management (Base Dependencies)</name>
 
+    <properties>
+        <version.com.fasterxml.classmate>1.7.1</version.com.fasterxml.classmate>
+        <!-- n.b. H2 version here is driven by what Hibernate ORM version tests with as the H2 dialect! -->
+        <version.com.h2database>2.4.240</version.com.h2database>
+        <version.io.undertow.ee>2.0.0.Final</version.io.undertow.ee>
+        <version.io.undertow.jastow>2.3.0.Final</version.io.undertow.jastow>
+        <version.jakarta.annotation.jakarta-annotation-api>3.0.0</version.jakarta.annotation.jakarta-annotation-api>
+        <version.jakarta.authentication.jakarta-authentication-api>3.1.0</version.jakarta.authentication.jakarta-authentication-api>
+        <version.jakarta.authorization.jakarta-authorization-api>3.0.0</version.jakarta.authorization.jakarta-authorization-api>
+        <version.jakarta.enterprise.concurrent.jakarta-enterprise.concurrent-api>3.1.1</version.jakarta.enterprise.concurrent.jakarta-enterprise.concurrent-api>
+        <version.jakarta.enterprise>4.1.0</version.jakarta.enterprise>
+        <version.jakarta.faces.jakarta-faces-api>4.1.2</version.jakarta.faces.jakarta-faces-api>
+        <version.jakarta.interceptor.jakarta-interceptor-api>2.2.0</version.jakarta.interceptor.jakarta-interceptor-api>
+        <version.jakarta.persistence>3.2.0</version.jakarta.persistence>
+        <version.jakarta.security.enterprise>4.0.0</version.jakarta.security.enterprise>
+        <version.jakarta.servlet.jakarta-servlet-api>6.1.0</version.jakarta.servlet.jakarta-servlet-api>
+        <version.jakarta.servlet.jsp.jakarta-servlet-jsp-api>4.0.0</version.jakarta.servlet.jsp.jakarta-servlet-jsp-api>
+        <version.jakarta.validation.jakarta-validation-api>3.1.1</version.jakarta.validation.jakarta-validation-api>
+        <version.jakarta.websocket.jakarta-websocket-api>2.2.0</version.jakarta.websocket.jakarta-websocket-api>
+        <version.jakarta.ws.rs.jakarta-ws-rs-api>4.0.0</version.jakarta.ws.rs.jakarta-ws-rs-api>
+        <version.org.apache.lucene>9.12.3</version.org.apache.lucene>
+        <version.org.bytebuddy>1.18.8</version.org.bytebuddy>
+        <version.org.elasticsearch.client.rest-client>9.3.1</version.org.elasticsearch.client.rest-client>
+        <version.org.glassfish.expressly>6.0.0</version.org.glassfish.expressly>
+        <version.org.glassfish.jakarta.faces>4.1.7</version.org.glassfish.jakarta.faces>
+        <version.org.glassfish.soteria>4.0.2</version.org.glassfish.soteria>
+        <version.org.hibernate.search>8.3.0.Final</version.org.hibernate.search>
+        <version.org.hibernate.validator>9.1.0.Final</version.org.hibernate.validator>
+        <version.org.hibernate>7.3.2.Final</version.org.hibernate>
+        <version.org.jboss.resteasy>7.0.2.Final</version.org.jboss.resteasy>
+        <version.org.jboss.weld.weld>6.0.4.Final</version.org.jboss.weld.weld>
+        <version.org.jboss.weld.weld-api>6.0.Final</version.org.jboss.weld.weld-api>
+        <version.org.wildfly.security.jakarta.elytron-ee>4.0.0.Final</version.org.wildfly.security.jakarta.elytron-ee>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
 

--- a/boms/standard-test-expansion/pom.xml
+++ b/boms/standard-test-expansion/pom.xml
@@ -258,7 +258,7 @@
             <dependency>
                 <groupId>org.jboss.weld.se</groupId>
                 <artifactId>weld-se-core</artifactId>
-                <version>${version.org.jboss.weld.weld}</version>
+                <version>${version.org.jboss.weld.se.weld-se-core}</version>
                 <scope>test</scope>
             </dependency>
 

--- a/boms/standard-test/pom.xml
+++ b/boms/standard-test/pom.xml
@@ -268,7 +268,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-client-utils</artifactId>
-                <version>${version.org.jboss.resteasy}</version>
+                <version>${version.org.jboss.resteasy.client-utils}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -408,7 +408,6 @@
         <version.antlr>4.13.0</version.antlr>
         <version.at.yawk.lz4.lz4-java>1.10.4</version.at.yawk.lz4.lz4-java>
         <version.com.carrotsearch.hppc>0.10.0</version.com.carrotsearch.hppc>
-        <version.com.fasterxml.classmate>1.7.1</version.com.fasterxml.classmate>
         <version.com.fasterxml.jackson>2.21.3</version.com.fasterxml.jackson>
         <version.com.github.ben-manes.caffeine>3.2.4</version.com.github.ben-manes.caffeine>
         <version.com.github.fge.btf>1.2</version.com.github.fge.btf>
@@ -421,8 +420,6 @@
         <version.com.google.guava>33.0.0-jre</version.com.google.guava>
         <version.com.google.guava.failureaccess>1.0.3</version.com.google.guava.failureaccess>
         <version.com.google.protobuf>4.28.3</version.com.google.protobuf>
-        <!-- n.b. H2 version here is driven by what Hibernate ORM version tests with as the H2 dialect! -->
-        <version.com.h2database>2.4.240</version.com.h2database>
         <version.com.ibm.async.asyncutil>0.1.0</version.com.ibm.async.asyncutil>
         <version.com.microsoft.azure>8.6.6</version.com.microsoft.azure>
         <version.com.nimbus.jose-jwt>10.3.1</version.com.nimbus.jose-jwt>
@@ -461,36 +458,20 @@
         <version.io.smallrye.smallrye-reactive-messaging>4.32.1</version.io.smallrye.smallrye-reactive-messaging>
         <!-- TODO (jrp) temporary override until the new version of Undertow is integrated into core and that version of core is integrated here -->
         <version.io.undertow>2.4.1.Final</version.io.undertow>
-        <version.io.undertow.ee>2.0.0.Final</version.io.undertow.ee>
-        <version.io.undertow.jastow>2.3.0.Final</version.io.undertow.jastow>
         <version.io.vertx.vertx>4.5.27</version.io.vertx.vertx>
         <version.io.vertx.vertx-kafka-client>4.4.9</version.io.vertx.vertx-kafka-client>
         <version.jakarta.activation.jakarta.activation-api>2.1.4</version.jakarta.activation.jakarta.activation-api>
-        <version.jakarta.annotation.jakarta-annotation-api>3.0.0</version.jakarta.annotation.jakarta-annotation-api>
-        <version.jakarta.authentication.jakarta-authentication-api>3.1.0</version.jakarta.authentication.jakarta-authentication-api>
-        <version.jakarta.authorization.jakarta-authorization-api>3.0.0</version.jakarta.authorization.jakarta-authorization-api>
         <version.jakarta.batch.jakarta.batch-api>2.1.1</version.jakarta.batch.jakarta.batch-api>
         <version.jakarta.data.jakarta-data-api>1.0.1</version.jakarta.data.jakarta-data-api>
         <version.jakarta.ejb.jakarta-ejb-api>4.0.1</version.jakarta.ejb.jakarta-ejb-api>
-        <version.jakarta.enterprise.concurrent.jakarta-enterprise.concurrent-api>3.1.1</version.jakarta.enterprise.concurrent.jakarta-enterprise.concurrent-api>
-        <version.jakarta.enterprise>4.1.0</version.jakarta.enterprise>
-        <version.jakarta.faces.jakarta-faces-api>4.1.2</version.jakarta.faces.jakarta-faces-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>
-        <version.jakarta.interceptor.jakarta-interceptor-api>2.2.0</version.jakarta.interceptor.jakarta-interceptor-api>
         <version.jakarta.jms.jakarta-jms-api>3.1.0</version.jakarta.jms.jakarta-jms-api>
         <version.jakarta.json.bind.api>3.0.1</version.jakarta.json.bind.api>
         <version.jakarta.mail-api>2.1.3</version.jakarta.mail-api>
         <version.jakarta.mvc.jakarta-mvc-api>2.1.0</version.jakarta.mvc.jakarta-mvc-api>
-        <version.jakarta.persistence>3.2.0</version.jakarta.persistence>
         <version.jakarta.resource.jakarta-resource-api>2.1.0</version.jakarta.resource.jakarta-resource-api>
-        <version.jakarta.security.enterprise>4.0.0</version.jakarta.security.enterprise>
-        <version.jakarta.servlet.jakarta-servlet-api>6.1.0</version.jakarta.servlet.jakarta-servlet-api>
-        <version.jakarta.servlet.jsp.jakarta-servlet-jsp-api>4.0.0</version.jakarta.servlet.jsp.jakarta-servlet-jsp-api>
         <version.jakarta.servlet.jsp.jstl.jakarta-servlet-jsp-jstl-api>3.0.2</version.jakarta.servlet.jsp.jstl.jakarta-servlet-jsp-jstl-api>
         <version.jakarta.transaction.jakarta-transaction-api>2.0.1</version.jakarta.transaction.jakarta-transaction-api>
-        <version.jakarta.validation.jakarta-validation-api>3.1.1</version.jakarta.validation.jakarta-validation-api>
-        <version.jakarta.websocket.jakarta-websocket-api>2.2.0</version.jakarta.websocket.jakarta-websocket-api>
-        <version.jakarta.ws.rs.jakarta-ws-rs-api>4.0.0</version.jakarta.ws.rs.jakarta-ws-rs-api>
         <version.jakarta.xml.bind.jakarta-xml-bind-api>4.0.5</version.jakarta.xml.bind.jakarta-xml-bind-api>
         <version.jboss.jaxbintros>2.0.1</version.jboss.jaxbintros>
         <version.joda-time>2.12.7</version.joda-time>
@@ -505,7 +486,6 @@
         <version.org.apache.james.apache-mime4j>0.8.14</version.org.apache.james.apache-mime4j>
         <version.org.apache.kafka>4.2.0</version.org.apache.kafka>
         <version.org.apache.kafka.test-image>4.2.0</version.org.apache.kafka.test-image>
-        <version.org.apache.lucene>9.12.3</version.org.apache.lucene>
         <version.org.apache.neethi>3.2.2</version.org.apache.neethi>
         <version.org.apache.qpid.proton>0.34.1</version.org.apache.qpid.proton>
         <version.org.apache.santuario>3.0.6</version.org.apache.santuario>
@@ -513,7 +493,6 @@
         <version.org.apache.wss4j>3.0.5</version.org.apache.wss4j>
         <version.org.apache.ws.xmlschema>2.3.2</version.org.apache.ws.xmlschema>
         <version.org.bitbucket.jose4j>0.9.6</version.org.bitbucket.jose4j>
-        <version.org.bytebuddy>1.18.8</version.org.bytebuddy>
         <version.org.codehaus.woodstox.stax2-api>4.2.2</version.org.codehaus.woodstox.stax2-api>
         <version.org.codehaus.woodstox.woodstox-core>7.0.0</version.org.codehaus.woodstox.woodstox-core>
         <version.org.cryptacular>1.2.5</version.org.cryptacular>
@@ -533,22 +512,15 @@
         <version.org.eclipse.microprofile.telemetry>2.1</version.org.eclipse.microprofile.telemetry>
         <version.org.eclipse.persistence.eclipselink>4.0.9</version.org.eclipse.persistence.eclipselink>
         <version.org.eclipse.yasson>3.0.4</version.org.eclipse.yasson>
-        <version.org.elasticsearch.client.rest-client>9.3.1</version.org.elasticsearch.client.rest-client>
         <version.org.glassfish.concurro>3.1.0</version.org.glassfish.concurro>
-        <version.org.glassfish.expressly>6.0.0</version.org.glassfish.expressly>
-        <version.org.glassfish.jakarta.faces>4.1.7</version.org.glassfish.jakarta.faces>
         <version.org.glassfish.jaxb>4.0.8</version.org.glassfish.jaxb>
         <version.org.glassfish.jaxb.jaxb-xjc>${version.org.glassfish.jaxb}</version.org.glassfish.jaxb.jaxb-xjc>
-        <version.org.glassfish.soteria>4.0.2</version.org.glassfish.soteria>
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.1-jbossorg-1</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hibernate.commons.annotations>7.0.3.Final</version.org.hibernate.commons.annotations>
-        <version.org.hibernate>7.3.2.Final</version.org.hibernate>
         <!-- We need to use this value in configuring maven plugins, so simply overriding version.org.hibernate
              in boms/legacy-ee is inadequate. So we'll declare the value here and reference it in boms/legacy-ee. -->
         <version.org.hibernate.legacy>6.6.49.Final</version.org.hibernate.legacy>
         <version.org.hibernate.models>1.1.1</version.org.hibernate.models>
-        <version.org.hibernate.search>8.3.0.Final</version.org.hibernate.search>
-        <version.org.hibernate.validator>9.1.0.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.11.Final</version.org.hornetq>
         <version.org.infinispan>16.0.11</version.org.infinispan>
         <version.org.jasypt>1.9.3</version.org.jasypt>
@@ -567,7 +539,7 @@
         <version.org.jboss.narayana>7.3.4.Final</version.org.jboss.narayana>
         <version.org.jboss.narayana.lra>1.1.0.Final</version.org.jboss.narayana.lra>
         <version.org.jboss.openjdk-orb>10.1.3.Final</version.org.jboss.openjdk-orb>
-        <version.org.jboss.resteasy>7.0.2.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy.client-utils>7.0.2.Final</version.org.jboss.resteasy.client-utils>
         <version.org.jboss.resteasy.extensions>2.0.1.Final</version.org.jboss.resteasy.extensions>
         <version.org.jboss.resteasy.microprofile>3.0.1.Final</version.org.jboss.resteasy.microprofile>
         <version.org.jboss.resteasy.spring>3.2.0.Final</version.org.jboss.resteasy.spring>
@@ -576,8 +548,7 @@
         <version.org.jboss.spec.jakarta.xml.ws.api_4.0_spec>1.0.0.Final</version.org.jboss.spec.jakarta.xml.ws.api_4.0_spec>
         <version.org.jboss.universe.community>1.2.2.Final</version.org.jboss.universe.community>
         <version.org.jboss.universe.producer.wildfly>1.4.1.Final</version.org.jboss.universe.producer.wildfly>
-        <version.org.jboss.weld.weld>6.0.4.Final</version.org.jboss.weld.weld>
-        <version.org.jboss.weld.weld-api>6.0.Final</version.org.jboss.weld.weld-api>
+        <version.org.jboss.weld.se.weld-se-core>6.0.4.Final</version.org.jboss.weld.se.weld-se-core>
         <version.org.jboss.ws.api>3.0.0.Final</version.org.jboss.ws.api>
         <version.org.jboss.ws.common>5.1.0.Final</version.org.jboss.ws.common>
         <version.org.jboss.ws.common.tools>2.1.0.Final</version.org.jboss.ws.common.tools>
@@ -612,7 +583,6 @@
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-mp>2.0.0.Final</version.org.wildfly.security.elytron-mp>
         <version.org.wildfly.security.elytron-tests-common>2.4.2.Final</version.org.wildfly.security.elytron-tests-common>
-        <version.org.wildfly.security.jakarta.elytron-ee>4.0.0.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.wildfly.transaction.client>3.0.5.Final</version.org.wildfly.transaction.client>
         <version.org.wildfly.wildfly-application-development-guide>1.0.0.Final</version.org.wildfly.wildfly-application-development-guide>
         <preview.version.org.wildfly.wildfly-ee-9-deployment-transformer>2.0.0.Final</preview.version.org.wildfly.wildfly-ee-9-deployment-transformer>

--- a/pom.xml
+++ b/pom.xml
@@ -519,7 +519,10 @@
         <version.org.hibernate.commons.annotations>7.0.3.Final</version.org.hibernate.commons.annotations>
         <!-- We need to use this value in configuring maven plugins, so simply overriding version.org.hibernate
              in boms/legacy-ee is inadequate. So we'll declare the value here and reference it in boms/legacy-ee. -->
-        <version.org.hibernate.legacy>6.6.49.Final</version.org.hibernate.legacy>
+        <legacy.version.org.hibernate>6.6.49.Final</legacy.version.org.hibernate>
+        <!-- We need to use this value in configuring maven plugins, so simply overriding version.org.hibernate
+             in boms/standard-preview-ee is inadequate. So we'll declare the value here and reference it in boms/standard-preview-ee. -->
+        <standard.version.org.hibernate>7.3.2.Final</standard.version.org.hibernate>
         <version.org.hibernate.models>1.1.1</version.org.hibernate.models>
         <version.org.hornetq>2.4.11.Final</version.org.hornetq>
         <version.org.infinispan>16.0.11</version.org.infinispan>

--- a/pom.xml
+++ b/pom.xml
@@ -352,10 +352,10 @@
         <version.org.wiremock>3.10.0</version.org.wiremock>
         <version.dom4j>2.1.5</version.dom4j>
         <version.httpunit>1.7.3</version.httpunit>
-        <legacy.version.io.netty>4.0.19.Final</legacy.version.io.netty>
+        <test.legacy.version.io.netty>4.0.19.Final</test.legacy.version.io.netty>
         <version.io.rest-assured>5.5.7</version.io.rest-assured>
-        <legacy.version.jakarta.enterprise>2.0.2</legacy.version.jakarta.enterprise>
-        <legacy.version.jakarta.inject.jakarta.inject-api>1.0.5</legacy.version.jakarta.inject.jakarta.inject-api>
+        <test.legacy.version.jakarta.enterprise>2.0.2</test.legacy.version.jakarta.enterprise>
+        <test.legacy.version.jakarta.inject.jakarta.inject-api>1.0.5</test.legacy.version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.mvc>2.1.0</version.jakarta.mvc>
         <version.jaxen>1.1.6</version.jaxen>
         <version.jsoup>1.15.4</version.jsoup>
@@ -383,7 +383,7 @@
              versions of the Shrinkwrap Resolvers. -->
         <version.org.jboss.shrinkwrap.resolvers>2.2.7</version.org.jboss.shrinkwrap.resolvers>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
-        <legacy.version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>2.0.0.Final</legacy.version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>
+        <test.legacy.version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>2.0.0.Final</test.legacy.version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>
         <version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>2.0.0.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>
         <version.org.junit>5.14.4</version.org.junit>
         <version.org.keycloak>25.0.6</version.org.keycloak>
@@ -397,7 +397,7 @@
         <version.org.testng.mp.rest.client>7.10.2</version.org.testng.mp.rest.client>
         <version.org.wildfly.arquillian>5.1.0.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.extras.creaper>2.0.3</version.org.wildfly.extras.creaper>
-        <legacy.version.org.wildfly.naming-client>1.0.17.Final</legacy.version.org.wildfly.naming-client>
+        <test.legacy.version.org.wildfly.naming-client>1.0.17.Final</test.legacy.version.org.wildfly.naming-client>
 
         <!--
             *Non-plugin* PRODUCTION CODE dependency versions. Please keep alphabetical.
@@ -1534,7 +1534,7 @@
                         <doNotDowngrade>true</doNotDowngrade>
                         <ignoreStreams>org.apache.maven:*,org.apache.maven.resolver:*,org.codehaus.plexus:*</ignoreStreams>
                         <injectRepositories>false</injectRepositories>
-                        <ignorePropertiesPrefixedWith>legacy.</ignorePropertiesPrefixedWith>
+                        <ignorePropertiesPrefixedWith>test.legacy.</ignorePropertiesPrefixedWith>
                     </configuration>
                 </plugin>
             </plugins>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -40,7 +40,7 @@
 
         <!-- Annotation processor version used by the maven-compile plugin.
              Overridden in profiles for legacy EE testing -->
-        <version.org.hibernate.jpamodelgen>${version.org.hibernate}</version.org.hibernate.jpamodelgen>
+        <version.org.hibernate.jpamodelgen>${standard.version.org.hibernate}</version.org.hibernate.jpamodelgen>
     </properties>
 
     <dependencies>
@@ -1248,7 +1248,7 @@
             <properties>
                 <!-- Use the version of the hibernate-jpamodelgen annotation processor
                      that aligns with the ORM version in the legacy EE FP. -->
-                <version.org.hibernate.jpamodelgen>${version.org.hibernate.legacy}</version.org.hibernate.jpamodelgen>
+                <version.org.hibernate.jpamodelgen>${legacy.version.org.hibernate}</version.org.hibernate.jpamodelgen>
             </properties>
             <build>
                 <plugins>
@@ -1312,7 +1312,7 @@
             <properties>
                 <!-- Use the version of the hibernate-jpamodelgen annotation processor
                      that aligns with the ORM version in the legacy EE FP. -->
-                <version.org.hibernate.jpamodelgen>${version.org.hibernate.legacy}</version.org.hibernate.jpamodelgen>
+                <version.org.hibernate.jpamodelgen>${legacy.version.org.hibernate}</version.org.hibernate.jpamodelgen>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
 https://redhat.atlassian.net/browse/WFLY-21926

Resolves the problem breaking CI in #20050 

@yersan Hopefully this doesn't break the alignment use case you were working. I don't think there is any alternative to using a root pom property of some form for this.

This at least somewhat addresses a goal I have in mind for your change of making it more clear when a PR is mixing shared dependency changes with EE 11-specific ones. Your change does the bulk of that by splitting the properties for most deps into different poms so its clearer that there's mixing if that occurs. The Hibernate ORM version is still vulnerable to mixing concerns, but it's just one comment and it has an unusual name and a comment to help make the prop visually unusual.

Note that mixing isn't necessarily wrong; it just requires more care to ensure the shared component also works well with its EE 10 dependency. 
