### PR TITLE
[WFLY-21910] replace -proc:full with explicit annotationProcessorPaths

### DIFF
--- a/appclient/pom.xml
+++ b/appclient/pom.xml
@@ -78,15 +78,5 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
     </dependencies>
 </project>

--- a/batch-jberet/pom.xml
+++ b/batch-jberet/pom.xml
@@ -120,14 +120,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.msc</groupId>
             <artifactId>jboss-msc</artifactId>
         </dependency>

--- a/bean-validation/pom.xml
+++ b/bean-validation/pom.xml
@@ -104,14 +104,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>staxmapper</artifactId>
         </dependency>

--- a/clustering/common/pom.xml
+++ b/clustering/common/pom.xml
@@ -40,12 +40,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Internal dependencies -->
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/clustering/ejb/infinispan/pom.xml
+++ b/clustering/ejb/infinispan/pom.xml
@@ -46,12 +46,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Internal dependencies -->
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/clustering/infinispan/extension/pom.xml
+++ b/clustering/infinispan/extension/pom.xml
@@ -51,12 +51,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Internal dependencies -->
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/clustering/jgroups/extension/pom.xml
+++ b/clustering/jgroups/extension/pom.xml
@@ -36,12 +36,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Internal dependencies -->
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/clustering/singleton/extension/pom.xml
+++ b/clustering/singleton/extension/pom.xml
@@ -40,12 +40,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Internal dependencies -->
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/clustering/singleton/server/pom.xml
+++ b/clustering/singleton/server/pom.xml
@@ -39,12 +39,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Internal dependencies -->
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/clustering/web/undertow/pom.xml
+++ b/clustering/web/undertow/pom.xml
@@ -46,12 +46,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Internal dependencies -->
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -222,14 +222,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.msc</groupId>
             <artifactId>jboss-msc</artifactId>
         </dependency>

--- a/datasources-agroal/pom.xml
+++ b/datasources-agroal/pom.xml
@@ -121,14 +121,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
             <groupId>org.jboss.metadata</groupId>
             <artifactId>jboss-metadata-common</artifactId>
             <exclusions>

--- a/ee-security/pom.xml
+++ b/ee-security/pom.xml
@@ -64,16 +64,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
         <dependency>
             <groupId>org.jboss.msc</groupId>
             <artifactId>jboss-msc</artifactId>

--- a/ee/pom.xml
+++ b/ee/pom.xml
@@ -108,14 +108,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.wildfly.common</groupId>
             <artifactId>wildfly-common</artifactId>
         </dependency>

--- a/ejb3/pom.xml
+++ b/ejb3/pom.xml
@@ -286,16 +286,6 @@ vi:ts=4:sw=4:expandtab
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
         <dependency>
             <groupId>org.jboss.metadata</groupId>
             <artifactId>jboss-metadata-ejb</artifactId>

--- a/elytron-oidc-client/pom.xml
+++ b/elytron-oidc-client/pom.xml
@@ -67,14 +67,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                 projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.metadata</groupId>
             <artifactId>jboss-metadata-web</artifactId>
         </dependency>

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -83,14 +83,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
             <scope>provided</scope>

--- a/iiop-openjdk/pom.xml
+++ b/iiop-openjdk/pom.xml
@@ -130,16 +130,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
         <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>

--- a/jakarta-data/pom.xml
+++ b/jakarta-data/pom.xml
@@ -101,16 +101,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
         <dependency>
             <groupId>org.jboss.msc</groupId>
             <artifactId>jboss-msc</artifactId>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -134,16 +134,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
         <dependency>
             <groupId>org.jboss.msc</groupId>
             <artifactId>jboss-msc</artifactId>

--- a/jdr/pom.xml
+++ b/jdr/pom.xml
@@ -94,13 +94,5 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
     </dependencies>
 </project>

--- a/jpa/hibernate6/pom.xml
+++ b/jpa/hibernate6/pom.xml
@@ -64,16 +64,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
         <dependency>
             <groupId>org.hibernate.common</groupId>
             <artifactId>hibernate-commons-annotations</artifactId>

--- a/jpa/hibernate7/pom.xml
+++ b/jpa/hibernate7/pom.xml
@@ -64,16 +64,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
         <dependency>
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-core</artifactId>

--- a/jpa/hibernatesearch/pom.xml
+++ b/jpa/hibernatesearch/pom.xml
@@ -47,16 +47,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>

