### PR TITLE
[WFLY-21931] Build modules do not override the wildfly.channels when …

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -94,6 +94,16 @@
                             <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
                             <offline-provisioning>${galleon.offline}</offline-provisioning>
                             <overwrite-provisioned-server>true</overwrite-provisioned-server>
+                            <channels>
+                                <channel>
+                                    <name>wildfly</name>
+                                    <manifest>
+                                        <groupId>${channels.maven.groupId}</groupId>
+                                        <artifactId>wildfly</artifactId>
+                                        <version>${full.maven.version}</version>
+                                    </manifest>
+                                </channel>
+                            </channels>
                             <feature-packs>
                                 <feature-pack>
                                     <transitive>true</transitive>
@@ -174,4 +184,15 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <!-- For the build zip, ignore any external channel setting -->
+            <id>external.channel.profile</id>
+            <activation><property><name>external.wildfly.channels</name></property></activation>
+            <properties>
+                <wildfly.channels>${channels.maven.groupId}:wildfly:${full.maven.version}</wildfly.channels>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/ee-build/pom.xml
+++ b/ee-build/pom.xml
@@ -77,6 +77,16 @@
                             <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
                             <offline-provisioning>${galleon.offline}</offline-provisioning>
                             <overwrite-provisioned-server>true</overwrite-provisioned-server>
+                            <channels>
+                                <channel>
+                                    <name>wildfly-ee</name>
+                                    <manifest>
+                                        <groupId>${channels.maven.groupId}</groupId>
+                                        <artifactId>wildfly-${latest.ee.artifactid.segment}</artifactId>
+                                        <version>${ee.maven.version}</version>
+                                    </manifest>
+                                </channel>
+                            </channels>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${ee.maven.groupId}</groupId>
@@ -148,4 +158,15 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <!-- For the build zip, ignore any external channel setting -->
+            <id>external.channel.profile</id>
+            <activation><property><name>external.wildfly.channels</name></property></activation>
+            <properties>
+                <wildfly.channels>${channels.maven.groupId}:wildfly-${latest.ee.artifactid.segment}:${ee.maven.version}</wildfly.channels>
+            </properties>
+        </profile>
+    </profiles>
+
 </project>

--- a/legacy/ee-feature-pack/build/pom.xml
+++ b/legacy/ee-feature-pack/build/pom.xml
@@ -73,11 +73,15 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Depends on the org.wildfly.channels:wildfly-compat-ee-10 artifact to ensure
+             that this channel is built first before the distribution is created -->
         <dependency>
             <groupId>${channels.maven.groupId}</groupId>
-            <artifactId>wildfly</artifactId>
-            <type>yaml</type>
+            <artifactId>wildfly-compat-${legacy.ee.artifactid.segment}</artifactId>
+            <version>${full.maven.version}</version>
             <classifier>manifest</classifier>
+            <type>yaml</type>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -123,11 +127,21 @@
                             <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
                             <offline-provisioning>${galleon.offline}</offline-provisioning>
                             <overwrite-provisioned-server>true</overwrite-provisioned-server>
+                            <channels>
+                                <channel>
+                                    <name>wildfly</name>
+                                    <manifest>
+                                        <groupId>${channels.maven.groupId}</groupId>
+                                        <artifactId>wildfly-compat-${legacy.ee.artifactid.segment}</artifactId>
+                                        <version>${full.maven.version}</version>
+                                    </manifest>
+                                </channel>
+                            </channels>
                             <feature-packs>
                                 <feature-pack>
                                     <transitive>true</transitive>
                                     <groupId>${ee.maven.groupId}</groupId>
-                                    <artifactId>wildfly-ee-10-feature-pack</artifactId>
+                                    <artifactId>${legacy.ee.feature.pack.artifactId}</artifactId>
                                     <version>${ee.maven.version}</version>
                                     <included-packages>
                                         <name>docs.examples.configs</name>
@@ -203,4 +217,16 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <!-- For the build zip, ignore any external channel setting -->
+            <id>external.channel.profile</id>
+            <activation><property><name>external.wildfly.channels</name></property></activation>
+            <properties>
+                <wildfly.channels>${channels.maven.groupId}:wildfly-compat-${legacy.ee.artifactid.segment}:${full.maven.version}</wildfly.channels>
+            </properties>
+        </profile>
+    </profiles>
+
 </project>

--- a/legacy/ee-feature-pack/ee-build/pom.xml
+++ b/legacy/ee-feature-pack/ee-build/pom.xml
@@ -78,11 +78,21 @@
                             <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
                             <offline-provisioning>${galleon.offline}</offline-provisioning>
                             <overwrite-provisioned-server>true</overwrite-provisioned-server>
+                            <channels>
+                                <channel>
+                                    <name>wildfly-${legacy.ee.artifactid.segment}</name>
+                                    <manifest>
+                                        <groupId>${channels.maven.groupId}</groupId>
+                                        <artifactId>wildfly-${legacy.ee.artifactid.segment}</artifactId>
+                                        <version>${ee.maven.version}</version>
+                                    </manifest>
+                                </channel>
+                            </channels>
                             <feature-packs>
                                 <feature-pack>
-                                    <groupId>${project.groupId}</groupId>
+                                    <groupId>${ee.maven.groupId}</groupId>
                                     <artifactId>${legacy.ee.feature.pack.artifactId}</artifactId>
-                                    <version>${project.version}</version>
+                                    <version>${ee.maven.version}</version>
                                     <included-packages>
                                         <name>docs.examples.configs</name>
                                     </included-packages>
@@ -149,4 +159,15 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <!-- For the build zip, ignore any external channel setting -->
+            <id>external.channel.profile</id>
+            <activation><property><name>external.wildfly.channels</name></property></activation>
+            <properties>
+                <wildfly.channels>${channels.maven.groupId}:wildfly-${legacy.ee.artifactid.segment}:${ee.maven.version}</wildfly.channels>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
…it is externally set

Jira issue: https://redhat.atlassian.net/browse/WFLY-21931

For the sake of completeness, I've also added changes to make the wildfly-maven-plugin configurations in builds* modules similar to the dist* ones