### PR TITLE
[WFLY-21992] Component upgrade to Hibernate ORM 7.4.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -521,7 +521,7 @@
         <legacy.version.org.hibernate>6.6.49.Final</legacy.version.org.hibernate>
         <!-- We need to use this value in configuring maven plugins, so simply overriding version.org.hibernate
              in boms/standard-preview-ee is inadequate. So we'll declare the value here and reference it in boms/standard-preview-ee. -->
-        <standard.version.org.hibernate>7.4.0.Final</standard.version.org.hibernate>
+        <standard.version.org.hibernate>7.4.1.Final</standard.version.org.hibernate>
         <version.org.hibernate.models>1.1.1</version.org.hibernate.models>
         <version.org.hornetq>2.4.11.Final</version.org.hornetq>
         <version.org.infinispan>16.0.11</version.org.infinispan>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21992

The changes are listed in [Release Release 7.4.1 · hibernate/hibernate-orm](https://github.com/hibernate/hibernate-orm/releases/tag/7.4.1) which includes [HHH-20518: After updating from 7.3.6 to 7.4.0 hibernate enhance failsClosed](https://hibernate.atlassian.net/browse/HHH-20518)
  which allows Hibernate ORM Build time enhancement testing to work (https://redhat.atlassian.net/browse/WFLY-21969).