### PR TITLE
[WFLY-20744] Throw ISE in case ConcurrentContextService is not started

### DIFF
--- a/concurrency/spi/src/main/java/org/jboss/as/ee/concurrent/ConcurrentContext.java
+++ b/concurrency/spi/src/main/java/org/jboss/as/ee/concurrent/ConcurrentContext.java
@@ -86,6 +86,14 @@ public class ConcurrentContext {
 
     /**
      *
+     * @return
+     */
+    public ServiceName getServiceName() {
+        return serviceName;
+    }
+
+    /**
+     *
      * @param serviceName
      */
     public void setServiceName(ServiceName serviceName) {
@@ -166,6 +174,9 @@ public class ConcurrentContext {
 
         @Override
         public ResetContextHandle setup() throws IllegalStateException {
+            if (concurrentContext.getServiceName() == null) {
+                throw EeLogger.ROOT_LOGGER.serviceNotStarted();
+            }
             final LinkedList<ResetContextHandle> resetHandles = new LinkedList<>();
             final ResetContextHandle resetContextHandle = new ChainedResetContextHandle(resetHandles);
             try {

--- a/concurrency/spi/src/main/java/org/jboss/as/ee/concurrent/ConcurrentContextSetupAction.java
+++ b/concurrency/spi/src/main/java/org/jboss/as/ee/concurrent/ConcurrentContextSetupAction.java
@@ -7,7 +7,6 @@ package org.jboss.as.ee.concurrent;
 import org.jboss.as.server.deployment.SetupAction;
 import org.jboss.msc.service.ServiceName;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -17,9 +16,11 @@ import java.util.Set;
 public class ConcurrentContextSetupAction implements SetupAction {
 
     private final ConcurrentContext concurrentContext;
+    private final ServiceName serviceName;
 
-    public ConcurrentContextSetupAction(ConcurrentContext concurrentContext) {
+    public ConcurrentContextSetupAction(ConcurrentContext concurrentContext, ServiceName serviceName) {
         this.concurrentContext = concurrentContext;
+        this.serviceName = serviceName;
     }
 
     @Override
@@ -39,7 +40,7 @@ public class ConcurrentContextSetupAction implements SetupAction {
 
     @Override
     public Set<ServiceName> dependencies() {
-        return Collections.emptySet();
+        return Set.of(serviceName);
     }
 
     public ConcurrentContext getConcurrentContext() {

--- a/concurrency/spi/src/main/java/org/jboss/as/ee/concurrent/deployers/EEConcurrentContextProcessor.java
+++ b/concurrency/spi/src/main/java/org/jboss/as/ee/concurrent/deployers/EEConcurrentContextProcessor.java
@@ -93,9 +93,9 @@ public class EEConcurrentContextProcessor implements DeploymentUnitProcessor {
     private void processModuleDescription(final EEModuleDescription moduleDescription, DeploymentUnit deploymentUnit, DeploymentPhaseContext phaseContext, ServiceName localTransactionProviderCapabilityServiceName) {
         final ConcurrentContext concurrentContext = new ConcurrentContext();
         // setup context
-        setupConcurrentContext(concurrentContext, moduleDescription.getApplicationName(), moduleDescription.getModuleName(), null, deploymentUnit.getAttachment(MODULE).getClassLoader(), moduleDescription.getNamespaceContextSelector(), deploymentUnit, phaseContext.getServiceTarget(), localTransactionProviderCapabilityServiceName);
+        final ServiceName serviceName = setupConcurrentContext(concurrentContext, moduleDescription.getApplicationName(), moduleDescription.getModuleName(), null, deploymentUnit.getAttachment(MODULE).getClassLoader(), moduleDescription.getNamespaceContextSelector(), deploymentUnit, phaseContext.getServiceTarget(), localTransactionProviderCapabilityServiceName);
         // attach setup action
-        final ConcurrentContextSetupAction setupAction = new ConcurrentContextSetupAction(concurrentContext);
+        final ConcurrentContextSetupAction setupAction = new ConcurrentContextSetupAction(concurrentContext, serviceName);
         deploymentUnit.putAttachment(ConcurrencyAttachments.CONCURRENT_CONTEXT_SETUP_ACTION, setupAction);
         deploymentUnit.addToAttachmentList(Attachments.WEB_SETUP_ACTIONS, setupAction);
     }
@@ -113,7 +113,8 @@ public class EEConcurrentContextProcessor implements DeploymentUnitProcessor {
                     }
                 }
                 // setup context
-                setupConcurrentContext(concurrentContext, description.getApplicationName(), description.getModuleName(), description.getComponentName(), configuration.getModuleClassLoader(), configuration.getNamespaceContextSelector(), context.getDeploymentUnit(), context.getServiceTarget(), localTransactionProviderCapabilityServiceName);
+                final ServiceName serviceName = setupConcurrentContext(concurrentContext, description.getApplicationName(), description.getModuleName(), description.getComponentName(), configuration.getModuleClassLoader(), configuration.getNamespaceContextSelector(), context.getDeploymentUnit(), context.getServiceTarget(), localTransactionProviderCapabilityServiceName);
+                componentDescription.addDependency(serviceName);
                 // add the interceptor which manages the concurrent context
                 final ConcurrentContextInterceptor interceptor = new ConcurrentContextInterceptor(concurrentContext);
                 final InterceptorFactory interceptorFactory = new ImmediateInterceptorFactory(interceptor);
@@ -141,7 +142,7 @@ public class EEConcurrentContextProcessor implements DeploymentUnitProcessor {
      * @param serviceTarget
      * @param localTransactionProviderCapabilityServiceName the service name of the local tx provider capability. If not present this param should be null
      */
-    private void setupConcurrentContext(ConcurrentContext concurrentContext, String applicationName, String moduleName, String componentName, ClassLoader moduleClassLoader, NamespaceContextSelector namespaceContextSelector, DeploymentUnit deploymentUnit, ServiceTarget serviceTarget, ServiceName localTransactionProviderCapabilityServiceName) {
+    private ServiceName setupConcurrentContext(ConcurrentContext concurrentContext, String applicationName, String moduleName, String componentName, ClassLoader moduleClassLoader, NamespaceContextSelector namespaceContextSelector, DeploymentUnit deploymentUnit, ServiceTarget serviceTarget, ServiceName localTransactionProviderCapabilityServiceName) {
         // add default factories
         concurrentContext.addFactory(new NamingContextHandleFactory(namespaceContextSelector, deploymentUnit.getServiceName()));
         concurrentContext.addFactory(new ClassLoaderContextHandleFactory(moduleClassLoader));
@@ -164,6 +165,7 @@ public class EEConcurrentContextProcessor implements DeploymentUnitProcessor {
             serviceBuilder.requires(localTransactionProviderCapabilityServiceName);
         }
         serviceBuilder.install();
+        return serviceName;
     }
 
     @Override

--- a/concurrency/spi/src/main/java/org/jboss/as/ee/concurrent/service/ConcurrentContextService.java
+++ b/concurrency/spi/src/main/java/org/jboss/as/ee/concurrent/service/ConcurrentContextService.java
@@ -18,7 +18,6 @@ import org.jboss.msc.service.StopContext;
 public class ConcurrentContextService implements Service<ConcurrentContext> {
 
     private final ConcurrentContext concurrentContext;
-    private volatile boolean started;
 
     public ConcurrentContextService(ConcurrentContext concurrentContext) {
         this.concurrentContext = concurrentContext;
@@ -26,18 +25,17 @@ public class ConcurrentContextService implements Service<ConcurrentContext> {
 
     @Override
     public void start(StartContext context) throws StartException {
-        started = true;
         concurrentContext.setServiceName(context.getController().getName());
     }
 
     @Override
     public void stop(StopContext context) {
-        started = false;
+        concurrentContext.setServiceName(null);
     }
 
     @Override
     public ConcurrentContext getValue() throws IllegalStateException, IllegalArgumentException {
-        if(!started) {
+        if(concurrentContext.getServiceName() == null) {
             throw EeLogger.ROOT_LOGGER.serviceNotStarted();
         }
         return concurrentContext;


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/WFLY-20744
Description: in short we use the ConcurrentContext service to learn if the deployment is running or not, and if not we invalidate the context setup, what leads to the abort and cancelling of periodic tasks left over by the deployment.
The changes regarding Component and Web/CDI setup action were due to an unknown issue, those components were not depending on the ConcurrentContextService, and with the main change this additional issue was noticed in our testsuite.