### PR TITLE
[40.x] WFLY-21986, WFLY-21987 Upgrade wildfly-clustering to 10.0.8.Final, Infinispan to 16.0.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -550,7 +550,7 @@
         <version.org.hibernate.search>8.3.0.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>9.1.0.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.11.Final</version.org.hornetq>
-        <version.org.infinispan>16.0.11</version.org.infinispan>
+        <version.org.infinispan>16.0.13</version.org.infinispan>
         <version.org.jasypt>1.9.3</version.org.jasypt>
         <version.org.jberet>3.1.0.Final</version.org.jberet>
         <version.org.jboss.activemq.artemis.integration>2.0.4.Final</version.org.jboss.activemq.artemis.integration>
@@ -597,7 +597,7 @@
         <version.org.opensaml.opensaml>4.3.2</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.9.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.clustering>10.0.7.Final</version.org.wildfly.clustering>
+        <version.org.wildfly.clustering>10.0.8.Final</version.org.wildfly.clustering>
         <!--
             Maintain separation between these two frequently updated artifacts to avoid merge conflicts.
         -->


### PR DESCRIPTION
Backport of https://github.com/wildfly/wildfly/pull/20126


____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21986](https://redhat.atlassian.net/browse/WFLY-21986)
> * [WFLY-21987](https://redhat.atlassian.net/browse/WFLY-21987)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)