--- a/jpa/persistence-cdi-extension/pom.xml
+++ b/jpa/persistence-cdi-extension/pom.xml
@@ -64,16 +64,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-    
         <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>

--- a/jpa/spi/pom.xml
+++ b/jpa/spi/pom.xml
@@ -40,16 +40,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>

--- a/jpa/subsystem/pom.xml
+++ b/jpa/subsystem/pom.xml
@@ -56,14 +56,6 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/jsf/injection/pom.xml
+++ b/jsf/injection/pom.xml
@@ -84,16 +84,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-security-manager</artifactId>

--- a/jsf/subsystem/pom.xml
+++ b/jsf/subsystem/pom.xml
@@ -85,16 +85,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
         <dependency>
             <groupId>org.jboss.metadata</groupId>
             <artifactId>jboss-metadata-web</artifactId>

--- a/legacy/keycloak/pom.xml
+++ b/legacy/keycloak/pom.xml
@@ -63,16 +63,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-            projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-web-common</artifactId>

--- a/legacy/opentracing-extension/pom.xml
+++ b/legacy/opentracing-extension/pom.xml
@@ -69,14 +69,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
         <!-- This is only required for the extension to initialize Netty's InternalLoggerFactory -->
         <dependency>
             <groupId>io.netty</groupId>

--- a/legacy/picketlink/pom.xml
+++ b/legacy/picketlink/pom.xml
@@ -74,14 +74,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed
-              at compile or runtime by other projects that depend on this project. -->
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
             <groupId>org.projectodd.vdx</groupId>
             <artifactId>vdx-core</artifactId>
             <scope>test</scope>

--- a/legacy/security/subsystem/pom.xml
+++ b/legacy/security/subsystem/pom.xml
@@ -90,16 +90,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/mail/pom.xml
+++ b/mail/pom.xml
@@ -75,16 +75,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
         <dependency>
             <groupId>org.jboss.metadata</groupId>
             <artifactId>jboss-metadata-common</artifactId>

--- a/messaging-activemq/injection/pom.xml
+++ b/messaging-activemq/injection/pom.xml
@@ -95,16 +95,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-            projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
         <dependency>
             <groupId>org.jboss.metadata</groupId>
             <artifactId>jboss-metadata-common</artifactId>

--- a/messaging-activemq/subsystem/pom.xml
+++ b/messaging-activemq/subsystem/pom.xml
@@ -298,16 +298,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-            projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
         <dependency>
             <groupId>org.jboss.common</groupId>
             <artifactId>jboss-common-beans</artifactId>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -97,14 +97,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
             <scope>provided</scope>

--- a/microprofile/config-smallrye/pom.xml
+++ b/microprofile/config-smallrye/pom.xml
@@ -100,14 +100,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
             <scope>provided</scope>

--- a/microprofile/fault-tolerance-smallrye/extension/pom.xml
+++ b/microprofile/fault-tolerance-smallrye/extension/pom.xml
@@ -88,12 +88,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.projectodd.vdx</groupId>
             <artifactId>vdx-wildfly</artifactId>
             <scope>test</scope>

--- a/microprofile/health-smallrye/pom.xml
+++ b/microprofile/health-smallrye/pom.xml
@@ -107,14 +107,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
             <scope>provided</scope>

--- a/microprofile/jwt-smallrye/pom.xml
+++ b/microprofile/jwt-smallrye/pom.xml
@@ -74,13 +74,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.jboss.xnio</groupId>

--- a/microprofile/lra/coordinator/pom.xml
+++ b/microprofile/lra/coordinator/pom.xml
@@ -76,12 +76,6 @@
       <artifactId>jboss-logging-annotations</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jboss.logging</groupId>
-      <artifactId>jboss-logging-processor</artifactId>
-      <scope>provided</scope>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.wildfly.core</groupId>
       <artifactId>wildfly-controller</artifactId>
     </dependency>

--- a/microprofile/lra/participant/pom.xml
+++ b/microprofile/lra/participant/pom.xml
@@ -116,13 +116,6 @@
       <groupId>${ee.maven.groupId}</groupId>
       <artifactId>wildfly-ee</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>org.jboss.logging</groupId>
-      <artifactId>jboss-logging-processor</artifactId>
-      <scope>provided</scope>
-      <optional>true</optional>
-    </dependency>
     <dependency>
       <groupId>org.wildfly.core</groupId>
       <artifactId>wildfly-controller</artifactId>

