### PR TITLE
WFLY-21973 Clustering testsuite: Arquillian container configuration does not wait for all ports it uses before re/starting nodes

### DIFF
--- a/testsuite/integration/basic/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/basic/src/test/resources/arquillian-bootable.xml
@@ -24,7 +24,6 @@
 
             <!-- AS7-4070 -->
             <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>
 

--- a/testsuite/integration/basic/src/test/resources/arquillian.xml
+++ b/testsuite/integration/basic/src/test/resources/arquillian.xml
@@ -23,7 +23,6 @@
 
             <!-- AS7-4070 -->
             <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
             <property name="javaHome">${container.java.home}</property>
         </configuration>
     </container>

--- a/testsuite/integration/clustering/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/clustering/src/test/resources/arquillian-bootable.xml
@@ -49,8 +49,7 @@
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node0:127.0.0.1}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
-                <!-- AS7-4070 Arquillian should wait until a port is free after AS JVM process ends to prevent "port in use" -->
-                <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
+                <property name="waitForPorts">7600 7601 8009 8080 8787 ${as.managementPort:9990}</property>
             </configuration>
         </container>
         <container qualifier="node-2" mode="custom">
@@ -62,7 +61,7 @@
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10090</property>
-                <property name="waitForPorts">8788 10090</property>
+                <property name="waitForPorts">7700 7701 8109 8180 8788 10090</property>
             </configuration>
         </container>
         <container qualifier="node-3" mode="custom">
@@ -74,7 +73,7 @@
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node2}</property>
                 <property name="managementPort">10190</property>
-                <property name="waitForPorts">8789 10190</property>
+                <property name="waitForPorts">7800 7801 8209 8280 8789 10190</property>
             </configuration>
         </container>
         <container qualifier="node-4" mode="custom">
@@ -87,7 +86,7 @@
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node3}</property>
                 <property name="managementPort">10290</property>
-                <property name="waitForPorts">8790 10290</property>
+                <property name="waitForPorts">7900 7901 8309 8380 8790 10290</property>
             </configuration>
         </container>
 

--- a/testsuite/integration/clustering/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/clustering/src/test/resources/arquillian-bootable.xml
@@ -22,7 +22,6 @@
             <property name="managementAddress">${node0:127.0.0.1}</property>
             <property name="managementPort">${as.managementPort:9990}</property>
             <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>
 
@@ -36,7 +35,6 @@
             <property name="managementAddress">${node0:127.0.0.1}</property>
             <property name="managementPort">${as.managementPort:9990}</property>
             <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>
 
@@ -53,7 +51,6 @@
                 <property name="managementPort">${as.managementPort:9990}</property>
                 <!-- AS7-4070 Arquillian should wait until a port is free after AS JVM process ends to prevent "port in use" -->
                 <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
         <container qualifier="node-2" mode="custom">
@@ -66,7 +63,6 @@
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">8788 10090</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
         <container qualifier="node-3" mode="custom">
@@ -79,7 +75,6 @@
                 <property name="managementAddress">${node2}</property>
                 <property name="managementPort">10190</property>
                 <property name="waitForPorts">8789 10190</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
         <container qualifier="node-4" mode="custom">
@@ -93,7 +88,6 @@
                 <property name="managementAddress">${node3}</property>
                 <property name="managementPort">10290</property>
                 <property name="waitForPorts">8790 10290</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
 
@@ -106,7 +100,6 @@
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">10490</property>
                 <property name="waitForPorts">10490</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
     </group>

--- a/testsuite/integration/clustering/src/test/resources/arquillian-byteman.xml
+++ b/testsuite/integration/clustering/src/test/resources/arquillian-byteman.xml
@@ -21,7 +21,6 @@
             <property name="managementAddress">${node0}</property>
             <property name="managementPort">${as.managementPort:9990}</property>
             <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>
 
@@ -37,7 +36,6 @@
                 <property name="managementPort">${as.managementPort:9990}</property>
                 <!-- AS7-4070 Arquillian should wait until a port is free after AS JVM process ends to prevent "port in use" -->
                 <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
         <container qualifier="node-2" mode="custom">
