### PR TITLE
[WFLY-21930] Fix EJB-over-HTTP session stickiness path mismatch

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/http/HttpInvokerCookiePathTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/http/HttpInvokerCookiePathTestCase.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.ejb.remote.http;
+
+import java.net.URL;
+
+import org.apache.http.Header;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that the HTTP invoker session cookie has the correct path attribute.
+ * This test verifies the fix for [WFLY-21930] where the cookie path was missing
+ * the leading slash, causing load balancers and HTTP clients to reject the cookie.
+ *
+ * @author Rafael Rosa
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class HttpInvokerCookiePathTestCase {
+
+    private static final String PATH_PREFIX = "path=";
+
+    @ArquillianResource
+    private URL url;
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(WebArchive.class, HttpInvokerCookiePathTestCase.class.getSimpleName() + ".war");
+    }
+
+     /**
+     * Verifies that the JSESSIONID cookie set by the HTTP invoker endpoint
+     * has a path attribute that starts with a forward slash.
+     */
+    @Test
+    public void testHttpInvokerCookiePathHasLeadingSlash() throws Exception {
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            // Access the wildfly-services endpoint to trigger HTTP invoker session cookie
+            String wildflyServicesUrl = url.getProtocol() + "://" + url.getHost() + ":" + url.getPort() + "/wildfly-services";
+            HttpGet request = new HttpGet(wildflyServicesUrl);
+
+            try (CloseableHttpResponse response = httpClient.execute(request)) {
+                // Inspect Set-Cookie headers
+                Header[] setCookieHeaders = response.getHeaders("Set-Cookie");
+
+                boolean foundJSessionId = false;
+                String actualPath = null;
+
+                // Look for JSESSIONID cookie from HTTP invoker
+                for (Header header : setCookieHeaders) {
+                    String cookieValue = header.getValue();
+
+                    if (cookieValue.contains("JSESSIONID=")) {
+                        foundJSessionId = true;
+
+                        // Extract path attribute
+                        String[] parts = cookieValue.split(";");
+                        for (String part : parts) {
+                            String trimmed = part.trim();
+                            if (trimmed.toLowerCase().startsWith(PATH_PREFIX)) {
+                                actualPath = trimmed.substring(PATH_PREFIX.length());
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                }
+
+                Assert.assertTrue(
+                    "HTTP invoker endpoint should set JSESSIONID cookie",
+                    foundJSessionId
+                );
+                Assert.assertNotNull(
+                    "JSESSIONID cookie should have a path attribute",
+                    actualPath
+                );
+                Assert.assertTrue(
+                    "HTTP invoker cookie path must start with '/', but was: " + actualPath,
+                    actualPath.startsWith("/")
+                );
+                Assert.assertEquals(
+                    "HTTP invoker cookie path should be '/wildfly-services'",
+                    "/wildfly-services",
+                    actualPath
+                );
+            }
+        }
+    }
+}

--- a/undertow/src/main/java/org/wildfly/extension/undertow/Host.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/Host.java
@@ -292,13 +292,13 @@ public class Host implements Service<Host>, FilterLocation, SuspendableActivity 
     }
 
     void registerLocation(String path) {
-        String realPath = path.startsWith("/") ? path : "/" + path;
+        String realPath = UndertowUtils.normalizePath(path);
         locations.put(realPath, null);
         server.get().getUndertowService().fireEvent(listener -> listener.onDeploymentStart(realPath, Host.this));
     }
 
     void unregisterLocation(String path) {
-        String realPath = path.startsWith("/") ? path : "/" + path;
+        String realPath = UndertowUtils.normalizePath(path);
         locations.remove(realPath);
         server.get().getUndertowService().fireEvent(listener -> listener.onDeploymentStop(realPath, Host.this));
     }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpInvokerHostService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpInvokerHostService.java
@@ -64,7 +64,7 @@ final class HttpInvokerHostService implements Service {
         }
 
         SessionCookieConfig sessionConfig = new SessionCookieConfig();
-        sessionConfig.setPath(this.path);
+        sessionConfig.setPath(UndertowUtils.normalizePath(this.path));
         Server server = this.host.get().getServer();
         ServletContainerService container = server.getServletContainer();
         CookieConfig affinityCookeConfig = container.getAffinityCookieConfig();
@@ -147,3 +147,4 @@ final class HttpInvokerHostService implements Service {
         return path;
     }
 }
+

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowUtils.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowUtils.java
@@ -1,0 +1,19 @@
+package org.wildfly.extension.undertow;
+
+public final class UndertowUtils {
+
+    private UndertowUtils() {
+    }
+
+    /**
+     * Normalizes the path to ensure it starts with a leading slash.
+     *
+     * @param path the path to normalize
+     * @return the normalized path with a leading slash, or {@code null} if the input path was null
+     */
+    public static String normalizePath(String path) {
+        if (path == null) return null;
+        return path.startsWith("/") ? path : "/" + path;
+    }
+
+}

--- a/undertow/src/test/java/org/wildfly/extension/undertow/UndertowUtilsTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/UndertowUtilsTestCase.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.undertow;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link UndertowUtils}.
+ *
+ * @author Rafael Rosa
+ */
+public class UndertowUtilsTestCase {
+
+    @Test
+    public void testNormalizePathWithoutLeadingSlash() {
+        assertEquals("/wildfly-services", UndertowUtils.normalizePath("wildfly-services"));
+    }
+
+    @Test
+    public void testNormalizePathWithLeadingSlash() {
+        assertEquals("/wildfly-services", UndertowUtils.normalizePath("/wildfly-services"));
+    }
+
+    @Test
+    public void testNormalizePathEmpty() {
+        assertEquals("/", UndertowUtils.normalizePath(""));
+    }
+
+    @Test
+    public void testNormalizePathNull() {
+        assertEquals(null, UndertowUtils.normalizePath(null));
+    }
+
+    @Test
+    public void testNormalizePathRoot() {
+        assertEquals("/", UndertowUtils.normalizePath("/"));
+    }
+
+    @Test
+    public void testNormalizePathComplex() {
+        assertEquals("/api/v1/services", UndertowUtils.normalizePath("api/v1/services"));
+        assertEquals("/api/v1/services", UndertowUtils.normalizePath("/api/v1/services"));
+    }
+}


### PR DESCRIPTION
JIRA Issues:
* Upstream: [WFLY-21930](https://redhat.atlassian.net/browse/WFLY-21930)
* Downstream: [JBEAP-33250](https://redhat.atlassian.net/issues?filter=51706&selectedIssue=JBEAP-33250)

This PR fixes a session stickiness issue in EJB-over-HTTP where a path mismatch was preventing the session from being correctly associated with the request.