### PR TITLE
WFLY-21920 Remote queries fail with "IllegalArgumentException: No marshaller registered for Protobuf type" when using container-managed RemoteCacheContainer with deployment-specific types

### DIFF
--- a/clustering/infinispan/client/api/src/main/java/org/wildfly/clustering/infinispan/client/RemoteCacheContainer.java
+++ b/clustering/infinispan/client/api/src/main/java/org/wildfly/clustering/infinispan/client/RemoteCacheContainer.java
@@ -8,7 +8,7 @@ package org.wildfly.clustering.infinispan.client;
 import org.infinispan.client.hotrod.jmx.RemoteCacheManagerMXBean;
 
 /**
- * Extends Infinispan's {@link org.wildfly.clustering.infinispan.client.client.hotrod.RemoteCacheContainer} additionally exposing the name of the
+ * Extends Infinispan's {@link org.infinispan.client.hotrod.RemoteCacheContainer}, additionally exposing the name of the
  * remote cache container, an administration utility, and a mechanism for configuring near caching per remote cache.
  *
  * @author Radoslav Husar

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/client/ManagedRemoteCacheContainer.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/client/ManagedRemoteCacheContainer.java
@@ -16,6 +16,7 @@ import org.infinispan.client.hotrod.RemoteSchemasAdmin;
 import org.infinispan.client.hotrod.RemoteSchemasAdmin.SchemaOpResult;
 import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.configuration.RemoteCacheConfiguration;
+import org.infinispan.client.hotrod.impl.MarshallerRegistry;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.protostream.GeneratedSchema;
@@ -62,14 +63,19 @@ public class ManagedRemoteCacheContainer extends RemoteCacheContainerDecorator i
         List<Runnable> stopTasks = new LinkedList<>();
         ClassLoader loader = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
         Module module = Module.forClassLoader(loader, false);
+        MarshallerRegistry deploymentSpecificMarshallerRegistry = null;
         // If thread context is that of a deployment ...
         if ((module != null) && module.getName().startsWith(ServiceModuleLoader.MODULE_PREFIX)) {
             Configuration configuration = this.container.getConfiguration();
+            Marshaller marshaller = UserMarshallerFactory.forMediaType(configuration.marshaller().mediaType()).createUserMarshaller(this.loader, List.of(loader));
+            if (marshaller.mediaType().equals(MediaType.APPLICATION_PROTOSTREAM)) {
+                deploymentSpecificMarshallerRegistry = new MarshallerRegistry();
+                deploymentSpecificMarshallerRegistry.registerMarshaller(marshaller);
+            }
             Map<String, RemoteCacheConfiguration> configurations = configuration.remoteCaches();
             synchronized (configurations) {
                 // If remote cache configuration is undefined, auto-create
                 if (!configurations.containsKey(cacheName)) {
-                    Marshaller marshaller = UserMarshallerFactory.forMediaType(this.container.getConfiguration().marshaller().mediaType()).createUserMarshaller(this.loader, List.of(loader));
                     // If this is a protostream marshaller, additionally auto-register deployment-specific schemas with server
                     if (marshaller.mediaType().equals(MediaType.APPLICATION_PROTOSTREAM)) {
                         RemoteSchemasAdmin admin = this.container.administration().schemas();
@@ -93,7 +99,8 @@ public class ManagedRemoteCacheContainer extends RemoteCacheContainerDecorator i
         }
 
         RemoteCache<K, V> cache = this.container.getCache(cacheName);
-        return (cache != null) ? new ManagedRemoteCache<>(this, cache, this.registrar) {
+        RemoteCacheContainer cacheContainer = (deploymentSpecificMarshallerRegistry != null) ? new MarshallerRegistryRemoteCacheContainerDecorator(this, deploymentSpecificMarshallerRegistry) : this;
+        return (cache != null) ? new ManagedRemoteCache<>(cacheContainer, cache, this.registrar) {
             @Override
             public void stop() {
                 super.stop();

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/client/MarshallerRegistryRemoteCacheContainerDecorator.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/client/MarshallerRegistryRemoteCacheContainerDecorator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.clustering.infinispan.client;
+
+import org.infinispan.client.hotrod.impl.MarshallerRegistry;
+import org.wildfly.clustering.cache.infinispan.remote.RemoteCacheContainerDecorator;
+import org.wildfly.clustering.infinispan.client.RemoteCacheContainer;
+
+/**
+ * Decorator that overrides the marshaller registry with a deployment-specific one.
+ * This is necessary because {@code RemoteQueryFactory} obtains its {@code SerializationContext}
+ * from the container's marshaller registry rather than the per-cache marshaller,
+ * so query deserialization requires a registry that includes deployment-specific schemas.
+ *
+ * @author Radoslav Husar
+ * @since 41
+ */
+class MarshallerRegistryRemoteCacheContainerDecorator extends RemoteCacheContainerDecorator implements RemoteCacheContainer {
+    private final ManagedRemoteCacheContainer container;
+    private final MarshallerRegistry marshallerRegistry;
+
+    MarshallerRegistryRemoteCacheContainerDecorator(ManagedRemoteCacheContainer container, MarshallerRegistry marshallerRegistry) {
+        super(container);
+        this.container = container;
+        this.marshallerRegistry = marshallerRegistry;
+    }
+
+    @Override
+    public MarshallerRegistry getMarshallerRegistry() {
+        return this.marshallerRegistry;
+    }
+
+    @Override
+    public String getName() {
+        return this.container.getName();
+    }
+
+    @Override
+    public String[] getServers() {
+        return this.container.getServers();
+    }
+
+    @Override
+    public int getActiveConnectionCount() {
+        return this.container.getActiveConnectionCount();
+    }
+
+    @Override
+    public int getConnectionCount() {
+        return this.container.getConnectionCount();
+    }
+
+    @Override
+    public int getIdleConnectionCount() {
+        return this.container.getIdleConnectionCount();
+    }
+
+    @Override
+    public long getRetries() {
+        return this.container.getRetries();
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/infinispan/query/ContainerRemoteQueryTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/infinispan/query/ContainerRemoteQueryTestCase.java
@@ -26,7 +26,6 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.spec.se.manifest.ManifestDescriptor;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -36,7 +35,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @author Radoslav Husar
  * @since 27
  */
-@Disabled("https://redhat.atlassian.net/browse/WFLY-21920")
 @ExtendWith(ArquillianExtension.class)
 @ServerSetup(ServerSetupTask.class)
 public class ContainerRemoteQueryTestCase {
@@ -71,6 +69,13 @@ public class ContainerRemoteQueryTestCase {
             assertEquals(1, list.size());
             assertEquals(Book.class, list.get(0).getClass());
             assertEquals("A2", list.get(0).author);
+
+            // Verify subsequent getCache() call still supports query
+            RemoteCache<String, Book> cache2 = this.container.getCache("query");
+            Query<Book> query2 = cache2.query("FROM Book WHERE author='B2'");
+            list = query2.execute().list();
+            assertEquals(1, list.size());
+            assertEquals("B2", list.get(0).author);
         } finally {
             cache.clear();
             cache.stop();


### PR DESCRIPTION
Resolves
https://redhat.atlassian.net/browse/WFLY-21920