### PR TITLE
[WFLY-21952] Make wildfly.build.output.dir,dist.output.dir,ee.dist.ou…

### DIFF
--- a/testsuite/integration/expansion/pom.xml
+++ b/testsuite/integration/expansion/pom.xml
@@ -31,7 +31,7 @@
         <surefire.forked.process.timeout>3600</surefire.forked.process.timeout>
         <!-- For expansion tests we always use the 'build' module for pre-built installations, not 'ee-build'
              So exclude ${testsuite.default.build.project.prefix} from the path -->
-        <wildfly.build.output.dir>${testsuite.default.build.project.root}/build/target/${server.output.dir.prefix}-${server.output.dir.qualifier}${server.output.dir.version}</wildfly.build.output.dir>
+        <wildfly.build.output.dir>${testsuite.default.build.project.root}build/target/${server.output.dir.prefix}-${server.output.dir.qualifier}${server.output.dir.version}</wildfly.build.output.dir>
 
         <ts.glow.phase>none</ts.glow.phase>
         <ts.glow.config-name>standalone-microprofile.xml</ts.glow.config-name>

--- a/testsuite/integration/manualmode-expansion/pom.xml
+++ b/testsuite/integration/manualmode-expansion/pom.xml
@@ -247,7 +247,7 @@
                         <node3>${node3}</node3>
                         <mcast>${mcast}</mcast>
                         <!-- Tell ProvisioningConsistenceTestCase the location of the pre-built server -->
-                        <dist.output.dir>${testsuite.default.build.project.root}/dist/target/${server.output.dir.prefix}-${server.output.dir.qualifier}${server.output.dir.version}</dist.output.dir>
+                        <dist.output.dir>${testsuite.default.build.project.root}dist/target/${server.output.dir.prefix}-${server.output.dir.qualifier}${server.output.dir.version}</dist.output.dir>
                         <build.output.dir>${wildfly.build.output.dir}</build.output.dir>
                     </systemPropertyVariables>
                 </configuration>

--- a/testsuite/integration/manualmode/pom.xml
+++ b/testsuite/integration/manualmode/pom.xml
@@ -597,7 +597,7 @@
                         <multichannel.ee.feature.pack.artifactId>${testsuite.ee.only.feature.pack.artifactId}</multichannel.ee.feature.pack.artifactId>
                         <oidc.jboss.home>${oidc.jboss.home}</oidc.jboss.home>
                         <!-- Tell ProvisioningConsistenceTestCase the location of the pre-built server -->
-                        <ee.dist.output.dir>${testsuite.default.build.project.root}/ee-dist/target/${server.output.dir.prefix}-${server.output.dir.qualifier}${server.output.dir.version}</ee.dist.output.dir>
+                        <ee.dist.output.dir>${testsuite.default.build.project.root}ee-dist/target/${server.output.dir.prefix}-${server.output.dir.qualifier}${server.output.dir.version}</ee.dist.output.dir>
                         <build.output.dir>${wildfly.build.output.dir}</build.output.dir>
                     </systemPropertyVariables>
                 </configuration>

--- a/testsuite/integration/microprofile-tck/pom.xml
+++ b/testsuite/integration/microprofile-tck/pom.xml
@@ -29,7 +29,7 @@
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
         <!-- For expansion tests we always use the 'build' module for pre-built installations, not 'ee-build'
              So exclude ${testsuite.default.build.project.prefix} from the path -->
-        <wildfly.build.output.dir>${testsuite.default.build.project.root}/build/target/${server.output.dir.prefix}-${server.output.dir.qualifier}${server.output.dir.version}</wildfly.build.output.dir>
+        <wildfly.build.output.dir>${testsuite.default.build.project.root}build/target/${server.output.dir.prefix}-${server.output.dir.qualifier}${server.output.dir.version}</wildfly.build.output.dir>
         <maven.repo.local>${settings.localRepository}</maven.repo.local>
         <microprofile.jvm.args>-server -Xms64m -Xmx512m ${modular.jdk.args} -Dmaven.repo.local=${maven.repo.local}</microprofile.jvm.args>
         <!-- Properties that set the phase used for different plugin executions.

--- a/testsuite/integration/vdx/pom.xml
+++ b/testsuite/integration/vdx/pom.xml
@@ -30,7 +30,7 @@
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
         <jbossas.server.locale>-Duser.language=en -Duser.country=US</jbossas.server.locale>
         <!-- This testsuite uses the fat server 'dist' instead of the thin server 'build' -->
