### PR TITLE
Ignore Hibernate Validator in dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,7 @@ updates:
       # and when we do we want to check other components where we align with what ORM uses.
       - dependency-name: 'org.hibernate.orm:*'
       - dependency-name: 'org.hibernate:hibernate-core'
+      - dependency-name: 'org.hibernate.validator:*'
       # Dependencies exclusive to Hibernate Search:
       # we'll only upgrade those when we upgrade to a newer version of Hibernate Search.
       - dependency-name: 'org.elasticsearch.client:*'


### PR DESCRIPTION
@scottmarlow Did you meant  to ignore this one as well given that dependabot cannot upgrade that correctly either? i.e. https://github.com/wildfly/wildfly/pull/20173

@wildfly-bot[bot] skip format

