### PR TITLE
WFLY-21997   MicroProfile Fault Tolerance TCK is flaky in our CI due to strict timeout multiplier

### DIFF
--- a/testsuite/integration/microprofile-tck/fault-tolerance/pom.xml
+++ b/testsuite/integration/microprofile-tck/fault-tolerance/pom.xml
@@ -89,7 +89,7 @@
                     <systemPropertyVariables>
                         <microprofile.jvm.args>${microprofile.jvm.args}</microprofile.jvm.args>
                         <!-- Increase timeout to reduce timing intermittent failures -->
-                        <org.eclipse.microprofile.fault.tolerance.tck.timeout.multiplier>2.0</org.eclipse.microprofile.fault.tolerance.tck.timeout.multiplier>
+                        <org.eclipse.microprofile.fault.tolerance.tck.timeout.multiplier>3.0</org.eclipse.microprofile.fault.tolerance.tck.timeout.multiplier>
                     </systemPropertyVariables>
                     <excludes>
                         <!-- These are unsupportable legacy MicroProfile Metrics tests; not to be confused with **/telemetryMetrics/** tests -->


### PR DESCRIPTION
Resolves
https://redhat.atlassian.net/browse/WFLY-21997