@@ -49,7 +47,6 @@
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">8788 10090</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
         <container qualifier="node-3" mode="custom">
@@ -61,7 +58,6 @@
                 <property name="managementAddress">${node2}</property>
                 <property name="managementPort">10190</property>
                 <property name="waitForPorts">8789 10190</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
         <container qualifier="node-4" mode="custom">
@@ -73,7 +69,6 @@
                 <property name="managementAddress">${node3}</property>
                 <property name="managementPort">10290</property>
                 <property name="waitForPorts">8790 10290</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
 
@@ -86,7 +81,6 @@
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
                 <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
     </group>

--- a/testsuite/integration/clustering/src/test/resources/arquillian-byteman.xml
+++ b/testsuite/integration/clustering/src/test/resources/arquillian-byteman.xml
@@ -34,8 +34,7 @@
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
-                <!-- AS7-4070 Arquillian should wait until a port is free after AS JVM process ends to prevent "port in use" -->
-                <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
+                <property name="waitForPorts">7600 7601 8009 8080 8787 ${as.managementPort:9990}</property>
             </configuration>
         </container>
         <container qualifier="node-2" mode="custom">
@@ -46,7 +45,7 @@
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10090</property>
-                <property name="waitForPorts">8788 10090</property>
+                <property name="waitForPorts">7700 7701 8109 8180 8788 10090</property>
             </configuration>
         </container>
         <container qualifier="node-3" mode="custom">
@@ -57,7 +56,7 @@
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node2}</property>
                 <property name="managementPort">10190</property>
-                <property name="waitForPorts">8789 10190</property>
+                <property name="waitForPorts">7800 7801 8209 8280 8789 10190</property>
             </configuration>
         </container>
         <container qualifier="node-4" mode="custom">
@@ -68,7 +67,7 @@
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node3}</property>
                 <property name="managementPort">10290</property>
-                <property name="waitForPorts">8790 10290</property>
+                <property name="waitForPorts">7900 7901 8309 8380 8790 10290</property>
             </configuration>
         </container>
 

--- a/testsuite/integration/clustering/src/test/resources/arquillian-testable.xml
+++ b/testsuite/integration/clustering/src/test/resources/arquillian-testable.xml
@@ -20,7 +20,6 @@
             <property name="managementPort">${as.managementPort:9990}</property>
             <property name="serverConfig">${jboss.server.config.file.name}</property>
             <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>
 

--- a/testsuite/integration/clustering/src/test/resources/arquillian.xml
+++ b/testsuite/integration/clustering/src/test/resources/arquillian.xml
@@ -21,7 +21,6 @@
             <property name="managementAddress">${node0}</property>
             <property name="managementPort">${as.managementPort:9990}</property>
             <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
             <property name="javaHome">${container.java.home}</property>
         </configuration>
     </container>
@@ -35,7 +34,6 @@
             <property name="managementAddress">${node0}</property>
             <property name="managementPort">${as.managementPort:9990}</property>
             <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
             <property name="javaHome">${container.java.home}</property>
         </configuration>
     </container>
@@ -52,7 +50,6 @@
                 <property name="managementPort">${as.managementPort:9990}</property>
                 <!-- AS7-4070 Arquillian should wait until a port is free after AS JVM process ends to prevent "port in use" -->
                 <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -65,7 +62,6 @@
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">8788 10090</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -78,7 +74,6 @@
                 <property name="managementAddress">${node2}</property>
                 <property name="managementPort">10190</property>
                 <property name="waitForPorts">8789 10190</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -91,7 +86,6 @@
                 <property name="managementAddress">${node3}</property>
                 <property name="managementPort">10290</property>
                 <property name="waitForPorts">8790 10290</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -104,7 +98,6 @@
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">10490</property>
                 <property name="waitForPorts">10490</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>

--- a/testsuite/integration/clustering/src/test/resources/arquillian.xml
+++ b/testsuite/integration/clustering/src/test/resources/arquillian.xml
@@ -49,7 +49,8 @@
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
                 <!-- AS7-4070 Arquillian should wait until a port is free after AS JVM process ends to prevent "port in use" -->
