### PR TITLE
[WFLY-22019] Bump version.org.wildfly.bom-builder-plugin to 2.0.11.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,7 +328,7 @@
         <version.org.jacoco>0.8.14</version.org.jacoco>
         <version.org.jboss.galleon>7.0.7.Final</version.org.jboss.galleon>
         <version.org.owasp.dependency-check>12.2.2</version.org.owasp.dependency-check>
-        <version.org.wildfly.bom-builder-plugin>2.0.10.Final</version.org.wildfly.bom-builder-plugin>
+        <version.org.wildfly.bom-builder-plugin>2.0.11.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.galleon-plugins>8.1.5.Final</version.org.wildfly.galleon-plugins>


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/WFLY-22019