### PR TITLE
WFLY-22020 Standardize installation directory variable naming JBOSS_HOME/ WFLY_HOME/ WILDFLY_HOME/ YOUR_JBOSS_HOME/ JBOSSHOME/ EAP_HOME / etc in documentation

### DIFF
--- a/docs/src/main/asciidoc/Different_Flavors_of_WildFly.adoc
+++ b/docs/src/main/asciidoc/Different_Flavors_of_WildFly.adoc
@@ -289,7 +289,7 @@ more of a cloud native appserver and having an embedded messaging broker in the 
 A WildFly container in the cloud running an embedded broker is not scalable, as multiple broker instances need separate
 configuration to act as a primary or backup. An embedded messaging broker also has more advanced persistent storage
 requirements than a server primarily dedicated to handling HTTP requests would have. Note however that running an
-embedded broker is still supported. We've added to the $WILDFLY_HOME/docs/examples/configs folder an example
+embedded broker is still supported. We've added to the $JBOSS_HOME/docs/examples/configs folder an example
 ``standalone-activemq-embedded.xml`` configuration showing its use.
 * WildFly Preview provides the link:Admin_Guide{outfilesuffix}#Micrometer_Metrics[`micrometer` subsystem] in its out-of-the-box `standalone.xml`, `standalone-ha.xml`, `standalone-full.xml` and `standalone-full-ha.xml` configuration files, while standard WildFly instead provides the basic link:Admin_Guide{outfilesuffix}#MicroProfile_Metrics_SmallRye[`metrics` subsystem].
 * WildFly Preview includes a new xref:Admin_Guide.adoc#Feature_stability_levels[`preview` stability] `org.wildfly.extension.vertx` extension and its `vertx` subsystem, along with a new `vertx` Galleon layer so you can provision it in a slimmed server. This subsystem can be used to configure the Vert.x instance used by our OpenTelemetry integration.

--- a/docs/src/main/asciidoc/Getting_Started_Guide.adoc
+++ b/docs/src/main/asciidoc/Getting_Started_Guide.adoc
@@ -208,7 +208,7 @@ related to the release.
 
 Once you have installed WildFly {wildflyVersion} from a Zip archive, you can create a Linux service so it can be started/stopped automatically when your system boots up or is shut down.
 
-The following steps describe the process to configure WildFly as a systemd service. WildFly is shipped with a default systemd unit file configuration for Standalone and Domain mode. These wildfly-[standalone,domain].service files are located at the `$WFLY_HOME/bin/systemd` directory and assume that by default WildFly was installed at `/opt/wildfly` directory and would be launched with the `wildfly:wildfly` user:group. These files can be adjusted by you to cover your needs, for example, you can change the user that runs the service, the location of the WildFly installation you want to launch, the locations of the logs, and so on.
+The following steps describe the process to configure WildFly as a systemd service. WildFly is shipped with a default systemd unit file configuration for Standalone and Domain mode. These wildfly-[standalone,domain].service files are located at the `$JBOSS_HOME/bin/systemd` directory and assume that by default WildFly was installed at `/opt/wildfly` directory and would be launched with the `wildfly:wildfly` user:group. These files can be adjusted by you to cover your needs, for example, you can change the user that runs the service, the location of the WildFly installation you want to launch, the locations of the logs, and so on.
 
 Alternatively, you can use the `generate_systemd_unit.sh` script to automatically generate a new systemd unit file
 using your current server installation as the WildFly home, or to specify a different user/group.
@@ -221,33 +221,33 @@ First, create the user and group that will be used to launch the server:
 [source,shell,options="nowrap"]
 ----
 groupadd -r javagroup
-useradd -r -g javagroup -d $WFLY_HOME -s /sbin/nologin javauser
-chown -R javauser:javagroup $WFLY_HOME
+useradd -r -g javagroup -d $JBOSS_HOME -s /sbin/nologin javauser
+chown -R javauser:javagroup $JBOSS_HOME
 ----
 
 Secondly, generate the systemd unit file, in this example, we are generating the systemd unit file for a standalone server:
 [source,shell,options="nowrap"]
 ----
-cd $WFLY_HOME/bin/systemd
+cd $JBOSS_HOME/bin/systemd
 ./generate_systemd_unit.sh standalone javauser javagroup
 ----
 
-Thirdly, edit the `$WFLY_HOME/bin/systemd/wildfly-standalone.conf` file to configure the server environment, for example, to specify the JAVA_HOME environment variable, to add additional properties to the server launch command, and so on:
+Thirdly, edit the `$JBOSS_HOME/bin/systemd/wildfly-standalone.conf` file to configure the server environment, for example, to specify the JAVA_HOME environment variable, to add additional properties to the server launch command, and so on:
 [source,shell,options="nowrap"]
 ----
