### PR TITLE
[WFLY-21969] Add test to ensure Hibernate build time enhancement works

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -31,6 +31,10 @@
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
         <surefire.forked.process.timeout>3600</surefire.forked.process.timeout>
+        <version.org.hibernate>${standard.version.org.hibernate}</version.org.hibernate>
+        <version.org.hibernate.maven.plugin>${standard.version.org.hibernate}</version.org.hibernate.maven.plugin>
+        <version.org.hibernate.maven.plugin.groupId>org.hibernate.orm</version.org.hibernate.maven.plugin.groupId>
+        <version.org.hibernate.maven.plugin.artifactId>hibernate-maven-plugin</version.org.hibernate.maven.plugin.artifactId>
         <!-- properties to enable bootable phases -->
         <bootable-jar-maven-jar-plugin.create.modules.phase>none</bootable-jar-maven-jar-plugin.create.modules.phase>
         <bootable-jar-copy-module-files.phase>none</bootable-jar-copy-module-files.phase>
@@ -858,6 +862,44 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>${version.org.hibernate.maven.plugin.groupId}</groupId>
+                <artifactId>${version.org.hibernate.maven.plugin.artifactId}</artifactId>
+                <version>${version.org.hibernate.maven.plugin}</version>
+                <configuration>
+                    <classesDirectory>${project.build.testOutputDirectory}</classesDirectory>
+                    <dir>${project.build.testOutputDirectory}</dir>
+                    <base>${project.build.testOutputDirectory}</base>
+                    <classNames>org.jboss.as.test.integration.jpa.hibernate.buildtimeenhancementtest.entityClasses.Employee</classNames>
+                    <fileSets>
+                        <fileset>
+                            <directory>${project.build.testOutputDirectory}</directory>
+                            <includes>
+                                <include>
+                                    org/jboss/as/test/integration/jpa/hibernate/buildtimeenhancementtest/entityClasses/Employee.class
+                                </include>
+                            </includes>
+                        </fileset>
+                    </fileSets>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>enhance</id>
+                        <goals>
+                            <goal>enhance</goal>
+                        </goals>
+                        <phase>process-test-classes</phase>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.hibernate</groupId>
+                        <artifactId>hibernate-core</artifactId>
+                        <version>${version.org.hibernate}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
@@ -3779,6 +3821,36 @@
                     <scope>test</scope>
                 </dependency>
             </dependencies>
+        </profile>
+
+        <profile>
+            <id>legacy-ee-full-server-tests</id>
+            <activation>
+                <property><name>legacy-ee-full-server-tests</name></property>
+            </activation>
+            <properties>
+                <version.org.hibernate>${legacy.version.org.hibernate}</version.org.hibernate>
+                <!-- Use the version of the hibernate.maven.plugin
+                     that aligns with the ORM version in the legacy EE FP. -->
+                <version.org.hibernate.maven.plugin>${legacy.version.org.hibernate}</version.org.hibernate.maven.plugin>
+                <version.org.hibernate.maven.plugin.groupId>org.hibernate.orm.tooling</version.org.hibernate.maven.plugin.groupId>
+                <version.org.hibernate.maven.plugin.artifactId>hibernate-enhance-maven-plugin</version.org.hibernate.maven.plugin.artifactId>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>legacy-ee-only-server-tests</id>
+            <activation>
+                <property><name>legacy-ee-only-server-tests</name></property>
+            </activation>
+            <properties>
+                <version.org.hibernate>${legacy.version.org.hibernate}</version.org.hibernate>
+                <!-- Use the version of the hibernate.maven.plugin
+                     that aligns with the ORM version in the legacy EE FP. -->
+                <version.org.hibernate.maven.plugin>${legacy.version.org.hibernate}</version.org.hibernate.maven.plugin>
+                <version.org.hibernate.maven.plugin.groupId>org.hibernate.orm.tooling</version.org.hibernate.maven.plugin.groupId>
+                <version.org.hibernate.maven.plugin.artifactId>hibernate-enhance-maven-plugin</version.org.hibernate.maven.plugin.artifactId>
+            </properties>
         </profile>
 
     </profiles>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/buildtimeenhancementtest/BuildTimeEnhancementRunAsClientTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/buildtimeenhancementtest/BuildTimeEnhancementRunAsClientTestCase.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jpa.hibernate.buildtimeenhancementtest;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.jpa.hibernate.buildtimeenhancementtest.entityClasses.Employee;
