### PR TITLE
[WFLY-22002] Upgrade WildFly Core to 32.0.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -601,7 +601,7 @@
         <!--
             Maintain separation between these two frequently updated artifacts to avoid merge conflicts.
         -->
-        <version.org.wildfly.core>32.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>32.0.1.Final</version.org.wildfly.core>
         <!--
             Maintain separation between these two frequently updated artifacts to avoid merge conflicts.
         -->


### PR DESCRIPTION
Jira issue: https://redhat.atlassian.net/browse/WFLY-22002

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/32.0.1.Final
Diff: https://github.com/yersan/wildfly-core/compare/32.0.0.Final...32.0.1.Final

---

<details>
<div class="csg-wrapper" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif; font-size: 14px; font-weight: 400; line-height: 24px; vertical-align: baseline;"><h1 class="csg-h1" style="font-style: inherit; color: #172B4D; font-weight: 600; margin-bottom: 0; font-size: 29px; line-height: 1.10; margin-top: 40px; letter-spacing: -0.01em;">Release notes - WildFly Core - 32.0.1.Final</h1><h3 class="csg-h3" style="font-style: inherit; color: #172B4D; font-weight: 600; margin-bottom: 0; font-size: 20px; line-height: 1.20; font-weight: 500; letter-spacing: -0.008em;">Component Upgrade</h3><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7595" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7595</a> Upgrade Undertow Core to 2.4.1.Final</p><h3 class="csg-h3" style="font-style: inherit; color: #172B4D; font-weight: 600; margin-bottom: 0; font-size: 20px; line-height: 1.20; font-weight: 500; letter-spacing: -0.008em;">Bug</h3><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7616" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7616</a> Deprecate the /subsystem=elytron/policy=* resources</p></div>
</details>
