### PR TITLE
WFLY-22038 Coarse/FineHotRodSessionExpirationTestCase fails intermittently - use dedicated deployment descriptors for HotRod session expiration tests

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/CoarseHotRodSessionExpirationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/CoarseHotRodSessionExpirationTestCase.java
@@ -33,7 +33,7 @@ public class CoarseHotRodSessionExpirationTestCase extends AbstractHotRodSession
 
     static WebArchive getDeployment() {
         return getBaseDeployment(MODULE_NAME)
-                .addAsWebInfResource(CoarseHotRodSessionExpirationTestCase.class.getPackage(), "jboss-all_coarse.xml", "jboss-all.xml")
+                .addAsWebInfResource(CoarseHotRodSessionExpirationTestCase.class.getPackage(), "jboss-all_coarse_expiration.xml", "jboss-all.xml")
                 .addAsWebInfResource(CoarseHotRodSessionExpirationTestCase.class.getPackage(), "jboss-web.xml", "jboss-web.xml")
                 ;
     }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/FineHotRodSessionExpirationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/FineHotRodSessionExpirationTestCase.java
@@ -33,7 +33,7 @@ public class FineHotRodSessionExpirationTestCase extends AbstractHotRodSessionEx
 
     static WebArchive getDeployment() {
         return getBaseDeployment(MODULE_NAME)
-                .addAsWebInfResource(FineHotRodSessionExpirationTestCase.class.getPackage(), "jboss-all_fine.xml", "jboss-all.xml")
+                .addAsWebInfResource(FineHotRodSessionExpirationTestCase.class.getPackage(), "jboss-all_fine_expiration.xml", "jboss-all.xml")
                 .addAsWebInfResource(FineHotRodSessionExpirationTestCase.class.getPackage(), "jboss-web.xml", "jboss-web.xml")
                 ;
     }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/jboss-all_coarse_expiration.xml
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/jboss-all_coarse_expiration.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<jboss xmlns="urn:jboss:1.0">
+    <distributable-web xmlns="urn:jboss:distributable-web:5.0">
+        <!-- Define 'cache-configuration' to use the server template defined in infinispan.xml with a 1-second expiration reaper interval -->
+        <hotrod-session-management remote-cache-container="web" cache-configuration="default" granularity="SESSION">
+            <local-affinity/>
+        </hotrod-session-management>
+    </distributable-web>
+</jboss>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/jboss-all_fine_expiration.xml
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/jboss-all_fine_expiration.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<jboss xmlns="urn:jboss:1.0">
+    <distributable-web xmlns="urn:jboss:distributable-web:5.0">
+        <!-- Define 'cache-configuration' to use the server template defined in infinispan.xml with a 1-second expiration reaper interval -->
+        <hotrod-session-management remote-cache-container="web" cache-configuration="default" granularity="ATTRIBUTE">
+            <local-affinity/>
+        </hotrod-session-management>
+    </distributable-web>
+</jboss>


### PR DESCRIPTION

The DEFAULT_CONFIGURATION used by jboss-all_fine.xml omits expiration settings, so the Infinispan server defaults to a 60-second reaper wake-up interval causing the expiration test to miss the reaper cycle. Use a dedicated descriptor with cache-configuration="default" referencing the server template that defines a 1-second expiration reaper interval.

https://redhat.atlassian.net/browse/WFLY-22038