### PR TITLE
WFLY-22024 Deprecate AJP connector in Undertow subsystem

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/domain-sockets.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/domain-sockets.xml
@@ -7,10 +7,6 @@
 <feature-group-spec name="domain-sockets" xmlns="urn:jboss:galleon:feature-group:1.0">
 
     <feature spec="domain.socket-binding-group.socket-binding">
-        <param name="socket-binding" value="ajp"/>
-        <param name="port" value="${jboss.ajp.port:8009}"/>
-    </feature>
-    <feature spec="domain.socket-binding-group.socket-binding">
         <param name="socket-binding" value="http"/>
         <param name="port" value="${jboss.http.port:8080}"/>
     </feature>

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/modcluster.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/modcluster.xml
@@ -9,7 +9,7 @@
         <feature spec="subsystem.modcluster.proxy">
             <param name="proxy" value="default"/>
             <param name="advertise-socket" value="modcluster"/>
-            <param name="listener" value="ajp"/>
+            <param name="listener" value="default"/>
             <feature spec="subsystem.modcluster.proxy.load-provider.dynamic">
                 <feature spec="subsystem.modcluster.proxy.load-provider.dynamic.load-metric">
                     <param name="load-metric" value="cpu"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/undertow-sockets.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/undertow-sockets.xml
@@ -7,10 +7,6 @@
 <feature-group-spec name="undertow-sockets" xmlns="urn:jboss:galleon:feature-group:1.0">
 
     <feature spec="socket-binding-group.socket-binding">
-        <param name="socket-binding" value="ajp"/>
-        <param name="port" value="${jboss.ajp.port:8009}"/>
-    </feature>
-    <feature spec="socket-binding-group.socket-binding">
         <param name="socket-binding" value="http"/>
         <param name="port" value="${jboss.http.port:8080}"/>
     </feature>

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/unsecured-basic-ha-profile.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/unsecured-basic-ha-profile.xml
@@ -18,7 +18,6 @@
         </include>
     </feature-group>
 
-    <feature-group name="undertow-ajp-listener"/>
     <feature-group name="modcluster"/>
     <feature-group name="infinispan-dist"/>
     <feature-group name="jgroups"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/mod_cluster/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/mod_cluster/layer-spec.xml
@@ -15,7 +15,6 @@
         <layer name="web-server"/>
     </dependencies>
 
-    <feature-group name="undertow-ajp-listener"/>
     <feature-group name="modcluster"/>
 
     <feature spec="socket-binding-group">

--- a/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerResourceDefinition.java
@@ -15,6 +15,7 @@ import io.undertow.UndertowOptions;
 import io.undertow.protocols.ajp.AjpClientRequestClientStreamSinkChannel;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.DeprecationData;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
@@ -56,7 +57,11 @@ public class AjpListenerResourceDefinition extends ListenerResourceDefinition {
     static final List<AttributeDefinition> ATTRIBUTES = List.of(SCHEME, REDIRECT_SOCKET, MAX_AJP_PACKET_SIZE, ALLOWED_REQUEST_ATTRIBUTES_PATTERN);
 
     AjpListenerResourceDefinition() {
-        super(new SimpleResourceDefinition.Parameters(PATH_ELEMENT, UndertowExtension.getResolver(Constants.LISTENER)), new AjpListenerAdd(), Map.of());
+        super(new SimpleResourceDefinition.Parameters(PATH_ELEMENT, UndertowExtension.getResolver(Constants.LISTENER))
+                        .setDeprecationData(new DeprecationData(UndertowSubsystemModel.VERSION_15_0_0.getVersion())),
+                new AjpListenerAdd(),
+                Map.of()
+        );
     }
 
     @Override

--- a/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
+++ b/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
@@ -185,6 +185,8 @@ undertow.single-sign-on.credential-reference.type=The type of credential this re
 undertow.single-sign-on.credential-reference.clear-text=The secret specified using clear text. Check credential store way of supplying credential/secrets to services.
 undertow.single-sign-on.client-ssl-context=Reference to the SSL context used to secure back-channel logout connection.
 undertow.listener=http listener
+undertow.listener.deprecated=The AJP connector is deprecated due to inherent security deficiencies (no encryption, no authentication, CVEs), inability to support modern protocols (WebSocket, HTTP/2), and protocol stagnation (no development since 2001). \
+Migrate to HTTP proxying which offers all the same functionality with proper TLS and mutual authentication support.
 undertow.listener.add=Add listener
 undertow.listener.remove=Listener name
 undertow.listener.name=The listener name


### PR DESCRIPTION
- Mark ajp-listener resource as deprecated since model version 15.0.0
- Remove AJP listener and socket binding from default configuration
- Update mod_cluster default listener from AJP to HTTP

Our deprecation message is this:

The AJP connector is deprecated due to inherent security deficiencies (no encryption, no authentication, CVEs), inability to support modern protocols (WebSocket, HTTP/2), and protocol stagnation (no development since 2001). Migrate to HTTP proxying which offers all the same functionality with proper TLS and mutual authentication support.

Jira
https://redhat.atlassian.net/browse/WFLY-22024