### PR TITLE
[WFLY-21961] Allow building without expansion modules also for legacy variant

### DIFF
--- a/legacy/ee-feature-pack/pom.xml
+++ b/legacy/ee-feature-pack/pom.xml
@@ -27,19 +27,6 @@
 
     <name>WildFly: Legacy Feature-Pack Parent</name>
 
-    <modules>
-        <module>build</module>
-        <module>channel</module>
-        <module>dist</module>
-        <module>ee-build</module>
-        <module>ee-dist</module>
-        <module>feature-pack</module>
-        <module>galleon-local</module>
-        <!-- Add this if we define any layers in this FP -->
-        <!--<module>layer-metadata-tests</module>-->
-        <module>product-conf</module>
-    </modules>
-
     <dependencyManagement>
         <dependencies>
 
@@ -76,5 +63,43 @@
             <type>pom</type>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>base.build</id>
+            <activation>
+                <property>
+                    <name>!no.base.build</name>
+                </property>
+            </activation>
+            <modules>
+                <module>channel</module>
+                <module>ee-build</module>
+                <module>ee-dist</module>
+                <module>feature-pack</module>
+                <module>galleon-local</module>
+                <!-- Add this if we define any layers in this FP -->
+                <!--<module>layer-metadata-tests</module>-->
+                <module>product-conf</module>
+            </modules>
+        </profile>
+
+        <profile>
+            <id>expansion-build</id>
+            <activation>
+                <property>
+                    <!--
+                    Allow users to disable building expansion stuff if they just want base artifacts.
+                    This option requires -Dno.preview.build
+                    -->
+                    <name>!no.expansion.build</name>
+                </property>
+            </activation>
+            <modules>
+                <module>build</module>
+                <module>dist</module>
+            </modules>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21961

Follow up to work already done in https://github.com/wildfly/wildfly/pull/20095
The goal is for
```
mvn install -Dno.expansion.build -Dno.preview.build ...
```

to also skip expansion modules `legacy/ee-feature-pack/build` and `legacy/ee-feature-pack/dist` (which would fail to build because the non-legacy modules they depend on are not built with `-Dno.expansion.build -Dno.preview.build`)