### PR TITLE
WFLY-21975 Set FD_SOCK2 port_range to 0 for deterministic port binding

### DIFF
--- a/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
+++ b/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
@@ -54,7 +54,7 @@
         timeout_check_interval="5s"
     />
     <FD_SOCK port_range="0"/>
-    <FD_SOCK2 offset="1"/>
+    <FD_SOCK2 offset="1" port_range="0"/>
     <VERIFY_SUSPECT timeout="1s"/>
     <VERIFY_SUSPECT2 timeout="1s"/>
     <pbcast.NAKACK2


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21975

Discovered while investigating clustering intermittent CI failures and fixing https://redhat.atlassian.net/browse/WFLY-21973