### PR TITLE
WFLY-21979   jgroups-tcp-fd socket binding port 57600 is in the OS ephemeral port range + WFLY-21975   FD_SOCK2 port_range should be set to 0 for deterministic port binding

### DIFF
--- a/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
+++ b/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
@@ -54,7 +54,7 @@
         timeout_check_interval="5s"
     />
     <FD_SOCK port_range="0"/>
-    <FD_SOCK2 offset="1"/>
+    <FD_SOCK2 offset="1" port_range="0"/>
     <VERIFY_SUSPECT timeout="1s"/>
     <VERIFY_SUSPECT2 timeout="1s"/>
     <pbcast.NAKACK2

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/domain-jgroups-sockets.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/domain-jgroups-sockets.xml
@@ -19,7 +19,7 @@
     <feature spec="domain.socket-binding-group.socket-binding">
         <param name="socket-binding" value="jgroups-tcp-fd"/>
         <param name="interface" value="private"/>
-        <param name="port" value="57600"/>
+        <param name="port" value="7601"/>
     </feature>
     <feature spec="domain.socket-binding-group.socket-binding">
         <param name="socket-binding" value="jgroups-udp"/>
@@ -31,6 +31,6 @@
     <feature spec="domain.socket-binding-group.socket-binding">
         <param name="socket-binding" value="jgroups-udp-fd"/>
         <param name="interface" value="private"/>
-        <param name="port" value="54200"/>
+        <param name="port" value="7602"/>
     </feature>
 </feature-group-spec>

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/jgroups-sockets.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/jgroups-sockets.xml
@@ -19,7 +19,7 @@
     <feature spec="socket-binding-group.socket-binding">
         <param name="socket-binding" value="jgroups-tcp-fd"/>
         <param name="interface" value="private"/>
-        <param name="port" value="57600"/>
+        <param name="port" value="7601"/>
     </feature>
     <feature spec="socket-binding-group.socket-binding">
         <param name="socket-binding" value="jgroups-udp"/>
@@ -31,6 +31,6 @@
     <feature spec="socket-binding-group.socket-binding">
         <param name="socket-binding" value="jgroups-udp-fd"/>
         <param name="interface" value="private"/>
-        <param name="port" value="54200"/>
+        <param name="port" value="7602"/>
     </feature>
 </feature-group-spec>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-minimal.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-minimal.xml
@@ -85,7 +85,7 @@
             <socket-binding name="jgroups-mping" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
             <socket-binding name="jgroups-tcp" port="7600"/>
             <socket-binding name="jgroups-udp" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
-            <socket-binding name="jgroups-udp-fd" port="54200"/>
+            <socket-binding name="jgroups-udp-fd" port="7602"/>
             <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
             <socket-binding name="remoting" port="4447"/>
             <socket-binding name="txn-recovery-environment" port="4712"/>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
@@ -775,7 +775,7 @@
             <socket-binding name="jgroups-mping" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
             <socket-binding name="jgroups-tcp" port="7600"/>
             <socket-binding name="jgroups-udp" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
-            <socket-binding name="jgroups-udp-fd" port="54200"/>
+            <socket-binding name="jgroups-udp-fd" port="7602"/>
             <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
             <socket-binding name="remoting" port="4447"/>
             <socket-binding name="txn-recovery-environment" port="4712"/>
@@ -794,7 +794,7 @@
             <socket-binding name="jgroups-mping" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
             <socket-binding name="jgroups-tcp" port="7600"/>
             <socket-binding name="jgroups-udp" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
-            <socket-binding name="jgroups-udp-fd" port="54200"/>
+            <socket-binding name="jgroups-udp-fd" port="7602"/>
             <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
             <socket-binding name="remoting" port="4447"/>
             <socket-binding name="txn-recovery-environment" port="4712"/>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -843,7 +843,7 @@
             <socket-binding name="jgroups-mping" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
             <socket-binding name="jgroups-tcp" port="7600"/>
             <socket-binding name="jgroups-udp" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
-            <socket-binding name="jgroups-udp-fd" port="54200"/>
+            <socket-binding name="jgroups-udp-fd" port="7602"/>
             <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
             <socket-binding name="remoting" port="4447"/>
             <socket-binding name="txn-recovery-environment" port="4712"/>
@@ -862,7 +862,7 @@
             <socket-binding name="jgroups-mping" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
             <socket-binding name="jgroups-tcp" port="7600"/>
             <socket-binding name="jgroups-udp" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
-            <socket-binding name="jgroups-udp-fd" port="54200"/>
+            <socket-binding name="jgroups-udp-fd" port="7602"/>
             <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
             <socket-binding name="remoting" port="4447"/>
             <socket-binding name="txn-recovery-environment" port="4712"/>

