### PR TITLE
WFLY-20876 Remove generated version from JMS docs

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging.adoc
@@ -415,8 +415,7 @@ the command line.
 [[deployment-of--jms.xml-files]]
 == Deployment of -jms.xml files
 
-Starting with WildFly {wildflyVersion}, you have the ability to deploy a -jms.xml file
-defining Jakarta Messaging destinations, e.g.:
+You can deploy a -jms.xml file defining Jakarta Messaging destinations, e.g.:
 
 [source,xml,options="nowrap"]
 ----


### PR DESCRIPTION
## Summary

- Remove generated WildFly version wording from the JMS deployment docs where the version does not add value
- Keep the section focused on how to deploy `-jms.xml` descriptors

https://issues.redhat.com/browse/WFLY-20876

## Testing

- `cd docs && ../mvnw -q -DskipTests -Dmdep.skip=true package`
- `git diff --check`


____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-20876](https://redhat.atlassian.net/browse/WFLY-20876)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)