### PR TITLE
[WFLY-21935] [WFLY-21936] - Update Apache CXF and JBossWS dependencies to introduce Apache CXF 4.1.6 and JBossWS CXF 7.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -473,7 +473,7 @@
         <version.jakarta.servlet.jsp.jstl.jakarta-servlet-jsp-jstl-api>3.0.2</version.jakarta.servlet.jsp.jstl.jakarta-servlet-jsp-jstl-api>
         <version.jakarta.transaction.jakarta-transaction-api>2.0.1</version.jakarta.transaction.jakarta-transaction-api>
         <version.jakarta.xml.bind.jakarta-xml-bind-api>4.0.5</version.jakarta.xml.bind.jakarta-xml-bind-api>
-        <version.jboss.jaxbintros>2.0.1</version.jboss.jaxbintros>
+        <version.jboss.jaxbintros>2.1.0.Final</version.jboss.jaxbintros>
         <version.joda-time>2.12.7</version.joda-time>
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>8.4.2</version.net.shibboleth.utilities.java-support>
@@ -552,12 +552,12 @@
         <version.org.jboss.universe.community>1.2.2.Final</version.org.jboss.universe.community>
         <version.org.jboss.universe.producer.wildfly>1.4.1.Final</version.org.jboss.universe.producer.wildfly>
         <version.org.jboss.weld.se.weld-se-core>6.0.4.Final</version.org.jboss.weld.se.weld-se-core>
-        <version.org.jboss.ws.api>3.0.0.Final</version.org.jboss.ws.api>
-        <version.org.jboss.ws.common>5.1.0.Final</version.org.jboss.ws.common>
-        <version.org.jboss.ws.common.tools>2.1.0.Final</version.org.jboss.ws.common.tools>
-        <version.org.jboss.ws.cxf>7.3.8.Final</version.org.jboss.ws.cxf>
-        <version.org.jboss.ws.jaxws-undertow-httpspi>2.0.0.Final</version.org.jboss.ws.jaxws-undertow-httpspi>
-        <version.org.jboss.ws.spi>5.0.0.Final</version.org.jboss.ws.spi>
+        <version.org.jboss.ws.api>3.1.0.Final</version.org.jboss.ws.api>
+        <version.org.jboss.ws.common>5.2.0.Final</version.org.jboss.ws.common>
+        <version.org.jboss.ws.common.tools>2.2.0.Final</version.org.jboss.ws.common.tools>
+        <version.org.jboss.ws.cxf>7.4.0.Final</version.org.jboss.ws.cxf>
+        <version.org.jboss.ws.jaxws-undertow-httpspi>3.0.1.Final</version.org.jboss.ws.jaxws-undertow-httpspi>
+        <version.org.jboss.ws.spi>5.1.0.Final</version.org.jboss.ws.spi>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.10.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jctools.jctools-core>4.0.6</version.org.jctools.jctools-core>
         <version.org.jgroups>5.5.5.Final</version.org.jgroups>

--- a/pom.xml
+++ b/pom.xml
@@ -480,7 +480,7 @@
         <version.org.apache.activemq.artemis>2.53.0</version.org.apache.activemq.artemis>
         <version.org.apache.activemq.artemis.native>2.0.0</version.org.apache.activemq.artemis.native>
         <version.org.apache.avro>1.12.1</version.org.apache.avro>
-        <version.org.apache.cxf>4.0.11</version.org.apache.cxf>
+        <version.org.apache.cxf>4.1.6</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>4.1.3</version.org.apache.cxf.xjcplugins>
         <version.org.apache.httpcomponents.httpasyncclient>4.1.5</version.org.apache.httpcomponents.httpasyncclient>
         <version.org.apache.james.apache-mime4j>0.8.14</version.org.apache.james.apache-mime4j>


### PR DESCRIPTION
Upstream issues:

- https://redhat.atlassian.net/browse/WFLY-21935
- https://redhat.atlassian.net/browse/WFLY-21936

This PR replaces https://github.com/wildfly/wildfly/pull/20049.

The changes in the first commit allow consuming the Apache CXF 4.1.x stream, as the 4.0.x is no longer maintained.
The second commit introduces changes to update all JBossWS dependencies' versions that have been released to support the Apache CXF 4.1.x stream.

Summary:

- Apache CXF → 4.1.6
- jbossws-api → https://repo1.maven.org/maven2/org/jboss/ws/jbossws-api/3.1.0.Final/ 
- jbossws-spi → https://repo1.maven.org/maven2/org/jboss/ws/jbossws-spi/5.1.0.Final/  
- jbossws-common → https://repo1.maven.org/maven2/org/jboss/ws/jbossws-common/5.2.0.Final/ 
- jbossws-common-tools → https://repo1.maven.org/maven2/org/jboss/ws/jbossws-common-tools/2.2.0.Final/ 
- jaxws-undertow-httpspi → https://repo1.maven.org/maven2/org/jboss/ws/projects/jaxws-undertow-httpspi/3.0.1.Final/ (a major, but only because of previous configuration, could be a minor)
- jboss-jaxb-intros → https://repo1.maven.org/maven2/jboss/jaxbintros/jboss-jaxb-intros/2.1.0.Final/ 

- jbossws-cxf →e.g.: https://repo1.maven.org/maven2/org/jboss/ws/cxf/jbossws-cxf-server/7.4.0.Final/