+import org.jboss.as.test.shared.logging.LoggingUtil;
+import org.jboss.as.test.shared.TestLogHandlerSetupTask;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jboss.as.arquillian.api.ServerSetup;
+
+/**
+ * Verify that the Hibernate ORM build time bytecode enhancement Maven plugin works as expected.
+ * - Verify that Hibernate ORM build time enhancement was run against the Employee class.
+ * - Verify that the Hibernate ORM TRACE logger message for "HHH90009001" is logged to server.log indicating that
+ * runtime bytecode enhancement was ignored since build time enhancement was already performed.
+ * <p>
+ * For more details on build time enhancement see:
+ * - https://docs.hibernate.org/orm/6.6/userguide/html_single/#tooling-maven
+ * - https://docs.hibernate.org/orm/7.4/userguide/html_single/#tooling-maven
+ * @author Scott Marlow
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({BuildTimeEnhancementRunAsClientTestCase.TestLogHandlerSetup.class})
+public class BuildTimeEnhancementRunAsClientTestCase {
+
+    private static final String ARCHIVE_NAME = "jpa_BuildTimeEnhancementRunAsClientTestCase";
+    private static final String TEST_HANDLER_NAME = "test-" + BuildTimeEnhancementRunAsClientTestCase.class.getSimpleName();
+    private static final String TEST_LOG_FILE_NAME = TEST_HANDLER_NAME + ".log";
+
+    public static class TestLogHandlerSetup extends TestLogHandlerSetupTask {
+
+        @Override
+        public Collection<String> getCategories() {
+            return Collections.singletonList("org.hibernate");
+        }
+        @Override
+        public String getLevel() {
+            return "TRACE";
+        }
+        @Override
+        public String getHandlerName() {
+            return TEST_HANDLER_NAME;
+        }
+        @Override
+        public String getLogFileName() {
+            return TEST_LOG_FILE_NAME;
+        }
+
+    }
+
+    @Deployment
+    public static Archive<?> deploy() {
+
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, ARCHIVE_NAME + ".jar");
+        jar.addClasses(BuildTimeEnhancementRunAsClientTestCase.class,
+                Employee.class,
+                SFSB1.class
+        );
+        jar.addAsManifestResource(BuildTimeEnhancementRunAsClientTestCase.class.getPackage(), "persistence.xml", "persistence.xml");
+        return jar;
+    }
+
+    @Test
+    public void testHibernateBuildTimeEnhancement() {
+        // Note: ManagedTypeHelper is an internal Hibernate ORM class, if it is removed or renamed then this test can be updated
+        // accordingly.
+        assertTrue("Employee class is expected to be be build time bytecode enhanced but wasn't (" +
+                        org.hibernate.engine.internal.ManagedTypeHelper.isManagedType(Employee.class) + ")",
+                org.hibernate.engine.internal.ManagedTypeHelper.isManagedType(Employee.class));
+    }
+
+    @ContainerResource
+    private ManagementClient managementClient;
+
+    /**
+     * Ensure that Hibernate trace logging is enabled and validate that below "TRACE message HHH90009001" is logged by Hibernate for the
+     * org.jboss.as.test.integration.jpa.hibernate.buildtimeenhancementtest.entityClasses.Employee class.  The logged message will be something like:
+     * HHH90009001: Skipping enhancement of [org.jboss.as.test.integration.jpa.hibernate.buildtimeenhancementtest.entityClasses.Employee]: it's already annotated with @EnhancementInfo"
+     */
+    @Test
+    public void testHibernateRuntimeEnhancementLogsTraceMessageHHH90009001() throws Exception {
+        String expected = "Skipping enhancement of [org.jboss.as.test.integration.jpa.hibernate.buildtimeenhancementtest.entityClasses.Employee]: it's already annotated with @EnhancementInfo";
+        assertTrue("Hibernate ORM Log message not found: " + expected,
+                LoggingUtil.hasLogMessage(managementClient.getControllerClient(), TEST_HANDLER_NAME, expected));
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/buildtimeenhancementtest/BuildTimeEnhancementTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/buildtimeenhancementtest/BuildTimeEnhancementTestCase.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jpa.hibernate.buildtimeenhancementtest;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.jpa.hibernate.buildtimeenhancementtest.entityClasses.Employee;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Verify that the Hibernate ORM build time bytecode enhancement Maven plugin works as expected.
+ * - Verify that Hibernate ORM build time enhancement was run against the Employee class.
+ * <p>
+ * For more details on build time enhancement see:
+ * - https://docs.hibernate.org/orm/6.6/userguide/html_single/#tooling-maven
+ * - https://docs.hibernate.org/orm/7.4/userguide/html_single/#tooling-maven
+ * @author Scott Marlow
+ */
+
+@RunWith(Arquillian.class)
+public class BuildTimeEnhancementTestCase {
+
+    private static final String ARCHIVE_NAME = "jpa_BuildTimeEnhancementTestCase";
+    @ArquillianResource
+    private InitialContext iniCtx;
+
+    @Deployment
+    public static Archive<?> deploy() {
+
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, ARCHIVE_NAME + ".jar");
+        jar.addClasses(BuildTimeEnhancementTestCase.class,
+                Employee.class,
+                SFSB1.class
+        );
+        jar.addAsManifestResource(BuildTimeEnhancementTestCase.class.getPackage(), "persistencenoclasstransformer.xml", "persistence.xml");
+        return jar;
+    }
+
+
+    protected <T> T lookup(String beanName, Class<T> interfaceType) throws NamingException {
+        return interfaceType.cast(iniCtx.lookup("java:global/" + ARCHIVE_NAME + "/" + beanName + "!" + interfaceType.getName()));
+    }
+
+    @Test
+    public void testHibernateBuildTimeEnhancement() {
+        // Note: ManagedTypeHelper is an internal Hibernate ORM class, if it is removed or renamed then this test can be updated
+        // accordingly.
+        assertTrue("Employee class is expected to be be build time bytecode enhanced but wasn't (" +
+                        org.hibernate.engine.internal.ManagedTypeHelper.isManagedType(Employee.class) + ")",
+                org.hibernate.engine.internal.ManagedTypeHelper.isManagedType(Employee.class));
+    }
+
+    @Test
+    public void testhibernateCanCreateEmployeeAndReadEmployee() throws Exception {
+        SFSB1 sfsb1 = lookup("SFSB1", SFSB1.class);
+        sfsb1.createEmployee("Kelly Smith", "Watford, England", 10);
+        sfsb1.createEmployee("Alex Scott", "London, England", 20);
+        Employee emp = sfsb1.getEmployeeNoTX(10);
+
+        assertNotNull("was able to read database row", emp);
+    }
+
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/buildtimeenhancementtest/SFSB1.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/buildtimeenhancementtest/SFSB1.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jpa.hibernate.buildtimeenhancementtest;
+
+import jakarta.ejb.Stateful;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.PersistenceContext;
+import org.jboss.as.test.integration.jpa.hibernate.buildtimeenhancementtest.entityClasses.Employee;
+
+/**
+ * stateful session bean
+ *
+ * @author Scott Marlow
+ */
+@Stateful
+public class SFSB1 {
+    @PersistenceContext(unitName = "mypc")
+    EntityManager em;
+
+    public void createEmployee(String name, String address, int id) {
+        Employee emp = new Employee();
+        emp.setId(id);
+        emp.setAddress(address);
+        emp.setName(name);
+        em.persist(emp);
+    }
+
+    public Employee getEmployeeNoTX(int id) {
+        return em.find(Employee.class, id, LockModeType.NONE);
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/buildtimeenhancementtest/entityClasses/Employee.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/buildtimeenhancementtest/entityClasses/Employee.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jpa.hibernate.buildtimeenhancementtest.entityClasses;
+
+import jakarta.persistence.Cacheable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * Employee entity class
+ *
+ * @author Scott Marlow
+ */
+@Entity
+@Cacheable(true)
+public class Employee {
+
+    @Id
+    private int id;
+
+    private String name;
+
+    private String address;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public int getId() {
+
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/buildtimeenhancementtest/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/buildtimeenhancementtest/persistence.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"
+             version="3.0">
+    <persistence-unit name="mypc">
+        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+        <properties>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+            <property name="jboss.as.jpa.classtransformer" value="true"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/buildtimeenhancementtest/persistencenoclasstransformer.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/buildtimeenhancementtest/persistencenoclasstransformer.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"
+             version="3.0">
+    <persistence-unit name="mypc">
+        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+        <properties>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+            <property name="jboss.as.jpa.classtransformer" value="false"/>
+        </properties>
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21969 

Add unit test that validates that the Hibernate build time enhancement works with the Hibernate Maven enhancement plugin.  

See ORM 6.6 documentation at https://docs.hibernate.org/orm/6.6/userguide/html_single/#tooling-maven and ORM 7.4 documentation at https://docs.hibernate.org/orm/7.4/userguide/html_single/#tooling-maven