### PR TITLE
WFLY-22044: upgrade licenses-plugin to 2.4.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,7 +335,7 @@
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.galleon-plugins>8.1.6.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.glow>2.1.0.Final</version.org.wildfly.glow>
-        <version.org.wildfly.licenses.plugin>2.4.4.Final</version.org.wildfly.licenses.plugin>
+        <version.org.wildfly.licenses.plugin>2.4.5.Final</version.org.wildfly.licenses.plugin>
         <version.org.wildfly.plugin>6.0.0.Final</version.org.wildfly.plugin>
         <version.org.wildfly.plugin.wildfly-detach-plugin>1.0.0.Final</version.org.wildfly.plugin.wildfly-detach-plugin>
         <version.org.wildfly.unstable.annotation.api>1.0.2.Final</version.org.wildfly.unstable.annotation.api>


### PR DESCRIPTION
Issue: [WFLY-22044](https://redhat.atlassian.net/browse/WFLY-22044)