### PR TITLE
[WFLY-22015] Stop publishing pre-built server tars to Maven

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -374,6 +374,36 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <!-- GPG signing is configured elsewhere. Just redeclare the execution here to help
+                         ensure the wildfly-detach-plugin runs after and can detach the asc files -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>gpg-sign</id>
+                                <phase>verify</phase> <!-- the normal phase for the 'sign' mojo -->
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-detach-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <!-- We built tars for local use, but we don't
+                                     want to install or deploy them. -->
+                                <id>detach-tars</id>
+                                <goals>
+                                    <goal>detach-artifacts</goal>
+                                </goals>
+                                <phase>verify</phase>
+                                <configuration>
+                                    <regex>\S{1,}tar\.gz\S*</regex>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/ee-dist/assembly.xml
+++ b/ee-dist/assembly.xml
@@ -9,7 +9,6 @@
     <id>distro</id>
     <formats>
        <format>zip</format>
-       <format>tar.gz</format>
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>
     <fileSets>

--- a/legacy/ee-feature-pack/dist/pom.xml
+++ b/legacy/ee-feature-pack/dist/pom.xml
@@ -374,6 +374,36 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <!-- GPG signing is configured elsewhere. Just redeclare the execution here to help
+                         ensure the wildfly-detach-plugin runs after and can detach the asc files -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>gpg-sign</id>
+                                <phase>verify</phase> <!-- the normal phase for the 'sign' mojo -->
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-detach-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <!-- We built tars for local use, but we don't
+                                     want to install or deploy them. -->
+                                <id>detach-tars</id>
+                                <goals>
+                                    <goal>detach-artifacts</goal>
+                                </goals>
+                                <phase>verify</phase>
+                                <configuration>
+                                    <regex>\S{1,}tar\.gz\S*</regex>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/legacy/ee-feature-pack/ee-dist/assembly.xml
+++ b/legacy/ee-feature-pack/ee-dist/assembly.xml
@@ -9,7 +9,6 @@
     <id>distro</id>
     <formats>
        <format>zip</format>
-       <format>tar.gz</format>
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>
     <fileSets>

--- a/pom.xml
+++ b/pom.xml
@@ -337,6 +337,7 @@
         <version.org.wildfly.glow>2.1.0.Final</version.org.wildfly.glow>
         <version.org.wildfly.licenses.plugin>2.4.4.Final</version.org.wildfly.licenses.plugin>
         <version.org.wildfly.plugin>6.0.0.Final</version.org.wildfly.plugin>
+        <version.org.wildfly.plugin.wildfly-detach-plugin>1.0.0.Final</version.org.wildfly.plugin.wildfly-detach-plugin>
         <version.org.wildfly.unstable.annotation.api>1.0.2.Final</version.org.wildfly.unstable.annotation.api>
         <version.org.wildfly.wildfly-channel-plugin>1.0.33</version.org.wildfly.wildfly-channel-plugin>
         <version.org.wildfly.wildfly-maven-gpg-plugin>3.2.8.SP1</version.org.wildfly.wildfly-maven-gpg-plugin>
@@ -1547,6 +1548,11 @@
                             <arg>-proc:full</arg>
                         </compilerArgs>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-detach-plugin</artifactId>
+                    <version>${version.org.wildfly.plugin.wildfly-detach-plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/preview/dist/pom.xml
+++ b/preview/dist/pom.xml
@@ -340,6 +340,36 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <!-- GPG signing is configured elsewhere. Just redeclare the execution here to help
+                         ensure the wildfly-detach-plugin runs after and can detach the asc files -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>gpg-sign</id>
+                                <phase>verify</phase> <!-- the normal phase for the 'sign' mojo -->
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-detach-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <!-- We built tars for local use, but we don't
+                                     want to install or deploy them. -->
+                                <id>detach-tars</id>
+                                <goals>
+                                    <goal>detach-artifacts</goal>
+                                </goals>
+                                <phase>verify</phase>
+                                <configuration>
+                                    <regex>\S{1,}tar\.gz\S*</regex>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-22015

Continue to build tars we attach to the GH release, just don't install/deploy them.

Stop building tars that we don't attach to the GH release.