### PR TITLE
WFLY-21928 Adding a fork stack protocol throws a duplicate resource ISE during runtime.

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractChannelResourceDefinitionRegistrar.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractChannelResourceDefinitionRegistrar.java
@@ -349,7 +349,9 @@ public abstract class AbstractChannelResourceDefinitionRegistrar<C extends Chann
                     String protocolName = protocolResource.getName();
                     Class<? extends Protocol> protocolClass = findProtocolClass(context, protocolName, protocolResource.getModel());
                     this.register(registration, protocolName, protocolClass);
-                    resource.registerChild(StackResourceDefinitionRegistrar.Component.PROTOCOL.pathElement(protocolName), PlaceholderResource.INSTANCE);
+                    if (resource != stackResource) {
+                        resource.registerChild(StackResourceDefinitionRegistrar.Component.PROTOCOL.pathElement(protocolName), PlaceholderResource.INSTANCE);
+                    }
                 }
             }
         }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21928

Unlike the channel resource, the fork resource already contains protocol child resources.