-                <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
+                <!-- WFLY-21973 jgroups-tcp, jgroups-tcp-fd, ajp, http, debug, management (+ port-offset per node) -->
+                <property name="waitForPorts">7600 7601 8009 8080 8787 ${as.managementPort:9990}</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -61,7 +62,7 @@
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10090</property>
-                <property name="waitForPorts">8788 10090</property>
+                <property name="waitForPorts">7700 7701 8109 8180 8788 10090</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -73,7 +74,7 @@
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node2}</property>
                 <property name="managementPort">10190</property>
-                <property name="waitForPorts">8789 10190</property>
+                <property name="waitForPorts">7800 7801 8209 8280 8789 10190</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -85,7 +86,7 @@
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node3}</property>
                 <property name="managementPort">10290</property>
-                <property name="waitForPorts">8790 10290</property>
+                <property name="waitForPorts">7900 7901 8309 8380 8790 10290</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>

--- a/testsuite/integration/expansion/src/test/resources/arquillian.xml
+++ b/testsuite/integration/expansion/src/test/resources/arquillian.xml
@@ -23,7 +23,6 @@
             <property name="managementAddress">${node0:127.0.0.1}</property>
             <property name="managementPort">${as.managementPort:9990}</property>
             <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
             <property name="javaHome">${container.java.home}</property>
         </configuration>
     </container>

--- a/testsuite/integration/hornetq-client/src/test/resources/arquillian.xml
+++ b/testsuite/integration/hornetq-client/src/test/resources/arquillian.xml
@@ -23,7 +23,6 @@
 
             <!-- AS7-4070 -->
             <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
             <property name="javaHome">${container.java.home}</property>
         </configuration>
     </container>

--- a/testsuite/integration/iiop/src/test/resources/arquillian.xml
+++ b/testsuite/integration/iiop/src/test/resources/arquillian.xml
@@ -23,7 +23,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -40,7 +39,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port.node1:10090}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -59,7 +57,6 @@
                 <property name="managementPort">${as.managementPort:9990}</property>
 
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -74,7 +71,6 @@
                 <property name="managementPort">10090</property>
 
                 <property name="waitForPorts">${as.debug.port.node1:10090}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>

--- a/testsuite/integration/manualmode-expansion/src/test/resources/arquillian.xml
+++ b/testsuite/integration/manualmode-expansion/src/test/resources/arquillian.xml
@@ -24,7 +24,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="modulePath">${basedir}/target/wildfly/modules</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
@@ -42,7 +41,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="modulePath">${basedir}/target/wildfly/modules</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
@@ -62,7 +60,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="modulePath">${basedir}/target/wildfly/modules</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>

--- a/testsuite/integration/manualmode/src/test/resources/arquillian.xml
+++ b/testsuite/integration/manualmode/src/test/resources/arquillian.xml
@@ -22,7 +22,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="modulePath">${basedir}/target/wildfly/modules</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
@@ -40,7 +39,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="modulePath">${basedir}/target/wildfly/modules</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
@@ -58,7 +56,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="modulePath">${basedir}/target/wildfly/modules</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
@@ -76,7 +73,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -93,7 +89,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port.node1} 10090</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -110,7 +105,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -127,7 +121,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port.node1} 10090</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -144,7 +137,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -160,7 +152,6 @@
                 <property name="managementPort">11990</property>
 
                 <property name="waitForPorts">11990</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -177,7 +168,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port.node1} 10090</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -194,7 +184,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port.node1} 10240</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -211,7 +200,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port.node1} 10090</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -229,7 +217,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port.node1} 10090</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -246,7 +233,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -263,7 +249,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8987} ${as.managementPort:10090}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -281,7 +266,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -299,7 +283,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -316,7 +299,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port.node1:8887} ${as.managementPort.node1:10090}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -333,7 +315,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="modulePath">${basedir}/target/wildfly/modules</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