--- a/testsuite/integration/clustering/clustering-ha-bootable-jar.cli
+++ b/testsuite/integration/clustering/clustering-ha-bootable-jar.cli
@@ -15,18 +15,18 @@
 /subsystem=jgroups/stack=tcp/protocol=TCPPING:add(add-index=1,socket-bindings=[node-1,node-2,node-3,node-4])
 
 # TCP bridge stack configuration for XSite
-/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-1-bridge:add(host=${node0},port=7601)
-/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-2-bridge:add(host=${node1},port=7701)
-/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-3-bridge:add(host=${node2},port=7801)
-/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-4-bridge:add(host=${node3},port=7901)
-/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-bridge:add(interface=private, port=7601)
-/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd-bridge:add(interface=private, port=57601)
+/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-1-bridge:add(host=${node0}, port=7650)
+/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-2-bridge:add(host=${node1}, port=7750)
+/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-3-bridge:add(host=${node2}, port=7850)
+/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-4-bridge:add(host=${node3}, port=7950)
+/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-bridge:add(interface=private, port=7650)
+/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd-bridge:add(interface=private, port=7651)
 
 batch
 /subsystem=jgroups/stack=tcp-bridge:add
 /subsystem=jgroups/stack=tcp-bridge/transport=TCP:add(socket-binding=jgroups-tcp-bridge)
 /subsystem=jgroups/stack=tcp-bridge/protocol=RED:add
-/subsystem=jgroups/stack=tcp-bridge/protocol=TCPPING:add(socket-bindings=[node-1-bridge,node-2-bridge,node-3-bridge,node-4-bridge])
+/subsystem=jgroups/stack=tcp-bridge/protocol=TCPPING:add(socket-bindings=[node-1-bridge, node-2-bridge, node-3-bridge, node-4-bridge])
 /subsystem=jgroups/stack=tcp-bridge/protocol=MERGE3:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=FD_SOCK2:add(socket-binding=jgroups-tcp-fd-bridge)
 /subsystem=jgroups/stack=tcp-bridge/protocol=FD_ALL3:add

--- a/testsuite/integration/clustering/clustering-ha.cli
+++ b/testsuite/integration/clustering/clustering-ha.cli
@@ -17,18 +17,18 @@ embed-server --server-config=standalone-ha.xml
 /subsystem=jgroups/stack=tcp/protocol=TCPPING:add(add-index=1,socket-bindings=[node-1,node-2,node-3,node-4])
 
 # TCP bridge stack configuration for XSite
-/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-1-bridge:add(host=${node0},port=7601)
-/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-2-bridge:add(host=${node1},port=7701)
-/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-3-bridge:add(host=${node2},port=7801)
-/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-4-bridge:add(host=${node3},port=7901)
-/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-bridge:add(interface=private, port=7601)
-/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd-bridge:add(interface=private, port=57601)
+/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-1-bridge:add(host=${node0}, port=7650)
+/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-2-bridge:add(host=${node1}, port=7750)
+/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-3-bridge:add(host=${node2}, port=7850)
+/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-4-bridge:add(host=${node3}, port=7950)
+/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-bridge:add(interface=private, port=7650)
+/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd-bridge:add(interface=private, port=7651)
 
 batch
 /subsystem=jgroups/stack=tcp-bridge:add
 /subsystem=jgroups/stack=tcp-bridge/transport=TCP:add(socket-binding=jgroups-tcp-bridge)
 /subsystem=jgroups/stack=tcp-bridge/protocol=RED:add
-/subsystem=jgroups/stack=tcp-bridge/protocol=TCPPING:add(socket-bindings=[node-1-bridge,node-2-bridge,node-3-bridge,node-4-bridge])
+/subsystem=jgroups/stack=tcp-bridge/protocol=TCPPING:add(socket-bindings=[node-1-bridge, node-2-bridge, node-3-bridge, node-4-bridge])
 /subsystem=jgroups/stack=tcp-bridge/protocol=MERGE3:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=FD_SOCK2:add(socket-binding=jgroups-tcp-fd-bridge)
 /subsystem=jgroups/stack=tcp-bridge/protocol=FD_ALL3:add
@@ -68,18 +68,18 @@ embed-server --server-config=standalone-full-ha.xml
 /subsystem=jgroups/stack=tcp/protocol=TCPPING:add(add-index=1,socket-bindings=[node-1,node-2,node-3,node-4])
 
 # TCP bridge stack configuration for XSite