-vim $WFLY_HOME/bin/systemd/wildfly-standalone.conf
+vim $JBOSS_HOME/bin/systemd/wildfly-standalone.conf
 ----
 
 Finally, copy the systemd unit file and the server configuration file to the expected location and enable the service:
 [source,shell,options="nowrap"]
 ----
-cp $WFLY_HOME/bin/systemd/wildfly-standalone.service $(pkg-config systemd --variable=systemdsystemunitdir)
-cp $WFLY_HOME/bin/systemd/wildfly-standalone.conf /etc/sysconfig/
+cp $JBOSS_HOME/bin/systemd/wildfly-standalone.service $(pkg-config systemd --variable=systemdsystemunitdir)
+cp $JBOSS_HOME/bin/systemd/wildfly-standalone.conf /etc/sysconfig/
 systemctl enable wildfly-standalone
 systemctl start wildfly-standalone
 ----
 
-If you want to remove the service, revert the above changes in an inverse order. For more information, consult the README file available in the `$WFLY_HOME/bin/systemd` directory.
+If you want to remove the service, revert the above changes in an inverse order. For more information, consult the README file available in the `$JBOSS_HOME/bin/systemd` directory.
 
 [[wildfly---a-quick-tour]]
 == WildFly - A Quick Tour

--- a/docs/src/main/asciidoc/_admin-guide/CLI_Recipes.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/CLI_Recipes.adoc
@@ -672,7 +672,7 @@ for a complete description of the command.
 [[mp-cli-script]]
 == Evolving standard configurations with support for MicroProfile
 
-The CLI script _JBOSS_HOME/docs/examples/enable-microprofile.cli_ can be applied to a default standalone configuration
+The CLI script _$JBOSS_HOME/docs/examples/enable-microprofile.cli_ can be applied to a default standalone configuration
 to add support for MicroProfile.
 
 Impact on updated configuration:

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Deployment_Scanner.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Deployment_Scanner.adoc
@@ -23,7 +23,7 @@ found in `standalone.xml`:
 
 You can define more `deployment-scanner` entries to scan for deployments
 from more locations. The configuration showed will scan the
-`JBOSS_HOME/standalone/deployments` directory every five seconds. The
+`$JBOSS_HOME/standalone/deployments` directory every five seconds. The
 runtime model is shown below, and uses default values for attributes not
 specified in the xml:
 
@@ -60,7 +60,7 @@ case the value is treated as relative to that path.
 |relative-to |STRING |Reference to a filesystem path defined in the
 "paths" section of the server configuration, or one of the system
 properties specified on startup. In the example above
-jboss.server.base.dir resolves to JBOSS_HOME/standalone
+jboss.server.base.dir resolves to $JBOSS_HOME/standalone
 
 |scan-enabled |BOOLEAN |If true scanning is enabled
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/JMX.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/JMX.adoc
@@ -58,9 +58,9 @@ paste your script when you have it working.
 !/bin/bash
 
 # specify your WildFly folder +
-export YOUR_JBOSS_HOME=~/WildFly
+export JBOSS_HOME=~/WildFly
 
-java -classpath $YOUR_JBOSS_HOME/bin/client/jboss-client.jar:./
+java -classpath $JBOSS_HOME/bin/client/jboss-client.jar:./
 JMXExample
 
 ----

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Jakarta_Enterprise_Beans_3.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Jakarta_Enterprise_Beans_3.adoc
@@ -358,7 +358,7 @@ following fields:
 * `class` - the class which implements the interceptor
 
 In order to use server interceptors you have to create a module that implements
-them and place it into _${WILDFLY_HOME}/modules_ directory.
+them and place it into the _$JBOSS_HOME/modules_ directory.
 
 Interceptor implementations are POJO classes which use
 _jakarta.interceptor.AroundInvoke_ and _jakarta.interceptor.AroundTimeout_ to
@@ -404,7 +404,7 @@ following fields:
 * `class` - the class which implements the interceptor
 
 In order to use server interceptors you have to create a module that implements
-them and place it into _${WILDFLY_HOME}/modules_ directory.
+them and place it into the _$JBOSS_HOME/modules_ directory.
 
 Interceptor implementations must implement _org.jboss.ejb.client.EJBClientInterceptor_
 interface.

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging.adoc
@@ -473,7 +473,7 @@ Jakarta Messaging jar since it will be provided by a WildFly module directly.
 To use these resources in a Jakarta Messaging bridge, we must bundle them in a WildFly
 module:
 
