### PR TITLE
WFLY-21525 Drop 14.0-community from set of current schemas, since this is identical to 15.0.

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemModel.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemModel.java
@@ -17,8 +17,8 @@ public enum UndertowSubsystemModel implements SubsystemModel {
     VERSION_11_0_0(11), // WildFly 23-26.x, EAP 7.4.x
     VERSION_12_0_0(12), // WildFly 27
     VERSION_13_0_0(13), // WildFly 28
-    VERSION_14_0_0(14), // WildFly 32-present
-    VERSION_15_0_0(15), // WildFly 32-present
+    VERSION_14_0_0(14), // WildFly 32-39
+    VERSION_15_0_0(15), // WildFly 40-present
     ;
     static final UndertowSubsystemModel CURRENT = VERSION_15_0_0;
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemSchema.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemSchema.java
@@ -64,11 +64,11 @@ public enum UndertowSubsystemSchema implements PersistentSubsystemSchema<Underto
     VERSION_13_0(13),   // WildFly 27       N.B. There were no schema changes between 12.0 and 13.0!
     VERSION_14_0(14),   // WildFly 28-39
     VERSION_14_0_PREVIEW(14, 0, Stability.PREVIEW),   // WildFly 33-35
-    VERSION_14_0_COMMUNITY(14, 0, Stability.COMMUNITY),   // WildFly 36-present
+    VERSION_14_0_COMMUNITY(14, 0, Stability.COMMUNITY),   // WildFly 36-40
     VERSION_15_0(15)    // WildFly 40-present
     ;
 
-    static final Set<UndertowSubsystemSchema> CURRENT = EnumSet.of(VERSION_15_0, VERSION_14_0_COMMUNITY);
+    static final Set<UndertowSubsystemSchema> CURRENT = EnumSet.of(VERSION_15_0);
     private final VersionedNamespace<IntVersion, UndertowSubsystemSchema> namespace;
     private final PersistentResourceXMLDescription.Factory factory = PersistentResourceXMLDescription.factory(this);
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemSchema.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemSchema.java
@@ -62,7 +62,7 @@ public enum UndertowSubsystemSchema implements PersistentSubsystemSchema<Underto
     VERSION_11_0(11),   // WildFly 20-22    N.B. There were no parser changes between 10.0 and 11.0 !!
     VERSION_12_0(12),   // WildFly 23-26.1, EAP 7.4
     VERSION_13_0(13),   // WildFly 27       N.B. There were no schema changes between 12.0 and 13.0!
-    VERSION_14_0(14),   // WildFly 28-present
+    VERSION_14_0(14),   // WildFly 28-39
     VERSION_14_0_PREVIEW(14, 0, Stability.PREVIEW),   // WildFly 33-35
     VERSION_14_0_COMMUNITY(14, 0, Stability.COMMUNITY),   // WildFly 36-present
     VERSION_15_0(15)    // WildFly 40-present


### PR DESCRIPTION
Clean up following https://redhat.atlassian.net/browse/WFLY-21525 and https://redhat.atlassian.net/browse/WFLY-19808 which (together) made 14.0-community obsolete.