--- a/microprofile/metrics-smallrye/pom.xml
+++ b/microprofile/metrics-smallrye/pom.xml
@@ -67,14 +67,6 @@
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
         <!--Test dependencies -->
         <dependency>
             <groupId>org.jboss.xnio</groupId>

--- a/microprofile/openapi-smallrye/extension/pom.xml
+++ b/microprofile/openapi-smallrye/extension/pom.xml
@@ -32,12 +32,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Internal dependencies -->
         <dependency>
             <groupId>${ee.maven.groupId}</groupId>

--- a/microprofile/reactive-messaging-smallrye/amqp/pom.xml
+++ b/microprofile/reactive-messaging-smallrye/amqp/pom.xml
@@ -56,16 +56,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!--
-                This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                projects that depend on this project.
-            -->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.msc</groupId>
             <artifactId>jboss-msc</artifactId>
         </dependency>

--- a/microprofile/reactive-messaging-smallrye/common/pom.xml
+++ b/microprofile/reactive-messaging-smallrye/common/pom.xml
@@ -35,16 +35,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!--
-                This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                projects that depend on this project.
-            -->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-server</artifactId>
         </dependency>

--- a/microprofile/reactive-messaging-smallrye/config/pom.xml
+++ b/microprofile/reactive-messaging-smallrye/config/pom.xml
@@ -49,16 +49,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!--
-                This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                projects that depend on this project.
-            -->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/microprofile/reactive-messaging-smallrye/extension/pom.xml
+++ b/microprofile/reactive-messaging-smallrye/extension/pom.xml
@@ -97,16 +97,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!--
-                This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                projects that depend on this project.
-            -->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-controller</artifactId>
         </dependency>

--- a/microprofile/reactive-messaging-smallrye/kafka/pom.xml
+++ b/microprofile/reactive-messaging-smallrye/kafka/pom.xml
@@ -48,16 +48,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!--
-                This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                projects that depend on this project.
-            -->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.msc</groupId>
             <artifactId>jboss-msc</artifactId>
         </dependency>

--- a/microprofile/reactive-streams-operators-smallrye/cdi-provider/pom.xml
+++ b/microprofile/reactive-streams-operators-smallrye/cdi-provider/pom.xml
@@ -38,16 +38,6 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!--
-                This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                projects that depend on this project.
-            -->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
         </dependency>
     </dependencies>

--- a/microprofile/reactive-streams-operators-smallrye/extension/pom.xml
+++ b/microprofile/reactive-streams-operators-smallrye/extension/pom.xml
@@ -39,16 +39,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!--
-                This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                projects that depend on this project.
-            -->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-controller</artifactId>
         </dependency>

--- a/microprofile/telemetry-smallrye/extension/pom.xml
+++ b/microprofile/telemetry-smallrye/extension/pom.xml
@@ -122,14 +122,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
             <scope>provided</scope>

--- a/mod_cluster/extension/pom.xml
+++ b/mod_cluster/extension/pom.xml
@@ -53,14 +53,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
             <scope>provided</scope>

--- a/naming/pom.xml
+++ b/naming/pom.xml
@@ -73,14 +73,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/observability/micrometer/pom.xml
+++ b/observability/micrometer/pom.xml
@@ -130,14 +130,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-core</artifactId>
         </dependency>

--- a/observability/opentelemetry/pom.xml
+++ b/observability/opentelemetry/pom.xml
@@ -162,14 +162,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>

--- a/pojo/pom.xml
+++ b/pojo/pom.xml
@@ -80,14 +80,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -556,6 +556,7 @@
         <version.org.jboss.ws.jaxws-undertow-httpspi>3.0.1.Final</version.org.jboss.ws.jaxws-undertow-httpspi>
         <version.org.jboss.ws.spi>5.1.0.Final</version.org.jboss.ws.spi>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.10.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
+        <version.org.jboss.logging.jboss-logging-tools>3.0.4.Final</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jctools.jctools-core>4.0.6</version.org.jctools.jctools-core>
         <version.org.jgroups>5.5.5.Final</version.org.jgroups>
         <version.org.jgroups.aws>4.0.1.Final</version.org.jgroups.aws>
