### PR TITLE
Update the wildfly-bot config to use 'hornetq-client' for the testsui…

### DIFF
--- a/.github/wildfly-bot.yml
+++ b/.github/wildfly-bot.yml
@@ -83,7 +83,7 @@ wildfly:
     - id: messaging-activemq
       directories:
         - messaging-activemq
-        - testsuite/integration/legacy
+        - testsuite/integration/hornetq-client
       notify: [ ehsavoie ]
 
     - id: metrics


### PR DESCRIPTION
…te FKA 'legacy'

No issue required

No JIRA required

I renamed a TS module a few weeks back and wildfly-bot.yml needs to be updated to reflect that.

@wildfly-bot[bot] skip format