@@ -351,7 +332,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="modulePath">${basedir}/target/wildfly/modules</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
@@ -370,7 +350,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="modulePath">${basedir}/target/wildfly/modules</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
@@ -389,7 +368,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="modulePath">${basedir}/target/wildfly/modules</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
@@ -408,7 +386,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="modulePath">${basedir}/target/wildfly/modules</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
@@ -427,7 +404,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="modulePath">${basedir}/target/wildfly/modules</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
@@ -446,7 +422,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="modulePath">${basedir}/target/wildfly/modules</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
@@ -465,7 +440,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="modulePath">${basedir}/target/wildfly/modules</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
@@ -484,7 +458,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="modulePath">${basedir}/target/wildfly/modules</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
@@ -503,7 +476,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="modulePath">${basedir}/target/wildfly/modules</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
@@ -524,7 +496,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="modulePath">${basedir}/target/wildfly-multi-channel/modules</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
@@ -543,7 +514,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="modulePath">${basedir}/target/wildfly/modules</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>

--- a/testsuite/integration/microprofile-tck/config/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/microprofile-tck/config/src/test/resources/arquillian-bootable.xml
@@ -19,7 +19,6 @@
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>
             <property name="waitForPorts">9990</property>
-            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 

--- a/testsuite/integration/microprofile-tck/config/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/config/src/test/resources/arquillian.xml
@@ -18,7 +18,6 @@
             <property name="managementPort">9990</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone-microprofile.xml}</property>
             <property name="waitForPorts">9990</property>
-            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 </arquillian>

--- a/testsuite/integration/microprofile-tck/fault-tolerance/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/microprofile-tck/fault-tolerance/src/test/resources/arquillian-bootable.xml
@@ -18,7 +18,6 @@
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>
             <property name="waitForPorts">9990</property>
-            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 </arquillian>

--- a/testsuite/integration/microprofile-tck/fault-tolerance/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/fault-tolerance/src/test/resources/arquillian.xml
@@ -18,7 +18,6 @@
             <property name="managementPort">9990</property>
             <property name="serverConfig">standalone-microprofile.xml</property>
             <property name="waitForPorts">9990</property>
-            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 </arquillian>

--- a/testsuite/integration/microprofile-tck/health/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/microprofile-tck/health/src/test/resources/arquillian-bootable.xml
@@ -19,7 +19,6 @@
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>
             <property name="waitForPorts">9990</property>
-            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 

--- a/testsuite/integration/microprofile-tck/health/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/health/src/test/resources/arquillian.xml
@@ -18,7 +18,6 @@
             <property name="managementPort">9990</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone-microprofile.xml}</property>
             <property name="waitForPorts">9990</property>
-            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 </arquillian>

--- a/testsuite/integration/microprofile-tck/jwt/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/microprofile-tck/jwt/src/test/resources/arquillian-bootable.xml
@@ -17,7 +17,6 @@
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>
             <property name="waitForPorts">9990</property>
-            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 

--- a/testsuite/integration/microprofile-tck/jwt/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/jwt/src/test/resources/arquillian.xml
@@ -18,7 +18,6 @@
             <property name="managementPort">9990</property>
             <property name="serverConfig">standalone-microprofile.xml</property>
             <property name="waitForPorts">9990</property>
-            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 

--- a/testsuite/integration/microprofile-tck/lra/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/microprofile-tck/lra/src/test/resources/arquillian-bootable.xml
@@ -20,7 +20,6 @@
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>
             <property name="waitForPorts">9990</property>
-            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 </arquillian>

--- a/testsuite/integration/microprofile-tck/lra/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/lra/src/test/resources/arquillian.xml
@@ -21,7 +21,6 @@
             <property name="managementPort">9990</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone-microprofile.xml}</property>
             <property name="waitForPorts">9990</property>
-            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 </arquillian>

--- a/testsuite/integration/microprofile-tck/openapi/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/microprofile-tck/openapi/src/test/resources/arquillian-bootable.xml
@@ -19,7 +19,6 @@
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>
             <property name="waitForPorts">9990</property>
-            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 

