### PR TITLE
WFLY-21959 - [CVE-2026-45292] Upgrade SmallRye OpenTelemetry to 2.15.0

### DIFF
--- a/boms/common-expansion/pom.xml
+++ b/boms/common-expansion/pom.xml
@@ -450,6 +450,17 @@
             </dependency>
             <dependency>
                 <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-common</artifactId>
+                <version>${version.io.opentelemetry.opentelemetry}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-context</artifactId>
                 <version>${version.io.opentelemetry.opentelemetry}</version>
                 <exclusions>
@@ -616,6 +627,17 @@
             <dependency>
                 <groupId>io.opentelemetry.instrumentation</groupId>
                 <artifactId>opentelemetry-runtime-telemetry-java8</artifactId>
+                <version>${version.io.opentelemetry.instrumentation}-alpha</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry.instrumentation</groupId>
+                <artifactId>opentelemetry-runtime-telemetry</artifactId>
                 <version>${version.io.opentelemetry.instrumentation}-alpha</version>
                 <exclusions>
                     <exclusion>
@@ -877,6 +899,17 @@
             <dependency>
                 <groupId>io.smallrye.opentelemetry</groupId>
                 <artifactId>smallrye-opentelemetry-rest</artifactId>
+                <version>${version.io.smallrye.smallrye-opentelemetry}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye.opentelemetry</groupId>
+                <artifactId>smallrye-opentelemetry-senders</artifactId>
                 <version>${version.io.smallrye.smallrye-opentelemetry}</version>
                 <exclusions>
                     <exclusion>

--- a/galleon-pack/galleon-shared/pom.xml
+++ b/galleon-pack/galleon-shared/pom.xml
@@ -78,11 +78,13 @@
         <dependency><groupId>io.opentelemetry.instrumentation</groupId><artifactId>opentelemetry-instrumentation-api-incubator</artifactId></dependency>
         <dependency><groupId>io.opentelemetry.instrumentation</groupId><artifactId>opentelemetry-instrumentation-api</artifactId></dependency>
         <dependency><groupId>io.opentelemetry.instrumentation</groupId><artifactId>opentelemetry-runtime-telemetry-java8</artifactId></dependency>
+        <dependency><groupId>io.opentelemetry.instrumentation</groupId><artifactId>opentelemetry-runtime-telemetry</artifactId></dependency>
         <dependency><groupId>io.opentelemetry.proto</groupId><artifactId>opentelemetry-proto</artifactId></dependency>
         <dependency><groupId>io.opentelemetry.semconv</groupId><artifactId>opentelemetry-semconv</artifactId></dependency>
         <dependency><groupId>io.opentelemetry.semconv</groupId><artifactId>opentelemetry-semconv-incubating</artifactId></dependency>
         <dependency><groupId>io.opentelemetry</groupId><artifactId>opentelemetry-api-incubator</artifactId></dependency>
         <dependency><groupId>io.opentelemetry</groupId><artifactId>opentelemetry-api</artifactId></dependency>
+        <dependency><groupId>io.opentelemetry</groupId><artifactId>opentelemetry-common</artifactId></dependency>
         <dependency><groupId>io.opentelemetry</groupId><artifactId>opentelemetry-context</artifactId></dependency>
         <dependency><groupId>io.opentelemetry</groupId><artifactId>opentelemetry-exporter-common</artifactId></dependency>
         <dependency><groupId>io.opentelemetry</groupId><artifactId>opentelemetry-exporter-logging</artifactId></dependency>
@@ -295,6 +297,7 @@
         <dependency><groupId>io.smallrye.opentelemetry</groupId><artifactId>smallrye-opentelemetry-exporters</artifactId></dependency>
         <dependency><groupId>io.smallrye.opentelemetry</groupId><artifactId>smallrye-opentelemetry-propagation</artifactId></dependency>
         <dependency><groupId>io.smallrye.opentelemetry</groupId><artifactId>smallrye-opentelemetry-rest</artifactId></dependency>
+        <dependency><groupId>io.smallrye.opentelemetry</groupId><artifactId>smallrye-opentelemetry-senders</artifactId></dependency>
 
         <dependency>
             <groupId>io.smallrye.reactive</groupId>

--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/opentelemetry/api/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/opentelemetry/api/main/module.xml
@@ -10,6 +10,7 @@
     <resources>
         <artifact name="${io.opentelemetry:opentelemetry-api}"/>
         <artifact name="${io.opentelemetry:opentelemetry-api-incubator}"/>
+        <artifact name="${io.opentelemetry:opentelemetry-common}"/>
     </resources>
 
     <dependencies>

--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/opentelemetry/instrumentation/api/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/opentelemetry/instrumentation/api/main/module.xml
@@ -11,6 +11,7 @@
         <artifact name="${io.opentelemetry.instrumentation:opentelemetry-instrumentation-api}"/>
         <artifact name="${io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator}"/>
         <artifact name="${io.opentelemetry.instrumentation:opentelemetry-runtime-telemetry-java8}"/>
