### PR TITLE
WFLY-22039 Add Weld dependencies to `jakarta.persistence.api` module

### DIFF
--- a/ee-feature-pack/galleon-shared-preview/src/main/resources/modules/system/layers/base/jakarta/persistence/api/main/module.xml
+++ b/ee-feature-pack/galleon-shared-preview/src/main/resources/modules/system/layers/base/jakarta/persistence/api/main/module.xml
@@ -19,5 +19,9 @@
         <module name="java.sql" export="true"/>
         <!-- Persistence integration with CDI needs the following CDI API -->
         <module name="jakarta.enterprise.api"/>
+        <!-- Weld needs these to define proxy classes in this module's classloader -->
+        <module name="org.jboss.weld.api" optional="true"/>
+        <module name="org.jboss.weld.core" optional="true"/>
+        <module name="org.jboss.weld.spi" optional="true"/>
     </dependencies>
 </module>


### PR DESCRIPTION
JIRA - https://redhat.atlassian.net/browse/WFLY-22039

This was reproducible taking a kitchensink quickstart and adding an eagerly initialized bean that has `@Inject EntityManagerFactory emf;`. With this fix in place, I can no longer see the warning logged.

For some background, this was likely via https://github.com/wildfly/wildfly/commit/cfdec6937c98f3aab611915a3a2a7305719776cc where a CDI extension registering normal scoped beans was introduced.
This prompts Weld to create proxies and determines that the JPA module is the place they should land in. Failing to have deps on Weld results in the logging that was reported on Zulip:

> WARN  [org.jboss.as.weld] (ServerService Thread Pool -- 90) WFLYWELD0052: Using deployment classloader to load proxy classes for module jakarta.persistence.api. Package-private access will not work. To fix this the module should declare dependencies on [org.jboss.weld.core, org.jboss.weld.spi, org.jboss.weld.api]