-in JBOSS_HOME/modules, we create the layout:
+in $JBOSS_HOME/modules, we create the layout:
 
 [source,options="nowrap"]
 ----

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Undertow_using_as_a_Load_Balancer.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Undertow_using_as_a_Load_Balancer.adoc
@@ -50,13 +50,13 @@ WildFly 11 added load balancer profiles for both standalone and domain modes.
 [source,options="nowrap"]
 ----
 # configure correct path to WildFly installation
-WILDFLY_HOME=/path/to/wildfly
+JBOSS_HOME=/path/to/wildfly
 
 # configure correct IP of the node
 MY_IP=192.168.1.1
 
 # run the load balancer profile
-$WILDFLY_HOME/bin/standalone.sh -b $MY_IP -bprivate $MY_IP -c standalone-load-balancer.xml
+$JBOSS_HOME/bin/standalone.sh -b $MY_IP -bprivate $MY_IP -c standalone-load-balancer.xml
 ----
 
 It's highly recommended to use private/internal network for communication between load balancer and nodes.
@@ -71,14 +71,14 @@ If it's not the case, then configure the IP address of the load balancer statica
 [source,options="nowrap"]
 ----
 # configure correct path to WildFly installation
-WILDFLY_HOME=/path/to/wildfly
+JBOSS_HOME=/path/to/wildfly
 # configure correct IP of the node
 MY_IP=192.168.1.2
 
 # Configure static load balancer IP address.
 # This is necessary when UDP multicast doesn't work in your environment.
 LOAD_BALANCER_IP=192.168.1.1
-$WILDFLY_HOME/bin/jboss-cli.sh <<EOT
+$JBOSS_HOME/bin/jboss-cli.sh <<EOT
 
 embed-server -c=standalone-ha.xml
 /subsystem=modcluster/proxy=default:write-attribute(name=advertise, value=false)
@@ -87,7 +87,7 @@ embed-server -c=standalone-ha.xml
 EOT
 
 # start the woker node with HA profile
-$WILDFLY_HOME/bin/standalone.sh -c standalone-ha.xml -b $MY_IP -bprivate $MY_IP
+$JBOSS_HOME/bin/standalone.sh -c standalone-ha.xml -b $MY_IP -bprivate $MY_IP
 ----
 
 Again, to make it safe, users should configure private/internal IP address into `MY_IP` variable.

--- a/docs/src/main/asciidoc/_developer-guide/H2_Web_Console_Integration.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/H2_Web_Console_Integration.adoc
@@ -19,7 +19,7 @@ WildFly has historically integrated H2 in such a way that this is possible. But 
 
 However it is possible for users of WildFly to restore this integration by adding a JBoss Modules module named `javax.servlet.api.h2` to their server installation. The steps to do this are as follows:
 
-* `cd $WILDFLY_HOME`
+* `cd $JBOSS_HOME`
 * `mkdir -p modules/javax/servlet/api/h2`
 * In that dir create a `module.xml` file with the following content:
 

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_invocations_from_a_remote_client_using_JNDI.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_invocations_from_a_remote_client_using_JNDI.adoc
@@ -639,11 +639,11 @@ be
 == Using the jboss-client.jar
 
 A jboss-client jar is shipped in the distribution. It's available at
-WILDFLY_HOME/bin/client/jboss-client.jar. Place this jar in the
+$JBOSS_HOME/bin/client/jboss-client.jar. Place this jar in the
 classpath of your client application.
 
 If you are using Maven to build the client application, then please
-follow the instructions in the WILDFLY_HOME/bin/client/README.txt to add
+follow the instructions in the $JBOSS_HOME/bin/client/README.txt to add
 this jar as a Maven dependency.
 
 [NOTE]

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_invocations_from_a_remote_server_instance.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_invocations_from_a_remote_server_instance.adoc
@@ -96,7 +96,7 @@ this.
 
 As a first step we'll configure a user on the destination server who
 will be allowed to access the destination server. We create the user
-using the `add-user` script that's available in the JBOSS_HOME/bin
+using the `add-user` script that's available in the $JBOSS_HOME/bin
 folder. In this example, we'll be configuring a `Application User` named
 `ejb` and with a password `test` in the `ApplicationRealm`. Running the
 `add-user` script is an interactive process and you will see
@@ -177,7 +177,7 @@ The application ( _myapp.ear_ in our case) will be deployed to
 "Destination Server". The process of deploying the application is out of
 scope of this chapter. You can either use the Command Line Interface or
 the Admin console or any IDE or manually copy it to
