### PR TITLE
(40.x) [TEST] - Bumping Apache CXF alone to 4.1.6 (WildFly 40.x only)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -499,7 +499,7 @@
         <version.org.apache.activemq.artemis>2.53.0</version.org.apache.activemq.artemis>
         <version.org.apache.activemq.artemis.native>2.0.0</version.org.apache.activemq.artemis.native>
         <version.org.apache.avro>1.12.1</version.org.apache.avro>
-        <version.org.apache.cxf>4.0.11</version.org.apache.cxf>
+        <version.org.apache.cxf>4.1.6</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>4.1.3</version.org.apache.cxf.xjcplugins>
         <version.org.apache.httpcomponents.httpasyncclient>4.1.5</version.org.apache.httpcomponents.httpasyncclient>
         <version.org.apache.james.apache-mime4j>0.8.14</version.org.apache.james.apache-mime4j>


### PR DESCRIPTION
Test PR to validate the version bump of Apache CXF alone, from 4.0.11 to 4.1.6.
