### PR TITLE
WFLY-22001 Deprecate statistics-enabled attribute on JGroups channel …

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractChannelResourceDefinitionRegistrar.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractChannelResourceDefinitionRegistrar.java
@@ -253,7 +253,7 @@ public abstract class AbstractChannelResourceDefinitionRegistrar<C extends Chann
                             }
                         });
                     }
-                    return channel.stats(configuration.isStatisticsEnabled());
+                    return channel;
                 } catch (Exception e) {
                     throw new IllegalStateException(e);
                 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelResourceDefinitionRegistrar.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelResourceDefinitionRegistrar.java
@@ -60,7 +60,7 @@ public class ChannelResourceDefinitionRegistrar extends AbstractChannelResourceD
             .setRequired(false)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
-    static final StatisticsEnabledAttributeDefinition STATISTICS_ENABLED = new StatisticsEnabledAttributeDefinition.Builder().build();
+    static final StatisticsEnabledAttributeDefinition STATISTICS_ENABLED = new StatisticsEnabledAttributeDefinition.Builder().setDeprecated(JGroupsSubsystemModel.VERSION_12_0_0.getVersion()).build();
 
     private final ServiceValueExecutorRegistry<JChannel> channelRegistry;
 
@@ -113,16 +113,10 @@ public class ChannelResourceDefinitionRegistrar extends AbstractChannelResourceD
                     public ServiceDependency<ChannelConfiguration> resolve(OperationContext context, ModelNode model) throws OperationFailedException {
                         String name = context.getCurrentAddressValue();
                         String clusterName = CLUSTER.resolveModelAttribute(context, model).asString(name);
-                        boolean statisticsEnabled = STATISTICS_ENABLED.resolve(context, model);
                         return STACK.resolve(context, model).combine(MODULE.resolve(context, model), new BiFunction<>() {
                             @Override
                             public ChannelConfiguration apply(ChannelFactory factory, Module module) {
                                 return new ChannelConfiguration() {
-                                    @Override
-                                    public boolean isStatisticsEnabled() {
-                                        return statisticsEnabled;
-                                    }
-
                                     @Override
                                     public ChannelFactory getChannelFactory() {
                                         return factory;

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemModel.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemModel.java
@@ -27,9 +27,10 @@ public enum JGroupsSubsystemModel implements SubsystemModel {
     VERSION_8_0_0(8, 0, 0), // WildFly 20-26, EAP 7.4
     VERSION_9_0_0(9, 0, 0), // WildFly 27-29
     VERSION_10_0_0(10, 0, 0), // WildFly 30-38, EAP 8.0-8.1
-    VERSION_11_0_0(11, 0, 0), // WildFly 39-present
+    VERSION_11_0_0(11, 0, 0), // WildFly 39-40
+    VERSION_12_0_0(12, 0, 0), // WildFly 41-present
     ;
-    static final JGroupsSubsystemModel CURRENT = VERSION_11_0_0;
+    static final JGroupsSubsystemModel CURRENT = VERSION_12_0_0;
 
     private final ModelVersion version;
 

--- a/clustering/jgroups/extension/src/main/resources/org/jboss/as/clustering/jgroups/subsystem/LocalDescriptions.properties
+++ b/clustering/jgroups/extension/src/main/resources/org/jboss/as/clustering/jgroups/subsystem/LocalDescriptions.properties
@@ -96,6 +96,7 @@ jgroups.channel.stack=The protocol stack of the JGroups channel
 jgroups.channel.cluster=The cluster name of the JGroups channel. If undefined, the name of the channel will be used.
 jgroups.channel.module=The module from which to load channel services
 jgroups.channel.statistics-enabled=If enabled, collect channel statistics.
+jgroups.channel.statistics-enabled.deprecated=Deprecated. This attribute is effectively ignored. Use the statistics-enabled attribute on the stack resource instead.
 jgroups.channel.address=The IP address of the channel.
 jgroups.channel.address-as-uuid=The address of the channel as a UUID.
 jgroups.channel.discard-own-messages=If true, do not receive messages sent by this node (ourself).

--- a/clustering/jgroups/extension/src/main/resources/schema/jboss-as-jgroups_9_0.xsd
+++ b/clustering/jgroups/extension/src/main/resources/schema/jboss-as-jgroups_9_0.xsd
@@ -85,7 +85,7 @@
         </xs:attribute>
         <xs:attribute name="statistics-enabled" type="xs:boolean" default="false">
             <xs:annotation>
-                <xs:documentation>Indicates whether or not this channel will collect statistics.</xs:documentation>
+                <xs:documentation>Deprecated. This attribute is effectively ignored. Use the statistics-enabled attribute on the stack resource instead.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>

--- a/clustering/jgroups/extension/src/main/resources/schema/jboss-as-jgroups_community_9_0.xsd
+++ b/clustering/jgroups/extension/src/main/resources/schema/jboss-as-jgroups_community_9_0.xsd
@@ -85,7 +85,7 @@
         </xs:attribute>
         <xs:attribute name="statistics-enabled" type="xs:boolean" default="false">
             <xs:annotation>
-                <xs:documentation>Indicates whether or not this channel will collect statistics.</xs:documentation>
+                <xs:documentation>Deprecated. This attribute is effectively ignored. Use the statistics-enabled attribute on the stack resource instead.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>

--- a/clustering/jgroups/spi/src/main/java/org/wildfly/clustering/jgroups/spi/ChannelConfiguration.java
+++ b/clustering/jgroups/spi/src/main/java/org/wildfly/clustering/jgroups/spi/ChannelConfiguration.java
@@ -17,12 +17,6 @@ public interface ChannelConfiguration {
     UnaryServiceDescriptor<ChannelConfiguration> SERVICE_DESCRIPTOR = UnaryServiceDescriptor.of("org.wildfly.clustering.jgroups.channel-configuration", DEFAULT_SERVICE_DESCRIPTOR);
 
     /**
-     * Indicates whether statistics should be enabled.
-     * @return true, if statistics will be enabled for this channel, false otherwise.
-     */
-    boolean isStatisticsEnabled();
-
-    /**
      * The factory for creating this channel.
      * @return a channel factory
      */

--- a/clustering/jgroups/spi/src/main/java/org/wildfly/clustering/jgroups/spi/ForkChannelConfiguration.java
+++ b/clustering/jgroups/spi/src/main/java/org/wildfly/clustering/jgroups/spi/ForkChannelConfiguration.java
@@ -20,11 +20,6 @@ public interface ForkChannelConfiguration extends ChannelConfiguration {
     ForkChannelFactory getChannelFactory();
 
     @Override
-    default boolean isStatisticsEnabled() {
-        return this.getChannelFactory().getConfiguration().getChannelConfiguration().isStatisticsEnabled();
-    }
-
-    @Override
     default Module getModule() {
         return this.getChannelFactory().getConfiguration().getChannelConfiguration().getModule();
     }


### PR DESCRIPTION
…resource

The statistics-enabled attribute on the channel resource calls JChannel.stats(boolean) which is a no-op since JGRP-2426 moved all stats collection to MsgStats in the transport protocol. The actual statistics collection is controlled by the stack's statistics-enabled attribute which propagats to individual protocols.

https://redhat.atlassian.net/browse/WFLY-22001