-JBOSS_HOME/standalone/deployments folder (for standalone server). Just
+$JBOSS_HOME/standalone/deployments folder (for standalone server). Just
 ensure that the application has been deployed successfully.
 
 So far, we have built a EJB application and deployed it on the
@@ -408,7 +408,7 @@ connector on the "Destination Server".
 Let's deploy the client application on the "Client Server". The process
 of deploying the application is out of scope, of this chapter. You can
 use either the CLI or the admin console or a IDE or deploy manually to
-JBOSS_HOME/standalone/deployments folder. Just ensure that the
+$JBOSS_HOME/standalone/deployments folder. Just ensure that the
 application is deployed successfully.
 
 [[client-code-invoking-the-bean]]

--- a/docs/src/main/asciidoc/_elytron/Client_Authentication_with_Elytron_Client.adoc
+++ b/docs/src/main/asciidoc/_elytron/Client_Authentication_with_Elytron_Client.adoc
@@ -414,7 +414,7 @@ outside of the client code.
 
 If it does not find one, it will try and use the default
 _wildfly-config.xml_ provided in the
-_$WILDFLY_HOME/bin/client/jboss-client.jar_.
+_$JBOSS_HOME/bin/client/jboss-client.jar_.
 
 *default wildfly-config.xml*
 

--- a/docs/src/main/asciidoc/_elytron/Elytron_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_elytron/Elytron_Subsystem.adoc
@@ -452,14 +452,14 @@ and sets the identity of principals to $local
 realm that authenticates principals using application-users.properties
 and assigns roles using application-roles.properties. These files are
 located under jboss.server.config.dir, which by default, maps to
-EAP_HOME/standalone/configuration. They are also the same files used by
+$JBOSS_HOME/standalone/configuration. They are also the same files used by
 the legacy security default configuration.
 
 |ManagementRealm |The ManagementRealm security realm is a properties
 realm that authenticates principals using mgmt-users.properties and
 assigns roles using mgmt-groups.properties. These files are located
 under jboss.server.config.dir, which by default, maps to
-EAP_HOME/standalone/configuration. They are also the same files used by
+$JBOSS_HOME/standalone/configuration. They are also the same files used by
 the legacy security default configuration.
 
 |default-permission-mapper |The default-permission-mapper mapper is a

--- a/docs/src/main/asciidoc/_elytron/OpenSSL.adoc
+++ b/docs/src/main/asciidoc/_elytron/OpenSSL.adoc
@@ -94,7 +94,7 @@ We'll make use of this in the next step.
 === Overriding the Existing WildFly OpenSSL Module
 
 We're going to add a new module that will override the existing WildFly OpenSSL module that's found in the
-`$WILDFLY_HOME/modules/system/layers/base/org/wildfly/openssl` directory. Notice that the existing module
+`$JBOSS_HOME/modules/system/layers/base/org/wildfly/openssl` directory. Notice that the existing module
 contains a Java artifact in its `main` directory and native libraries for the default platforms in its
 `main/lib` directory.
 
@@ -102,21 +102,21 @@ First, create a new module that contains the WildFly OpenSSL Java artifact from 
 
 [source,shell]
 ----
-module add --name=org.wildfly.openssl --resources=$WILDFLY_HOME/modules/system/layers/base/org/wildfly/openssl/main/wildfly-openssl-java-VERSION.jar --dependencies=java.logging,jdk.unsupported
+module add --name=org.wildfly.openssl --resources=$JBOSS_HOME/modules/system/layers/base/org/wildfly/openssl/main/wildfly-openssl-java-VERSION.jar --dependencies=java.logging,jdk.unsupported
 ----
 
 Next, add the native library that we already built to this newly created module:
 
 [source,shell]
 ----
-mkdir $WILDFLY_HOME/modules/org/wildfly/openssl/main/lib
-cd $WILDFLY_HOME/modules/org/wildfly/openssl/main/lib
+mkdir $JBOSS_HOME/modules/org/wildfly/openssl/main/lib
+cd $JBOSS_HOME/modules/org/wildfly/openssl/main/lib
 jar xvf $WILDFLY_OPENSSL_NATIVES/linux-i386/target/wildfly-openssl-linux-i386-VERSION.jar linux-i386
 ----
 
