### PR TITLE
Add skip-teamcity label to Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ registries:
 updates:
   - package-ecosystem: "maven"
     directory: "/"
+    labels:
+      - "dependencies"
+      - "skip-teamcity"
     schedule:
       interval: "daily"
     ignore:
@@ -62,5 +65,8 @@ updates:
     # Workflow files stored in the
     # default location of `.github/workflows`
     directory: "/"
+    labels:
+      - "dependencies"
+      - "skip-teamcity"
     schedule:
       interval: "daily"


### PR DESCRIPTION
No Jira needed.