### PR TITLE
[WFLY-21961] Building server test suite fails with no.expansion.build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1650,7 +1650,10 @@
             <id>expansion-build</id>
             <activation>
                 <property>
-                    <!-- Allow users to disable building expansion stuff if they just want base artifacts -->
+                    <!--
+                    Allow users to disable building expansion stuff if they just want base artifacts.
+                    This option requires -Dno.preview.build
+                    -->
                     <name>!no.expansion.build</name>
                 </property>
             </activation>
@@ -1663,6 +1666,7 @@
                 <module>build</module>
                 <module>dist</module>
                 <module>galleon-pack</module>
+                <module>legacy/channel</module>
                 <module>legacy/opentracing-extension</module>
                 <module>microprofile</module>
                 <module>observability</module>
@@ -1703,7 +1707,6 @@
                 <module>boms/legacy-test</module>
                 <module>concurrency/impl-30</module>
                 <module>legacy/ee-feature-pack</module>
-                <module>legacy/channel</module>
             </modules>
         </profile>
 


### PR DESCRIPTION
Jira issue: https://redhat.atlassian.net/browse/WFLY-21961

This adds the requirement of also disable preview builds when no.expansion.build gets build.

I guess we can find a way to disable it automatically, but I just wanted to go using the simple approach