-You should now see a `libwfssl.so` file in the `$WILDFLY_HOME/modules/org/wildfly/openssl/main/lib/linux-i386` directory.
+You should now see a `libwfssl.so` file in the `$JBOSS_HOME/modules/org/wildfly/openssl/main/lib/linux-i386` directory.
 
 That's it, WildFly will now make use of the newly added WildFly OpenSSL module instead of the existing one,
 allowing it to make use of the new native library when running on the Linux i386 platform. Additional
-native libraries can be added to the `$WILDFLY_HOME/modules/org/wildfly/openssl/main/lib` directory
+native libraries can be added to the `$JBOSS_HOME/modules/org/wildfly/openssl/main/lib` directory
 if desired.

--- a/docs/src/main/asciidoc/_elytron/components/Filesystem_Security_Realm.adoc
+++ b/docs/src/main/asciidoc/_elytron/components/Filesystem_Security_Realm.adoc
@@ -297,7 +297,7 @@ The feature also creates a CLI script that can be used to add a key-store resour
 
 In order to use this feature, we can make use of the `elytron-tool.sh` (or .bat for windows) script. The format for the command to add integrity checking is as follows:
 ```
-$ WILDFLY_HOME/bin/elytron-tool.sh filesystem-realm-integrity --input-location <existing_path> --output-location <new_path> --keystore <ks_path> --password <ks_password> --summary
+$ $JBOSS_HOME/bin/elytron-tool.sh filesystem-realm-integrity --input-location <existing_path> --output-location <new_path> --keystore <ks_path> --password <ks_password> --summary
 ```
 
 The required options include:
@@ -309,7 +309,7 @@ The required options include:
 
 The elytron tool also allows for the conversion to be done in bulk, as in multiple filesystems can be converted all at once. This can be done using the following command: 
 ```
-$ WILDFLY_HOME/bin/elytron-tool.sh filesystem-realm-integrity --bulk-convert <descriptor> 
+$ $JBOSS_HOME/bin/elytron-tool.sh filesystem-realm-integrity --bulk-convert <descriptor> 
 ```
 In this case `<descriptor>` is a file, which contains the instructions for bulk conversion. An example of a descriptor file is shown below. Notice that each block contains the options to use for converting a single realm. Additionally, in addition to specifying the `input-location`, we have specified the `realm-name` as well. 
 ```

--- a/docs/src/main/asciidoc/_high-availability/load-balancing/SSL_Configuration_using_Elytron_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_high-availability/load-balancing/SSL_Configuration_using_Elytron_Subsystem.adoc
@@ -47,7 +47,7 @@ command:
 
 In order to successfully execute the command above you must have a
 *application.truststore* file inside your
-*JBOSS_HOME/standalone/configuration* directory. Where the trust store
+*$JBOSS_HOME/standalone/configuration* directory. Where the trust store
 is protected by a password with a value *password*. The trust store must
 contain the certificates associated with the load balancer or a
 certificate chain in case the load balancer's certificate is signed by a

--- a/jdr/src/main/java/org/jboss/as/jdr/util/JdrZipFile.java
+++ b/jdr/src/main/java/org/jboss/as/jdr/util/JdrZipFile.java
@@ -101,7 +101,7 @@ public class JdrZipFile {
     /**
      * Adds the content of the {@link InputStream} to the zip in a location that mirrors where {@link VirtualFile file} is located.
      *
-     * For example if {@code file} is at {@code /tmp/foo/bar} and {@code $JBOSS_HOME} is {@code tmp} then the destination will be {@code JBOSSHOME/foo/bar}
+     * For example if {@code file} is at {@code /tmp/foo/bar} and {@code $JBOSS_HOME} is {@code tmp} then the destination will be {@code JBOSS_HOME/foo/bar}
      *
      * @param file {@link VirtualFile} where metadata is read from
      * @param is content to write to the zip file

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jdr/mgmt/JdrReportManagmentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jdr/mgmt/JdrReportManagmentTestCase.java
@@ -76,7 +76,7 @@ public class JdrReportManagmentTestCase {
     }
 
     /**
-     * Tests if jdr.* script files are present in the WFLY_HOME/bin directory.
+     * Tests if jdr.* script files are present in the $JBOSS_HOME/bin directory.
      * The default server copy, see ts.copy-wildfly, does not copy these resources, so we only
      * execute this test when we are testing galleon layers, hence ts.layers enabled.
      */


### PR DESCRIPTION
Reported by user, so random weekend tinker.

Replaces $JBOSS_HOME, JBOSS_HOME, $WFLY_HOME, WFLY_HOME, and EAP_HOME with $WILDFLY_HOME across documentation and code comments with proper `$JBOSS_HOME` that the scripts actually parse and use.

More details on
https://redhat.atlassian.net/browse/WFLY-22020