### PR TITLE
WFLY-22026 IIOP SSLSocketFactory accesses serverSSLContext before null check

### DIFF
--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/security/SSLSocketFactory.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/security/SSLSocketFactory.java
@@ -97,10 +97,10 @@ public class SSLSocketFactory extends SocketFactoryBase {
     }
 
     public ServerSocket createSSLServerSocket(int port, int backlog, InetAddress inetAddress) throws IOException {
-        SSLServerSocketFactory serverSocketFactory = this.serverSSLContext.getServerSocketFactory();
         if (serverSSLContext == null) {
             throw IIOPLogger.ROOT_LOGGER.serverSSLNotConfiguredRuntime();
         }
+        SSLServerSocketFactory serverSocketFactory = this.serverSSLContext.getServerSocketFactory();
         return serverSocketFactory.createServerSocket(port, backlog, inetAddress);
     }
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-22026

Random spotting when looking into JGroups TLS stuff.