-/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-1-bridge:add(host=${node0},port=7601)
-/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-2-bridge:add(host=${node1},port=7701)
-/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-3-bridge:add(host=${node2},port=7801)
-/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-4-bridge:add(host=${node3},port=7901)
-/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-bridge:add(interface=private, port=7601)
-/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd-bridge:add(interface=private, port=57601)
+/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-1-bridge:add(host=${node0}, port=7650)
+/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-2-bridge:add(host=${node1}, port=7750)
+/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-3-bridge:add(host=${node2}, port=7850)
+/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-4-bridge:add(host=${node3}, port=7950)
+/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-bridge:add(interface=private, port=7650)
+/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd-bridge:add(interface=private, port=7651)
 
 batch
 /subsystem=jgroups/stack=tcp-bridge:add
 /subsystem=jgroups/stack=tcp-bridge/transport=TCP:add(socket-binding=jgroups-tcp-bridge)
 /subsystem=jgroups/stack=tcp-bridge/protocol=RED:add
-/subsystem=jgroups/stack=tcp-bridge/protocol=TCPPING:add(socket-bindings=[node-1-bridge,node-2-bridge,node-3-bridge,node-4-bridge])
+/subsystem=jgroups/stack=tcp-bridge/protocol=TCPPING:add(socket-bindings=[node-1-bridge, node-2-bridge, node-3-bridge, node-4-bridge])
 /subsystem=jgroups/stack=tcp-bridge/protocol=MERGE3:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=FD_SOCK2:add(socket-binding=jgroups-tcp-fd-bridge)
 /subsystem=jgroups/stack=tcp-bridge/protocol=FD_ALL3:add

--- a/testsuite/integration/clustering/clustering-microprofile-ha.cli
+++ b/testsuite/integration/clustering/clustering-microprofile-ha.cli
@@ -17,18 +17,18 @@ embed-server --server-config=standalone-microprofile-ha.xml
 /subsystem=jgroups/stack=tcp/protocol=TCPPING:add(add-index=1,socket-bindings=[node-1,node-2,node-3,node-4])
 
 # TCP bridge stack configuration for XSite
-/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-1-bridge:add(host=${node0},port=7601)
-/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-2-bridge:add(host=${node1},port=7701)
-/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-3-bridge:add(host=${node2},port=7801)
-/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-4-bridge:add(host=${node3},port=7901)
-/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-bridge:add(interface=private, port=7601)
-/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd-bridge:add(interface=private, port=57601)
+/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-1-bridge:add(host=${node0}, port=7650)
+/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-2-bridge:add(host=${node1}, port=7750)
+/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-3-bridge:add(host=${node2}, port=7850)
+/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-4-bridge:add(host=${node3}, port=7950)
+/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-bridge:add(interface=private, port=7650)
+/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd-bridge:add(interface=private, port=7651)
 
 batch
 /subsystem=jgroups/stack=tcp-bridge:add
 /subsystem=jgroups/stack=tcp-bridge/transport=TCP:add(socket-binding=jgroups-tcp-bridge)
 /subsystem=jgroups/stack=tcp-bridge/protocol=RED:add
-/subsystem=jgroups/stack=tcp-bridge/protocol=TCPPING:add(socket-bindings=[node-1-bridge,node-2-bridge,node-3-bridge,node-4-bridge])
+/subsystem=jgroups/stack=tcp-bridge/protocol=TCPPING:add(socket-bindings=[node-1-bridge, node-2-bridge, node-3-bridge, node-4-bridge])
 /subsystem=jgroups/stack=tcp-bridge/protocol=MERGE3:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=FD_SOCK2:add(socket-binding=jgroups-tcp-fd-bridge)
 /subsystem=jgroups/stack=tcp-bridge/protocol=FD_ALL3:add

--- a/testsuite/integration/vdx/src/test/resources/configurations/domain/domain-to-damage.xml
+++ b/testsuite/integration/vdx/src/test/resources/configurations/domain/domain-to-damage.xml
@@ -1514,9 +1514,9 @@
             <socket-binding name="https" port="${jboss.https.port:8443}"/>
             <socket-binding name="jgroups-mping" interface="private" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
             <socket-binding name="jgroups-tcp" interface="private" port="7600"/>
-            <socket-binding name="jgroups-tcp-fd" interface="private" port="57600"/>
+            <socket-binding name="jgroups-tcp-fd" interface="private" port="7601"/>
             <socket-binding name="jgroups-udp" interface="private" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
-            <socket-binding name="jgroups-udp-fd" interface="private" port="54200"/>
+            <socket-binding name="jgroups-udp-fd" interface="private" port="7602"/>
             <socket-binding name="modcluster" port="0" multicast-address="${jboss.modcluster.multicast.address:224.0.1.105}" multicast-port="23364"/>
             <socket-binding name="txn-recovery-environment" port="4712"/>
             <socket-binding name="txn-status-manager" port="4713"/>