--- a/testsuite/integration/microprofile-tck/openapi/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/openapi/src/test/resources/arquillian.xml
@@ -18,7 +18,6 @@
             <property name="managementPort">9990</property>
             <property name="serverConfig">standalone-microprofile.xml</property>
             <property name="waitForPorts">9990</property>
-            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 </arquillian>

--- a/testsuite/integration/microprofile-tck/reactive-messaging/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/microprofile-tck/reactive-messaging/src/test/resources/arquillian-bootable.xml
@@ -17,7 +17,6 @@
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>
             <property name="waitForPorts">9990</property>
-            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 

--- a/testsuite/integration/microprofile-tck/reactive-messaging/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/reactive-messaging/src/test/resources/arquillian.xml
@@ -18,7 +18,6 @@
             <property name="managementPort">9990</property>
             <property name="serverConfig">standalone-microprofile.xml</property>
             <property name="waitForPorts">9990</property>
-            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 </arquillian>

--- a/testsuite/integration/microprofile-tck/reactive-streams-operators/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/microprofile-tck/reactive-streams-operators/src/test/resources/arquillian-bootable.xml
@@ -17,7 +17,6 @@
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>
             <property name="waitForPorts">9990</property>
-            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 </arquillian>

--- a/testsuite/integration/microprofile-tck/reactive-streams-operators/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/reactive-streams-operators/src/test/resources/arquillian.xml
@@ -22,7 +22,6 @@
             <property name="managementPort">9990</property>
             <property name="serverConfig">standalone-microprofile.xml</property>
             <property name="waitForPorts">9990</property>
-            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 </arquillian>

--- a/testsuite/integration/microprofile-tck/rest-client/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/microprofile-tck/rest-client/src/test/resources/arquillian-bootable.xml
@@ -17,7 +17,6 @@
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>
             <property name="waitForPorts">9990</property>
-            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 </arquillian>

--- a/testsuite/integration/microprofile-tck/rest-client/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/rest-client/src/test/resources/arquillian.xml
@@ -18,7 +18,6 @@
             <property name="managementPort">9990</property>
             <property name="serverConfig">${jboss.server.config.file.name}</property>
             <property name="waitForPorts">9990</property>
-            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 </arquillian>

--- a/testsuite/integration/microprofile-tck/telemetry/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/microprofile-tck/telemetry/src/test/resources/arquillian-bootable.xml
@@ -20,7 +20,6 @@
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>
             <property name="waitForPorts">9990</property>
-            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 

--- a/testsuite/integration/microprofile-tck/telemetry/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/telemetry/src/test/resources/arquillian.xml
@@ -28,7 +28,6 @@
             <property name="managementPort">9990</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone-microprofile.xml}</property>
             <property name="waitForPorts">9990</property>
-            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 

--- a/testsuite/integration/multinode/src/test/resources/arquillian.xml
+++ b/testsuite/integration/multinode/src/test/resources/arquillian.xml
@@ -24,7 +24,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
@@ -41,7 +40,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port.node1} 10090</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <!-- Current module's directory. Will automatically pick up sub-module's basedir. -->
         <jbossas.ts.submodule.dir>${basedir}</jbossas.ts.submodule.dir>
-        <!-- Integration module's directory. To be overriden in sub-modules. -->
+        <!-- Integration module's directory. To be overridden in sub-modules. -->
         <jbossas.ts.integ.dir>${basedir}</jbossas.ts.integ.dir>
         <!-- This project's testsuite dir. To be changed for every submodule (until we figure out how to do it automatically). -->
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>

--- a/testsuite/integration/rbac/src/test/resources/arquillian.xml
+++ b/testsuite/integration/rbac/src/test/resources/arquillian.xml
@@ -21,7 +21,6 @@
 
             <!-- AS7-4070 -->
             <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
             <property name="javaHome">${container.java.home}</property>
         </configuration>
     </container>

--- a/testsuite/integration/secman/src/test/resources/arquillian.xml
+++ b/testsuite/integration/secman/src/test/resources/arquillian.xml
@@ -19,7 +19,6 @@
             <property name="managementAddress">${node0:127.0.0.1}</property>
             <property name="managementPort">${as.managementPort:9990}</property>
             <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
             <property name="javaHome">${container.java.home}</property>
         </configuration>
     </container>

