### PR TITLE
[WFLY-21772] Remove unnecessary domain[-ha]-profile feature group dif…

### DIFF
--- a/preview/galleon-local/src/main/resources/feature_groups/domain-ha-profile.xml
+++ b/preview/galleon-local/src/main/resources/feature_groups/domain-ha-profile.xml
@@ -6,7 +6,7 @@
 
 <feature-group-spec name="domain-ha-profile" xmlns="urn:jboss:galleon:feature-group:1.0">
 
-    <feature-group name="servlet-unsecured-domain-profile">
+    <feature-group name="servlet-domain-profile">
         <exclude spec="subsystem.jmx.remoting-connector.jmx"/>
     </feature-group>
 

--- a/preview/galleon-local/src/main/resources/feature_groups/domain-profile.xml
+++ b/preview/galleon-local/src/main/resources/feature_groups/domain-profile.xml
@@ -6,7 +6,7 @@
 
 <feature-group-spec name="domain-profile" xmlns="urn:jboss:galleon:feature-group:1.0">
 
-    <feature-group name="servlet-unsecured-domain-profile" />
+    <feature-group name="servlet-domain-profile" />
 
     <feature-group name="basic-profile"/>
     <feature-group name="infinispan-local"/>


### PR DESCRIPTION
…ferences between WFP and standard WF

https://redhat.atlassian.net/browse/WFLY-21772

This has no effect on what ends up being provisioned because the resources that are different between the feature-groups changed by this end up being provisioned for other reasons. So this is just codebase housekeeping to save maintainers wondering why code differs in the different feature-packs.