### PR TITLE
WFLY-21920 Remote queries fail with "IllegalArgumentException: No marshaller registered for Protobuf type" when using container-managed RemoteCacheContainer with deployment-specific types

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/client/ManagedRemoteCacheContainer.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/client/ManagedRemoteCacheContainer.java
@@ -18,7 +18,9 @@ import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.configuration.RemoteCacheConfiguration;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.commons.marshall.ProtoStreamMarshaller;
 import org.infinispan.protostream.GeneratedSchema;
+import org.infinispan.protostream.SerializationContext;
 import org.infinispan.protostream.SerializationContextInitializer;
 import org.jboss.as.clustering.infinispan.logging.InfinispanLogger;
 import org.jboss.as.clustering.infinispan.marshalling.UserMarshallerFactory;
@@ -73,6 +75,9 @@ public class ManagedRemoteCacheContainer extends RemoteCacheContainerDecorator i
                     // If this is a protostream marshaller, additionally auto-register deployment-specific schemas with server
                     if (marshaller.mediaType().equals(MediaType.APPLICATION_PROTOSTREAM)) {
                         RemoteSchemasAdmin admin = this.container.administration().schemas();
+                        // Also register schemas in the container-level serialization context for query support
+                        ProtoStreamMarshaller containerMarshaller = (ProtoStreamMarshaller) this.container.getMarshallerRegistry().getMarshaller(ProtoStreamMarshaller.class);
+                        SerializationContext containerContext = (containerMarshaller != null) ? containerMarshaller.getSerializationContext() : null;
                         for (SerializationContextInitializer initializer : ServiceLoader.load(SerializationContextInitializer.class, loader)) {
                             if (initializer instanceof GeneratedSchema schema) {
                                 if (WildFlySecurityManager.getClassLoaderPrivileged(schema.getClass()) == loader) {
@@ -81,6 +86,10 @@ public class ManagedRemoteCacheContainer extends RemoteCacheContainerDecorator i
                                         InfinispanLogger.ROOT_LOGGER.warn(result.getError());
                                     } else {
                                         stopTasks.add(() -> admin.remove(schema.getName()));
+                                    }
+                                    if (containerContext != null) {
+                                        schema.registerSchema(containerContext);
+                                        schema.registerMarshallers(containerContext);
                                     }
                                 }
                             }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/infinispan/query/ContainerRemoteQueryTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/infinispan/query/ContainerRemoteQueryTestCase.java
@@ -26,7 +26,6 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.spec.se.manifest.ManifestDescriptor;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -36,7 +35,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @author Radoslav Husar
  * @since 27
  */
-@Disabled("https://redhat.atlassian.net/browse/WFLY-21920")
 @ExtendWith(ArquillianExtension.class)
 @ServerSetup(ServerSetupTask.class)
 public class ContainerRemoteQueryTestCase {


### PR DESCRIPTION
Resolves
http://issues.redhat.com/browse/WFLY-21920

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21920](https://redhat.atlassian.net/browse/WFLY-21920)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)