--- a/testsuite/integration/smoke/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/smoke/src/test/resources/arquillian-bootable.xml
@@ -24,7 +24,6 @@
 
             <!-- AS7-4070 -->
             <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>
 

--- a/testsuite/integration/smoke/src/test/resources/arquillian.xml
+++ b/testsuite/integration/smoke/src/test/resources/arquillian.xml
@@ -21,7 +21,6 @@
 
             <!-- AS7-4070 -->
             <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
             <property name="javaHome">${container.java.home}</property>
         </configuration>
     </container>

--- a/testsuite/integration/vdx/src/test/resources/arquillian.xml
+++ b/testsuite/integration/vdx/src/test/resources/arquillian.xml
@@ -15,7 +15,6 @@
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>
             <property name="waitForPorts">9990</property>
-            <property name="waitForPortsTimeoutInSeconds">10</property>
             <property name="javaHome">${container.java.home}</property>
         </configuration>
     </container>

--- a/testsuite/integration/web/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/web/src/test/resources/arquillian-bootable.xml
@@ -23,7 +23,6 @@
 
             <!-- AS7-4070 -->
             <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>
 

--- a/testsuite/integration/web/src/test/resources/arquillian.xml
+++ b/testsuite/integration/web/src/test/resources/arquillian.xml
@@ -21,7 +21,6 @@
             <property name="managementAddress">${node0:127.0.0.1}</property>
             <property name="managementPort">${as.managementPort:9990}</property>
 
-            <property name="waitForPortsTimeoutInSeconds">8</property>
             <property name="javaHome">${container.java.home}</property>
         </configuration>
     </container>

--- a/testsuite/integration/ws/src/test/resources/arquillian.xml
+++ b/testsuite/integration/ws/src/test/resources/arquillian.xml
@@ -23,7 +23,6 @@
 
             <!-- AS7-4070 -->
             <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
             <property name="javaHome">${container.java.home}</property>
         </configuration>
     </container>

--- a/testsuite/preview/basic/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/preview/basic/src/test/resources/arquillian-bootable.xml
@@ -22,7 +22,6 @@
 
             <!-- AS7-4070 -->
             <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>
 

--- a/testsuite/preview/basic/src/test/resources/arquillian.xml
+++ b/testsuite/preview/basic/src/test/resources/arquillian.xml
@@ -21,7 +21,6 @@
 
             <!-- AS7-4070 -->
             <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
             <property name="javaHome">${container.java.home}</property>
         </configuration>
     </container>

--- a/testsuite/preview/expansion/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/preview/expansion/src/test/resources/arquillian-bootable.xml
@@ -24,7 +24,6 @@
 
             <!-- AS7-4070 -->
             <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>
 

--- a/testsuite/preview/expansion/src/test/resources/arquillian.xml
+++ b/testsuite/preview/expansion/src/test/resources/arquillian.xml
@@ -23,7 +23,6 @@
 
             <!-- AS7-4070 -->
             <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
             <property name="javaHome">${container.java.home}</property>
         </configuration>
     </container>

--- a/testsuite/preview/manualmode/src/test/resources/arquillian.xml
+++ b/testsuite/preview/manualmode/src/test/resources/arquillian.xml
@@ -22,7 +22,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="modulePath">${basedir}/target/wildfly/modules</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
@@ -41,7 +40,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="modulePath">${basedir}/target/wildfly/modules</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
@@ -60,7 +58,6 @@
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-                <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="modulePath">${basedir}/target/wildfly/modules</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>


### PR DESCRIPTION
Fixes
https://redhat.atlassian.net/browse/WFLY-21973

n.b. `waitForPortsTimeoutInSeconds`  overrides are simply redundant - https://github.com/wildfly/wildfly-arquillian/blob/main/common/src/main/java/org/jboss/as/arquillian/container/CommonManagedContainerConfiguration.java#L32