### PR TITLE
WFLY-22012 Consolidate EJB client topology update wait timeout into AbstractClusteringTestCase (fixes ClientClusterNodeSelectorTestCase fails intermittently)

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
@@ -4,6 +4,7 @@
  */
 package org.jboss.as.test.clustering.cluster;
 
+import java.time.Duration;
 import java.util.AbstractMap;
 import java.util.Map;
 import java.util.Optional;
@@ -90,6 +91,11 @@ public abstract class AbstractClusteringTestCase {
     // Timeouts
     public static final int GRACE_TIME_TO_REPLICATE = TimeoutUtil.adjust(4000);
     public static final int GRACE_TIME_TOPOLOGY_CHANGE = TimeoutUtil.adjust(3000);
+    /**
+     * Time to wait for the EJB client to receive a cluster topology update from the server.
+     * Accommodate for the fact that a client topology update does not necessarily mean that the beans on the server are available.
+     */
+    public static final Duration EJB_CLIENT_TOPOLOGY_UPDATE_WAIT = Duration.ofMillis(TimeoutUtil.adjust(5000));
     public static final int SUSPEND_TIMEOUT_S = TimeoutUtil.adjust(60);
     public static final int GRACE_TIME_TO_MEMBERSHIP_CHANGE = TimeoutUtil.adjust(10000);
     public static final int WAIT_FOR_PASSIVATION_MS = TimeoutUtil.adjust(5);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractRemoteStatefulEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractRemoteStatefulEJBFailoverTestCase.java
@@ -17,7 +17,6 @@ import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Result;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.StatefulIncrementorBean;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.shared.PermissionUtils;
-import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -32,7 +31,6 @@ import org.wildfly.common.function.ExceptionSupplier;
 @ExtendWith(ArquillianExtension.class)
 public abstract class AbstractRemoteStatefulEJBFailoverTestCase extends AbstractClusteringTestCase {
     private static final int COUNT = 20;
-    private static final long CLIENT_TOPOLOGY_UPDATE_WAIT = TimeoutUtil.adjust(5000);
 
     static Archive<?> createDeployment(String moduleName) {
         return ShrinkWrap.create(JavaArchive.class, moduleName + ".jar")
@@ -68,7 +66,7 @@ public abstract class AbstractRemoteStatefulEJBFailoverTestCase extends Abstract
 
             undeploy(this.findDeployment(target));
 
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+            Thread.sleep(EJB_CLIENT_TOPOLOGY_UPDATE_WAIT.toMillis());
 
             result = bean.increment();
             // Bean should failover to other node
@@ -80,7 +78,7 @@ public abstract class AbstractRemoteStatefulEJBFailoverTestCase extends Abstract
             deploy(this.findDeployment(target));
 
             // Allow sufficient time for client to receive new topology
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+            Thread.sleep(EJB_CLIENT_TOPOLOGY_UPDATE_WAIT.toMillis());
 
             result = bean.increment();
             String failbackTarget = result.getNode();
@@ -112,7 +110,7 @@ public abstract class AbstractRemoteStatefulEJBFailoverTestCase extends Abstract
             start(target);
 
             // Allow sufficient time for client to receive new topology
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+            Thread.sleep(EJB_CLIENT_TOPOLOGY_UPDATE_WAIT.toMillis());
 
             result = bean.increment();
             failbackTarget = result.getNode();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractRemoteStatelessEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractRemoteStatelessEJBFailoverTestCase.java
@@ -39,7 +39,6 @@ import org.wildfly.common.function.ExceptionSupplier;
 public abstract class AbstractRemoteStatelessEJBFailoverTestCase extends AbstractClusteringTestCase {
 
     private static final int COUNT = 20;
-    private static final long CLIENT_TOPOLOGY_UPDATE_WAIT = TimeoutUtil.adjust(5000);
     private static final long INVOCATION_WAIT = TimeoutUtil.adjust(10);
 
     static Archive<?> createDeployment(String moduleName) {
@@ -67,7 +66,7 @@ public abstract class AbstractRemoteStatelessEJBFailoverTestCase extends Abstrac
                 Incrementor bean = directory.lookupStateless(this.beanClass, Incrementor.class);
 
                 // Allow sufficient time for client to receive full topology
-                Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+                Thread.sleep(EJB_CLIENT_TOPOLOGY_UPDATE_WAIT.toMillis());
 
                 List<String> results = new ArrayList<>(COUNT);
                 for (int i = 0; i < COUNT; ++i) {
@@ -95,7 +94,7 @@ public abstract class AbstractRemoteStatelessEJBFailoverTestCase extends Abstrac
                 deploy(DEPLOYMENT_1);
 
                 // Allow sufficient time for client to receive new topology
-                Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+                Thread.sleep(EJB_CLIENT_TOPOLOGY_UPDATE_WAIT.toMillis());
 
                 for (int i = 0; i < COUNT; ++i) {
                     Result<Integer> result = bean.increment();
@@ -122,7 +121,7 @@ public abstract class AbstractRemoteStatelessEJBFailoverTestCase extends Abstrac
                 start(NODE_2);
 
                 // Allow sufficient time for client to receive new topology
-                Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+                Thread.sleep(EJB_CLIENT_TOPOLOGY_UPDATE_WAIT.toMillis());
 
                 for (int i = 0; i < COUNT; ++i) {
                     Result<Integer> result = bean.increment();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientClusterNodeSelectorTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientClusterNodeSelectorTestCase.java
@@ -27,7 +27,6 @@ import org.jboss.as.test.clustering.cluster.ejb.remote.bean.HeartbeatBean;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Result;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.shared.PermissionUtils;
-import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.ejb.client.ClusterNodeSelector;
 import org.jboss.ejb.client.EJBClientConnection;
 import org.jboss.ejb.client.EJBClientContext;
@@ -57,7 +56,6 @@ import org.wildfly.naming.client.WildFlyInitialContextFactory;
 public class ClientClusterNodeSelectorTestCase extends AbstractClusteringTestCase {
 
     private static final String MODULE_NAME = ClientClusterNodeSelectorTestCase.class.getSimpleName();
-    private static final long CLIENT_TOPOLOGY_UPDATE_WAIT = TimeoutUtil.adjust(2000);
 
     /**
      * Implementation of {@link ClusterNodeSelector} to be used for custom cluster node selection
@@ -135,7 +133,7 @@ public class ClientClusterNodeSelectorTestCase extends AbstractClusteringTestCas
             // first call goes to connected node regardless of CustomClusterNodeSelector
             // ====================================================================================
             Result<Date> res = bean.pulse();
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+            Thread.sleep(EJB_CLIENT_TOPOLOGY_UPDATE_WAIT.toMillis());
 
             // ====================================================================================
             // subsequent calls must be routed to the node selected by the CustomClusterNodeSelector

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/PassivationDisabledRemoteStatefulEjbFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/PassivationDisabledRemoteStatefulEjbFailoverTestCase.java
@@ -22,7 +22,6 @@ import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Result;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.shared.PermissionUtils;
-import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -40,7 +39,6 @@ import org.wildfly.common.function.ExceptionSupplier;
 @ExtendWith(ArquillianExtension.class)
 public class PassivationDisabledRemoteStatefulEjbFailoverTestCase extends AbstractClusteringTestCase {
     private static final int COUNT = 20;
-    private static final long CLIENT_TOPOLOGY_UPDATE_WAIT = TimeoutUtil.adjust(5000);
     private static final String MODULE_NAME = PassivationDisabledRemoteStatefulEjbFailoverTestCase.class.getSimpleName();
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
@@ -87,9 +85,9 @@ public class PassivationDisabledRemoteStatefulEjbFailoverTestCase extends Abstra
                 assertEquals(target, result.getNode(), String.valueOf(i));
             }
 
-            undeploy(this.findDeployment(target));
+            undeploy(findDeployment(target));
 
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+            Thread.sleep(EJB_CLIENT_TOPOLOGY_UPDATE_WAIT.toMillis());
 
             try {
                 result = bean.increment();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatefulEJBConcurrentFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatefulEJBConcurrentFailoverTestCase.java
@@ -27,7 +27,6 @@ import org.jboss.as.test.clustering.cluster.ejb.remote.bean.SlowStatefulIncremen
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.shared.PermissionUtils;
-import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -41,8 +40,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(ArquillianExtension.class)
 public class RemoteStatefulEJBConcurrentFailoverTestCase extends AbstractClusteringTestCase {
     private static final String MODULE_NAME = RemoteStatefulEJBConcurrentFailoverTestCase.class.getSimpleName();
-
-    private static final long CLIENT_TOPOLOGY_UPDATE_WAIT = TimeoutUtil.adjust(5000);
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
@@ -76,7 +73,7 @@ public class RemoteStatefulEJBConcurrentFailoverTestCase extends AbstractCluster
             AtomicInteger count = new AtomicInteger();
 
             // Allow sufficient time for client to receive full topology
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+            Thread.sleep(EJB_CLIENT_TOPOLOGY_UPDATE_WAIT.toMillis());
 
             String target = bean.increment().getNode();
             count.incrementAndGet();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TwoConnectorsEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TwoConnectorsEJBFailoverTestCase.java
@@ -25,7 +25,6 @@ import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.shared.IntermittentFailure;
 import org.jboss.as.test.shared.ManagementServerSetupTask;
 import org.jboss.as.test.shared.PermissionUtils;
-import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -49,7 +48,6 @@ public class TwoConnectorsEJBFailoverTestCase extends AbstractClusteringTestCase
     }
 
     private static final int COUNT = 20;
-    private static final long CLIENT_TOPOLOGY_UPDATE_WAIT = TimeoutUtil.adjust(5000);
     private static final String MODULE_NAME = TwoConnectorsEJBFailoverTestCase.class.getSimpleName();
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
@@ -123,7 +121,7 @@ public class TwoConnectorsEJBFailoverTestCase extends AbstractClusteringTestCase
     public void test(ExceptionSupplier<EJBDirectory, Exception> directoryProvider) throws Exception {
 
         // give the servers a moment to stabilize before invocation start
-        Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+        Thread.sleep(EJB_CLIENT_TOPOLOGY_UPDATE_WAIT.toMillis());
 
         try (EJBDirectory directory = directoryProvider.get()) {
             Incrementor bean = directory.lookupStateful(StatefulIncrementorBean.class, Incrementor.class);
@@ -143,7 +141,7 @@ public class TwoConnectorsEJBFailoverTestCase extends AbstractClusteringTestCase
 
             undeploy(findDeployment(target));
 
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+            Thread.sleep(EJB_CLIENT_TOPOLOGY_UPDATE_WAIT.toMillis());
 
             result = bean.increment();
             // Bean should failover to other node
@@ -155,7 +153,7 @@ public class TwoConnectorsEJBFailoverTestCase extends AbstractClusteringTestCase
             deploy(findDeployment(target));
 
             // Allow sufficient time for client to receive new topology
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+            Thread.sleep(EJB_CLIENT_TOPOLOGY_UPDATE_WAIT.toMillis());
 
             result = bean.increment();
             String failbackTarget = result.getNode();
@@ -178,7 +176,7 @@ public class TwoConnectorsEJBFailoverTestCase extends AbstractClusteringTestCase
             stop(target);
 
             // Allow sufficient time for client to receive new topology
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+            Thread.sleep(EJB_CLIENT_TOPOLOGY_UPDATE_WAIT.toMillis());
 
             result = bean.increment();
             // Bean should failover to other node
@@ -190,7 +188,7 @@ public class TwoConnectorsEJBFailoverTestCase extends AbstractClusteringTestCase
             start(target);
 
             // Allow sufficient time for client to receive new topology
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+            Thread.sleep(EJB_CLIENT_TOPOLOGY_UPDATE_WAIT.toMillis());
 
             result = bean.increment();
             failbackTarget = result.getNode();


### PR DESCRIPTION
Move the duplicated CLIENT_TOPOLOGY_UPDATE_WAIT constant from 6 individual EJB remote test classes into a single EJB_CLIENT_TOPOLOGY_UPDATE_WAIT field. This also fixes the insufficient 2-second timeout in ClientClusterNodeSelectorTestCase (now aligned with the common 5-second value used by all other EJB testrs).

See details in https://redhat.atlassian.net/browse/WFLY-22012