@@ -1546,9 +1546,9 @@
             <socket-binding name="iiop-ssl" interface="unsecure" port="3529"/>
             <socket-binding name="jgroups-mping" interface="private" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
             <socket-binding name="jgroups-tcp" interface="private" port="7600"/>
-            <socket-binding name="jgroups-tcp-fd" interface="private" port="57600"/>
+            <socket-binding name="jgroups-tcp-fd" interface="private" port="7601"/>
             <socket-binding name="jgroups-udp" interface="private" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
-            <socket-binding name="jgroups-udp-fd" interface="private" port="54200"/>
+            <socket-binding name="jgroups-udp-fd" interface="private" port="7602"/>
             <socket-binding name="modcluster" port="0" multicast-address="${jboss.modcluster.multicast.address:224.0.1.105}" multicast-port="23364"/>
             <socket-binding name="txn-recovery-environment" port="4712"/>
             <socket-binding name="txn-status-manager" port="4713"/>

--- a/testsuite/integration/vdx/src/test/resources/configurations/domain/duplicate-attribute.xml
+++ b/testsuite/integration/vdx/src/test/resources/configurations/domain/duplicate-attribute.xml
@@ -1386,9 +1386,9 @@
             <socket-binding name="https" port="${jboss.https.port:8443}"/>
             <socket-binding name="jgroups-mping" interface="private" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
             <socket-binding name="jgroups-tcp" interface="private" port="7600"/>
-            <socket-binding name="jgroups-tcp-fd" interface="private" port="57600"/>
+            <socket-binding name="jgroups-tcp-fd" interface="private" port="7601"/>
             <socket-binding name="jgroups-udp" interface="private" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
-            <socket-binding name="jgroups-udp-fd" interface="private" port="54200"/>
+            <socket-binding name="jgroups-udp-fd" interface="private" port="7602"/>
             <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
             <socket-binding name="txn-recovery-environment" port="4712"/>
             <socket-binding name="txn-status-manager" port="4713"/>
@@ -1418,9 +1418,9 @@
             <socket-binding name="iiop-ssl" interface="unsecure" port="3529"/>
             <socket-binding name="jgroups-mping" interface="private" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
             <socket-binding name="jgroups-tcp" interface="private" port="7600"/>
-            <socket-binding name="jgroups-tcp-fd" interface="private" port="57600"/>
+            <socket-binding name="jgroups-tcp-fd" interface="private" port="7601"/>
             <socket-binding name="jgroups-udp" interface="private" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
-            <socket-binding name="jgroups-udp-fd" interface="private" port="54200"/>
+            <socket-binding name="jgroups-udp-fd" interface="private" port="7602"/>
             <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
             <socket-binding name="txn-recovery-environment" port="4712"/>
             <socket-binding name="txn-status-manager" port="4713"/>

--- a/testsuite/integration/vdx/src/test/resources/configurations/standalone/standalone-full-ha-to-damage.xml
+++ b/testsuite/integration/vdx/src/test/resources/configurations/standalone/standalone-full-ha-to-damage.xml
@@ -530,9 +530,9 @@
     <socket-binding name="iiop-ssl" interface="unsecure" port="3529"/>
     <socket-binding name="jgroups-mping" interface="private" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
     <socket-binding name="jgroups-tcp" interface="private" port="7600"/>
-    <socket-binding name="jgroups-tcp-fd" interface="private" port="57600"/>
+    <socket-binding name="jgroups-tcp-fd" interface="private" port="7601"/>
     <socket-binding name="jgroups-udp" interface="private" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
-    <socket-binding name="jgroups-udp-fd" interface="private" port="54200"/>
+    <socket-binding name="jgroups-udp-fd" interface="private" port="7602"/>
     <socket-binding name="modcluster" port="0" multicast-address="${jboss.default.multicast.address:224.0.1.105}" multicast-port="23364"/>
     <socket-binding name="txn-recovery-environment" port="4712"/>
     <socket-binding name="txn-status-manager" port="4713"/>

--- a/testsuite/mixed-domain/src/test/resources/primary-config/domain-minimal.xml
+++ b/testsuite/mixed-domain/src/test/resources/primary-config/domain-minimal.xml
@@ -78,7 +78,7 @@
             <socket-binding name="jgroups-mping" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
             <socket-binding name="jgroups-tcp" port="7600"/>
             <socket-binding name="jgroups-udp" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
-            <socket-binding name="jgroups-udp-fd" port="54200"/>
+            <socket-binding name="jgroups-udp-fd" port="7602"/>
             <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
             <socket-binding name="remoting" port="4447"/>
             <socket-binding name="txn-recovery-environment" port="4712"/>


### PR DESCRIPTION
Review linked issues for in-depth details about the issues.

Resolves
https://redhat.atlassian.net/browse/WFLY-21975
https://redhat.atlassian.net/browse/WFLY-21979