-        <wildfly.build.output.dir>${testsuite.default.build.project.root}/${testsuite.default.build.project.prefix}dist/target/${server.output.dir.prefix}-${server.output.dir.qualifier}${server.output.dir.version}</wildfly.build.output.dir>
+        <wildfly.build.output.dir>${testsuite.default.build.project.root}${testsuite.default.build.project.prefix}dist/target/${server.output.dir.prefix}-${server.output.dir.qualifier}${server.output.dir.version}</wildfly.build.output.dir>
     </properties>
 
     <dependencies>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -98,7 +98,7 @@
         <testsuite.default.build.project.prefix></testsuite.default.build.project.prefix>
         <!-- 'Qualifier' segment to include in the name of the directory containing the pre-built server -->
         <server.output.dir.qualifier>${latest.ee.output.qualifier}</server.output.dir.qualifier>
-        <wildfly.build.output.dir>${testsuite.default.build.project.root}/${testsuite.default.build.project.prefix}build/target/${server.output.dir.prefix}-${server.output.dir.qualifier}${server.output.dir.version}</wildfly.build.output.dir>
+        <wildfly.build.output.dir>${testsuite.default.build.project.root}${testsuite.default.build.project.prefix}build/target/${server.output.dir.prefix}-${server.output.dir.qualifier}${server.output.dir.version}</wildfly.build.output.dir>
         <!-- Used to provide an absolute location for the distribution under test. -->
         <!-- This value is overridden in modules with the correct relative pathname. -->
         <jboss.dist>${project.basedir}/../${wildfly.build.output.dir}</jboss.dist>
@@ -739,7 +739,7 @@
                 <testsuite.ee.feature.pack.artifactId>${legacy.ee.feature.pack.artifactId}</testsuite.ee.feature.pack.artifactId>
                 <testsuite.ee.feature.pack.version>${ee.maven.version}</testsuite.ee.feature.pack.version>
                 <!-- For pre-built servers, use full builds pulled from the legacy/ee-feature-pack source tree -->
-                <testsuite.default.build.project.root>legacy/ee-feature-pack</testsuite.default.build.project.root>
+                <testsuite.default.build.project.root>legacy/ee-feature-pack/</testsuite.default.build.project.root>
                 <testsuite.default.build.project.prefix></testsuite.default.build.project.prefix>
                 <server.output.dir.qualifier>${legacy.ee.output.qualifier}</server.output.dir.qualifier>
                 <!-- For cases where we know for sure we don't want the 'wildfly' FP or channel, we can use these -->
@@ -795,7 +795,7 @@
                 <testsuite.ee.feature.pack.artifactId>${legacy.ee.feature.pack.artifactId}</testsuite.ee.feature.pack.artifactId>
                 <testsuite.ee.feature.pack.version>${ee.maven.version}</testsuite.ee.feature.pack.version>
                 <!-- For pre-built servers, use 'ee-' builds pulled from the legacy/ee-feature-pack source tree -->
-                <testsuite.default.build.project.root>legacy/ee-feature-pack</testsuite.default.build.project.root>
+                <testsuite.default.build.project.root>legacy/ee-feature-pack/</testsuite.default.build.project.root>
                 <testsuite.default.build.project.prefix>ee-</testsuite.default.build.project.prefix>
                 <server.output.dir.qualifier>${legacy.ee.output.qualifier}</server.output.dir.qualifier>
                 <!-- For cases where we know for sure we don't want the 'wildfly' FP or channel, we can use these -->
@@ -822,7 +822,7 @@
                 <!-- Tell tests what profile was used for provisioning -->
                 <server.provisioning.profile>preview-server-tests</server.provisioning.profile>
                 <!-- The pre-built legacy installations are not found under the top-level source root -->
-                <testsuite.default.build.project.root>preview</testsuite.default.build.project.root>
+                <testsuite.default.build.project.root>preview/</testsuite.default.build.project.root>
                 <!-- The pre-built server directory includes 'preview-' in its name -->
                 <server.output.dir.qualifier>${preview.output.qualifier}</server.output.dir.qualifier>
                 <!-- Use the WFP feature-pack -->


### PR DESCRIPTION
…tput.dir consistent across different server under tests

Jira issue: https://redhat.atlassian.net/browse/WFLY-21952