@@ -1543,10 +1544,18 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
-                        <compilerArgs combine.children="append">
-                            <!-- Note: this requires Java SE 17.0.11 or later. Update your environment if this causes a problem. -->
-                            <arg>-proc:full</arg>
-                        </compilerArgs>
+                        <annotationProcessorPaths combine.children="append">
+                            <path>
+                                <groupId>org.jboss.logging</groupId>
+                                <artifactId>jboss-logging-processor</artifactId>
+                                <version>${version.org.jboss.logging.jboss-logging-tools}</version>
+                            </path>
+                            <path>
+                                <groupId>org.kohsuke.metainf-services</groupId>
+                                <artifactId>metainf-services</artifactId>
+                                <version>${version.org.kohsuke.metainf-services}</version>
+                            </path>
+                        </annotationProcessorPaths>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/rts/pom.xml
+++ b/rts/pom.xml
@@ -73,12 +73,6 @@
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
         <!-- skip org.jboss.vfs -->
         <dependency>
             <groupId>io.smallrye</groupId>

--- a/sar/pom.xml
+++ b/sar/pom.xml
@@ -60,14 +60,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.common</groupId>
             <artifactId>jboss-common-beans</artifactId>
         </dependency>

--- a/system-jmx/pom.xml
+++ b/system-jmx/pom.xml
@@ -49,13 +49,5 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
     </dependencies>
 </project>

--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -124,11 +124,6 @@
 
         <!-- Build-time-only dependencies -->
         <dependency>
-            <groupId>org.infinispan.protostream</groupId>
-            <artifactId>protostream-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
             <scope>provided</scope>
@@ -442,6 +437,23 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <annotationProcessorPaths>
+                            <path>
+                                <groupId>org.infinispan.protostream</groupId>
+                                <artifactId>protostream-processor</artifactId>
+                                <version>${version.org.infinispan}</version>
+                            </path>
+                        </annotationProcessorPaths>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.wildfly.glow</groupId>

--- a/transactions/pom.xml
+++ b/transactions/pom.xml
@@ -82,14 +82,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.openjdk-orb</groupId>
             <artifactId>openjdk-orb</artifactId>
         </dependency>

--- a/undertow/pom.xml
+++ b/undertow/pom.xml
@@ -210,14 +210,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-auth</artifactId>
         </dependency>

--- a/web-common/pom.xml
+++ b/web-common/pom.xml
@@ -123,16 +123,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-security-manager</artifactId>

--- a/webservices/server-integration/pom.xml
+++ b/webservices/server-integration/pom.xml
@@ -96,14 +96,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
         <dependency>
             <groupId>org.jboss.ws</groupId>
             <artifactId>jbossws-api</artifactId>

--- a/weld/common/pom.xml
+++ b/weld/common/pom.xml
@@ -109,15 +109,6 @@
       </dependency>
 
       <dependency>
-         <groupId>org.jboss.logging</groupId>
-         <artifactId>jboss-logging-processor</artifactId>
-         <!-- This is a compile-time dependency of this project, but is not
-            needed at compile or runtime by other projects that depend on this project. -->
-         <scope>provided</scope>
-         <optional>true</optional>
-      </dependency>
-
-      <dependency>
          <groupId>org.jboss.modules</groupId>
          <artifactId>jboss-modules</artifactId>
          <exclusions>

--- a/weld/ejb/pom.xml
+++ b/weld/ejb/pom.xml
@@ -108,15 +108,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not
-               needed at compile or runtime by other projects that depend on this project. -->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
             <groupId>org.jboss.msc</groupId>
             <artifactId>jboss-msc</artifactId>
             <exclusions>

--- a/weld/subsystem/pom.xml
+++ b/weld/subsystem/pom.xml
@@ -127,15 +127,6 @@
       </dependency>
 
       <dependency>
-         <groupId>org.jboss.logging</groupId>
-         <artifactId>jboss-logging-processor</artifactId>
-         <!-- This is a compile-time dependency of this project, but is not
-            needed at compile or runtime by other projects that depend on this project. -->
-         <scope>provided</scope>
-         <optional>true</optional>
-      </dependency>
-
-      <dependency>
          <groupId>org.jboss.metadata</groupId>
          <artifactId>jboss-metadata-web</artifactId>
       </dependency>

--- a/xts/pom.xml
+++ b/xts/pom.xml
@@ -105,12 +105,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
         </dependency>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21910

  - Added jboss-logging-processor and metainf-services to annotationProcessorPaths in root pluginManagement with combine.children="append"
  - Removed -proc:full from compiler args
  - Removed jboss-logging-processor provided dependencies from 69 module POMs
  - Added protostream-processor to annotationProcessorPaths in testsuite/integration/clustering
  - Kept metainf-services as a dependency where used (provides @MetaInfServices annotation)