### PR TITLE
[WFLY-21971] Upgrade WildFly EE 10 to ANTLR 4.13.2 and Hibernate ORM 6.6.53.Final

### DIFF
--- a/boms/legacy-ee/pom.xml
+++ b/boms/legacy-ee/pom.xml
@@ -50,7 +50,7 @@
         <version.jakarta.validation.jakarta-validation-api>3.0.2</version.jakarta.validation.jakarta-validation-api>
         <version.jakarta.websocket.jakarta-websocket-api>2.1.1</version.jakarta.websocket.jakarta-websocket-api>
         <version.jakarta.ws.rs.jakarta-ws-rs-api>3.1.0</version.jakarta.ws.rs.jakarta-ws-rs-api>
-        <version.org.antlr>4.13.0</version.org.antlr>
+        <version.org.antlr>4.13.2</version.org.antlr>
         <version.org.apache.lucene>9.11.1</version.org.apache.lucene>
         <version.org.bytebuddy>1.17.8</version.org.bytebuddy>
         <version.org.elasticsearch.client.rest-client>8.15.4</version.org.elasticsearch.client.rest-client>

--- a/pom.xml
+++ b/pom.xml
@@ -518,7 +518,7 @@
         <version.org.hibernate.commons.annotations>7.0.3.Final</version.org.hibernate.commons.annotations>
         <!-- We need to use this value in configuring maven plugins, so simply overriding version.org.hibernate
              in boms/legacy-ee is inadequate. So we'll declare the value here and reference it in boms/legacy-ee. -->
-        <legacy.version.org.hibernate>6.6.49.Final</legacy.version.org.hibernate>
+        <legacy.version.org.hibernate>6.6.53.Final</legacy.version.org.hibernate>
         <!-- We need to use this value in configuring maven plugins, so simply overriding version.org.hibernate
              in boms/standard-preview-ee is inadequate. So we'll declare the value here and reference it in boms/standard-preview-ee. -->
         <standard.version.org.hibernate>7.4.0.Final</standard.version.org.hibernate>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21971

Hibernate ORM 6.6.53.Final uses ANTLR 4.13.2 so we will update WildFly EE 10 to also use ANTLR 4.13.2.

Upgrade from Hibernate ORM 6.6.49.Final to 6.6.53.Final includes changes https://github.com/hibernate/hibernate-orm/compare/6.6.49...6.6.53