### PR TITLE
Fix for WFLY-21939, Glow metadata tests should resolve feature-packs in offline mode

### DIFF
--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/AbstractLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/AbstractLayerMetaDataTestCase.java
@@ -108,7 +108,7 @@ public class AbstractLayerMetaDataTestCase {
                 argumentsAugmenter.accept(argumentsBuilder);
             }
             Arguments arguments = argumentsBuilder.build();
-            ScanResults scanResults = GlowSession.scan(MavenResolver.newMavenResolver(), arguments, GlowMessageWriter.DEFAULT);
+            ScanResults scanResults = GlowSession.scan(MavenResolver.newOfflineMavenResolver(), arguments, GlowMessageWriter.DEFAULT);
 
             Set<String> foundLayers = scanResults.getDiscoveredLayers().stream().map(l -> l.getName()).collect(Collectors.toSet());
             Set<String> foundDecorators = scanResults.getDecorators().stream().map(l -> l.getName()).collect(Collectors.toSet());

--- a/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/AbstractLayerMetaDataTestCase.java
+++ b/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/AbstractLayerMetaDataTestCase.java
@@ -108,7 +108,7 @@ public class AbstractLayerMetaDataTestCase {
                 argumentsAugmenter.accept(argumentsBuilder);
             }
             Arguments arguments = argumentsBuilder.build();
-            ScanResults scanResults = GlowSession.scan(MavenResolver.newMavenResolver(), arguments, GlowMessageWriter.DEFAULT);
+            ScanResults scanResults = GlowSession.scan(MavenResolver.newOfflineMavenResolver(), arguments, GlowMessageWriter.DEFAULT);
 
             Set<String> foundLayers = scanResults.getDiscoveredLayers().stream().map(l -> l.getName()).collect(Collectors.toSet());
             Set<String> foundDecorators = scanResults.getDecorators().stream().map(l -> l.getName()).collect(Collectors.toSet());

--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,7 @@
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.galleon-plugins>8.1.5.Final</version.org.wildfly.galleon-plugins>
-        <version.org.wildfly.glow>2.0.0.Final</version.org.wildfly.glow>
+        <version.org.wildfly.glow>2.1.0.Final</version.org.wildfly.glow>
         <version.org.wildfly.licenses.plugin>2.4.4.Final</version.org.wildfly.licenses.plugin>
         <version.org.wildfly.plugin>6.0.0.Final</version.org.wildfly.plugin>
         <version.org.wildfly.unstable.annotation.api>1.0.2.Final</version.org.wildfly.unstable.annotation.api>


### PR DESCRIPTION
ISSUE: https://redhat.atlassian.net/browse/WFLY-21939

There is a component upgrade to 2.1.0.Final for Glow: https://github.com/wildfly/wildfly-glow/compare/2.0.0.Final...2.1.0.Final