+        <artifact name="${io.opentelemetry.instrumentation:opentelemetry-runtime-telemetry}"/>
     </resources>
 
     <dependencies>

--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/smallrye/opentelemetry/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/smallrye/opentelemetry/main/module.xml
@@ -12,6 +12,7 @@
         <artifact name="${io.smallrye.opentelemetry:smallrye-opentelemetry-exporters}"/>
         <artifact name="${io.smallrye.opentelemetry:smallrye-opentelemetry-propagation}"/>
         <artifact name="${io.smallrye.opentelemetry:smallrye-opentelemetry-rest}"/>
+        <artifact name="${io.smallrye.opentelemetry:smallrye-opentelemetry-senders}"/>
     </resources>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -415,7 +415,7 @@
         <version.com.google.code.gson>2.14.0</version.com.google.code.gson>
         <version.com.google.guava>33.0.0-jre</version.com.google.guava>
         <version.com.google.guava.failureaccess>1.0.3</version.com.google.guava.failureaccess>
-        <version.com.google.protobuf>4.28.3</version.com.google.protobuf>
+        <version.com.google.protobuf>4.34.0</version.com.google.protobuf>
         <version.com.ibm.async.asyncutil>0.1.0</version.com.ibm.async.asyncutil>
         <version.com.microsoft.azure>8.6.6</version.com.microsoft.azure>
         <version.com.nimbus.jose-jwt>10.3.1</version.com.nimbus.jose-jwt>
@@ -433,25 +433,25 @@
         <version.io.grpc>1.70.0</version.io.grpc>
         <version.io.micrometer>1.16.6</version.io.micrometer>
         <version.io.netty>4.1.135.Final</version.io.netty>
-        <version.io.opentelemetry.instrumentation>2.14.0</version.io.opentelemetry.instrumentation>
+        <version.io.opentelemetry.instrumentation>2.27.0</version.io.opentelemetry.instrumentation>
         <version.io.opentelemetry.opentelemetry-semconv>1.32.0</version.io.opentelemetry.opentelemetry-semconv>
-        <version.io.opentelemetry.opentelemetry>1.48.0</version.io.opentelemetry.opentelemetry>
-        <version.io.opentelemetry.proto>1.5.0-alpha</version.io.opentelemetry.proto>
+        <version.io.opentelemetry.opentelemetry>1.62.0</version.io.opentelemetry.opentelemetry>
+        <version.io.opentelemetry.proto>1.10.0-alpha</version.io.opentelemetry.proto>
         <version.io.prometheus>1.3.3</version.io.prometheus>
         <version.io.reactivex.rxjava2>2.2.21</version.io.reactivex.rxjava2>
         <version.io.reactivex.rxjava3>3.1.12</version.io.reactivex.rxjava3>
         <version.io.smallrye.open-api>4.3.3</version.io.smallrye.open-api>
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
         <version.io.smallrye.smallrye-config>3.17.2</version.io.smallrye.smallrye-config>
-        <version.io.smallrye.smallrye-fault-tolerance>6.11.1</version.io.smallrye.smallrye-fault-tolerance>
+        <version.io.smallrye.smallrye-fault-tolerance>6.11.2</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>4.3.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>4.3.1</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-mutiny>3.1.1</version.io.smallrye.smallrye-mutiny>
         <version.io.smallrye.smallrye-mutiny-vertx>3.19.2</version.io.smallrye.smallrye-mutiny-vertx>
         <version.io.smallrye.smallrye-mutiny-zero>1.1.1</version.io.smallrye.smallrye-mutiny-zero>
-        <version.io.smallrye.smallrye-opentelemetry>2.11.2</version.io.smallrye.smallrye-opentelemetry>
-        <version.io.smallrye.smallrye-stork>2.7.10</version.io.smallrye.smallrye-stork>
+        <version.io.smallrye.smallrye-opentelemetry>2.15.1</version.io.smallrye.smallrye-opentelemetry>
         <version.io.smallrye.smallrye-reactive-messaging>4.35.0</version.io.smallrye.smallrye-reactive-messaging>
+        <version.io.smallrye.smallrye-stork>2.7.10</version.io.smallrye.smallrye-stork>
         <!-- TODO (jrp) temporary override until the new version of Undertow is integrated into core and that version of core is integrated here -->
         <version.io.undertow>2.4.1.Final</version.io.undertow>
         <version.io.vertx.vertx>4.5.28</version.io.vertx.vertx>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21959
https://redhat.atlassian.net/browse/WFLY-22004

Update SmallRye OpenTelemetry version
Update transitive dependency versions
Modify JBoss Modules to add new required upstream artifacts