### PR TITLE
WFLY-22034 Testsuite parent POMs leak shared dependencies to all child modules

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -151,6 +151,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ee-dist/pom.xml
+++ b/ee-dist/pom.xml
@@ -131,6 +131,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/legacy/ee-feature-pack/dist/pom.xml
+++ b/legacy/ee-feature-pack/dist/pom.xml
@@ -151,6 +151,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/legacy/ee-feature-pack/ee-dist/pom.xml
+++ b/legacy/ee-feature-pack/ee-dist/pom.xml
@@ -132,6 +132,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/preview/dist/pom.xml
+++ b/preview/dist/pom.xml
@@ -126,6 +126,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -57,6 +57,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -64,6 +64,31 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>wildfly-testsuite-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>commons-logging-jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-core-test-runner</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-jmx</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- These seem to be required first so that jbossws-cxf-client ends up on the class path first. Also required for Java 11 -->
         <dependency>
             <groupId>org.jboss.ws.cxf</groupId>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/pool/lifecycle/PooledEJBLifecycleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/pool/lifecycle/PooledEJBLifecycleTestCase.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.ReflectPermission;
 import java.util.PropertyPermission;
 import jakarta.ejb.EJB;
 import jakarta.jms.Connection;
@@ -89,8 +90,12 @@ public class PooledEJBLifecycleTestCase {
                 createPermissionsXmlAsset(new PropertyPermission("ts.timeout.factor", "read"),
                         new PropertyPermission("ts.preview", "read"),
                         new PropertyPermission("ts.bootable.preview", "read"),
-                        new PropertyPermission("preview-server-tests", "read")),
-                "jboss-permissions.xml");
+                        new PropertyPermission("preview-server-tests", "read"),
+                        // testing framework requirements
+                        new RuntimePermission("accessDeclaredMembers"),
+                        new RuntimePermission("getClassLoader"),
+                        new ReflectPermission("suppressAccessChecks")
+                ), "jboss-permissions.xml");
         return archive;
     }
 

--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -55,6 +55,26 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>wildfly-testsuite-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>commons-logging-jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Jakarta specification dependencies -->
         <dependency>
             <groupId>jakarta.activation</groupId>
@@ -308,6 +328,10 @@
             <version>${version.org.infinispan.server.driver}</version>
             <scope>test</scope>
             <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
                 <!-- Avoids issue on deploy - "Caused by: org.jboss.as.cli.CommandRegistry$RegisterHandlerException: The following command names could not be registered since they conflict with the already registered ones: cd" -->
                 <exclusion>
                     <groupId>org.infinispan</groupId>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jgroups/tls/JGroupsLogsUtil.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jgroups/tls/JGroupsLogsUtil.java
@@ -6,7 +6,7 @@ package org.jboss.as.test.clustering.cluster.jgroups.tls;
 
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.dmr.ModelNode;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * Util class for JGroups log detection
@@ -24,7 +24,7 @@ public class JGroupsLogsUtil {
         operation.get("lines").set(150);
         operation.get("tail").set(true);
         ModelNode response = client.getControllerClient().execute(operation);
-        Assert.assertTrue("Unable to read logs", "success".equals(response.get("outcome").asString()));
+        Assertions.assertEquals("success", response.get("outcome").asString(), "Unable to read logs");
         return response.get("result").asList().stream().anyMatch(lineNode -> lineNode.asString().contains("WFLYCLJG0037"));
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jgroups/tls/TLSFD1CommandDispatcherTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jgroups/tls/TLSFD1CommandDispatcherTestCase.java
@@ -10,7 +10,7 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.clustering.cluster.dispatcher.CommandDispatcherTestCase;
 import org.jboss.as.test.clustering.cluster.dispatcher.bean.ClusterTopologyRetrieverBean;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -34,7 +34,7 @@ class TLSFD1CommandDispatcherTestCase extends CommandDispatcherTestCase {
     @Override
     @Test
     public void test() throws Exception {
-        Assert.assertFalse("WFLYCLJG0037 found", JGroupsLogsUtil.findWFLYCLJG0037(client));
+        Assertions.assertFalse(JGroupsLogsUtil.findWFLYCLJG0037(client), "WFLYCLJG0037 found");
 
         // original test
         this.test(ClusterTopologyRetrieverBean.class);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jgroups/tls/TLSFD2CommandDispatcherTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jgroups/tls/TLSFD2CommandDispatcherTestCase.java
@@ -10,7 +10,7 @@ import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.clustering.cluster.dispatcher.CommandDispatcherTestCase;
 import org.jboss.as.test.clustering.cluster.dispatcher.bean.ClusterTopologyRetrieverBean;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -33,7 +33,7 @@ class TLSFD2CommandDispatcherTestCase extends CommandDispatcherTestCase {
     @Override
     @Test
     public void test() throws Exception {
-        Assert.assertTrue("WFLYCLJG0037 not found", JGroupsLogsUtil.findWFLYCLJG0037(client));
+        Assertions.assertTrue(JGroupsLogsUtil.findWFLYCLJG0037(client), "WFLYCLJG0037 not found");
 
         // original test
         this.test(ClusterTopologyRetrieverBean.class);

--- a/testsuite/integration/clustering/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/clustering/src/test/resources/arquillian-bootable.xml
@@ -8,9 +8,12 @@
 
     <defaultProtocol type="jmx-as7"/>
 
+    <!-- Uncomment to inspect generated deployment archives -->
+    <!--
     <engine>
-        <property name="deploymentExportPath">target/</property>
+        <property name="deploymentExportPath">target/deployments/</property>
     </engine>
+    -->
 
     <container qualifier="single">
         <configuration>

--- a/testsuite/integration/clustering/src/test/resources/arquillian-byteman.xml
+++ b/testsuite/integration/clustering/src/test/resources/arquillian-byteman.xml
@@ -8,9 +8,12 @@
 
     <defaultProtocol type="jmx-as7"/>
 
+    <!-- Uncomment to inspect generated deployment archives -->
+    <!--
     <engine>
-        <property name="deploymentExportPath">target/</property>
+        <property name="deploymentExportPath">target/deployments/</property>
     </engine>
+    -->
 
     <container qualifier="single">
         <configuration>

--- a/testsuite/integration/clustering/src/test/resources/arquillian-testable.xml
+++ b/testsuite/integration/clustering/src/test/resources/arquillian-testable.xml
@@ -8,9 +8,12 @@
 
     <defaultProtocol type="jmx-as7"/>
 
+    <!-- Uncomment to inspect generated deployment archives -->
+    <!--
     <engine>
-        <property name="deploymentExportPath">target/</property>
+        <property name="deploymentExportPath">target/deployments/</property>
     </engine>
+    -->
 
     <container qualifier="default" default="true">
         <configuration>

--- a/testsuite/integration/clustering/src/test/resources/arquillian.xml
+++ b/testsuite/integration/clustering/src/test/resources/arquillian.xml
@@ -8,9 +8,12 @@
 
     <defaultProtocol type="jmx-as7"/>
 
+    <!-- Uncomment to inspect generated deployment archives -->
+    <!--
     <engine>
-        <property name="deploymentExportPath">target/</property>
+        <property name="deploymentExportPath">target/deployments/</property>
     </engine>
+    -->
 
     <container qualifier="single">
         <configuration>

--- a/testsuite/integration/elytron-oidc-client/pom.xml
+++ b/testsuite/integration/elytron-oidc-client/pom.xml
@@ -34,6 +34,31 @@
 
     <dependencies>
         <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>wildfly-testsuite-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-version</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
             <scope>test</scope>
@@ -56,11 +81,6 @@
         <dependency>
             <groupId>org.jboss.ejb3</groupId>
             <artifactId>jboss-ejb3-ext-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.arquillian</groupId>
-            <artifactId>wildfly-arquillian-container-managed</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -58,6 +58,17 @@
     </properties>
 
     <dependencies>
+        <!-- jakarta.* -->
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
@@ -107,6 +118,16 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>commons-logging-jboss-logmanager</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -274,12 +295,6 @@
             <scope>test</scope>
         </dependency>
         <!-- Required for Java 11 -->
-        <dependency>
-            <groupId>org.wildfly.arquillian</groupId>
-            <artifactId>wildfly-arquillian-container-managed</artifactId>
-            <scope>test</scope>
-        </dependency>
-
 
         <!-- Jakarta RESTful Web Services Client implementation -->
         <dependency>
@@ -381,6 +396,11 @@
         <dependency>
             <groupId>${ee.maven.groupId}</groupId>
             <artifactId>wildfly-testsuite-shared</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/testsuite/integration/expansion/pom.xml
+++ b/testsuite/integration/expansion/pom.xml
@@ -44,6 +44,36 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>wildfly-testsuite-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.msc</groupId>
+            <artifactId>jboss-msc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-model-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- MicroProfile APIs -->
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>

--- a/testsuite/integration/expansion/src/test/resources/arquillian.xml
+++ b/testsuite/integration/expansion/src/test/resources/arquillian.xml
@@ -8,10 +8,12 @@
 
     <defaultProtocol type="jmx-as7"/>
 
+    <!-- Uncomment to inspect generated deployment archives -->
+    <!--
     <engine>
-        <!-- Uncomment to inspect created deployments -->
-        <property name="deploymentExportPath">target/deployments</property>
+        <property name="deploymentExportPath">target/deployments/</property>
     </engine>
+    -->
 
     <container qualifier="jboss" default="true">
         <configuration>

--- a/testsuite/integration/hornetq-client/pom.xml
+++ b/testsuite/integration/hornetq-client/pom.xml
@@ -39,6 +39,31 @@
 
     <dependencies>
         <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>wildfly-testsuite-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-dmr</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-commons</artifactId>
         </dependency>

--- a/testsuite/integration/iiop/pom.xml
+++ b/testsuite/integration/iiop/pom.xml
@@ -36,6 +36,21 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>wildfly-testsuite-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/manualmode-expansion/pom.xml
+++ b/testsuite/integration/manualmode-expansion/pom.xml
@@ -43,6 +43,31 @@
 
     <dependencies>
         <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>wildfly-testsuite-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>commons-logging-jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/manualmode/pom.xml
+++ b/testsuite/integration/manualmode/pom.xml
@@ -41,6 +41,26 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>wildfly-testsuite-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-deployment-repository</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-domain-management</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- These seem to be required first so that jbossws-cxf-client ends up on the class path first. Also required for Java 11 -->
         <dependency>
             <groupId>jakarta.activation</groupId>

--- a/testsuite/integration/microprofile-tck/jwt/pom.xml
+++ b/testsuite/integration/microprofile-tck/jwt/pom.xml
@@ -31,6 +31,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-testing-tools</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.reactivex.rxjava2</groupId>
             <artifactId>rxjava</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/microprofile-tck/openapi/pom.xml
+++ b/testsuite/integration/microprofile-tck/openapi/pom.xml
@@ -32,6 +32,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-testing-tools</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
             <scope>provided</scope>

--- a/testsuite/integration/microprofile-tck/pom.xml
+++ b/testsuite/integration/microprofile-tck/pom.xml
@@ -68,6 +68,11 @@
             <artifactId>wildfly-naming-client</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>commons-logging-jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <modules>

--- a/testsuite/integration/microprofile-tck/reactive-messaging/pom.xml
+++ b/testsuite/integration/microprofile-tck/reactive-messaging/pom.xml
@@ -43,6 +43,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-container-managed</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>
             <artifactId>microprofile-reactive-streams-operators-api</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/microprofile-tck/rest-client/pom.xml
+++ b/testsuite/integration/microprofile-tck/rest-client/pom.xml
@@ -91,6 +91,12 @@
         <ts.microprofile-tck-glow.expected-discovery>[cdi, ee-integration, jaxrs, jsonb, jsonp, microprofile-config, microprofile-rest-client, servlet]==>ee-core-profile-server,jaxrs,microprofile-rest-client</ts.microprofile-tck-glow.expected-discovery>
     </properties>
     <dependencies>
+        <!-- Required by wiremock server module -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- Required by the RESTEasy Client -->
         <dependency>
             <groupId>org.jboss.resteasy</groupId>

--- a/testsuite/integration/microprofile-tck/telemetry/pom.xml
+++ b/testsuite/integration/microprofile-tck/telemetry/pom.xml
@@ -30,6 +30,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-testing-tools</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
         </dependency>

--- a/testsuite/integration/multinode/pom.xml
+++ b/testsuite/integration/multinode/pom.xml
@@ -39,6 +39,41 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>commons-logging-jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -186,108 +186,17 @@
     </build>
 
     <dependencies>
-        <!-- Dependencies specific to the integration tests. -->
-
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-core-test-runner</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-           <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-model-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-core-model-test-framework</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-subsystem-test</artifactId>
-            <type>pom</type>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>${ee.maven.groupId}</groupId>
-            <artifactId>wildfly-testsuite-shared</artifactId>
-        </dependency>
+        <!-- DO NOT add dependencies here unless they are truly required by ALL child modules. -->
+        <!-- Declare dependencies in the specific module that requires them. See WFLY-22034. -->
         <dependency>
             <groupId>org.wildfly.arquillian</groupId>
             <artifactId>wildfly-arquillian-container-managed</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.wildfly.arquillian</groupId>
             <artifactId>wildfly-arquillian-protocol-jmx</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.shrinkwrap</groupId>
-            <artifactId>shrinkwrap-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.shrinkwrap</groupId>
-            <artifactId>shrinkwrap-impl-base</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>jakarta.enterprise</groupId>
-            <artifactId>jakarta.enterprise.cdi-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-elytron-auth</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-elytron-auth-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-elytron-base</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-elytron-credential</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-elytron-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-elytron-credential-store</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-elytron-permission</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-elytron-sasl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-elytron-security-manager</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-elytron-x500-cert</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-elytron-x500</artifactId>
         </dependency>
     </dependencies>
 

--- a/testsuite/integration/rbac/pom.xml
+++ b/testsuite/integration/rbac/pom.xml
@@ -35,8 +35,28 @@
 
     <dependencies>
         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-dmr</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller-client</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/testsuite/integration/rts/pom.xml
+++ b/testsuite/integration/rts/pom.xml
@@ -32,6 +32,23 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>commons-logging-jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Jakarta specifications -->
         <dependency>
             <groupId>jakarta.activation</groupId>

--- a/testsuite/integration/secman/pom.xml
+++ b/testsuite/integration/secman/pom.xml
@@ -38,6 +38,37 @@
 
     <dependencies>
         <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>wildfly-testsuite-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-testing-tools</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-subsystem-test</artifactId>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -45,6 +45,51 @@
 
     <dependencies>
         <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>wildfly-testsuite-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.msc</groupId>
+            <artifactId>jboss-msc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-naming</artifactId>
             <scope>test</scope>
@@ -422,6 +467,21 @@
            <artifactId>junit-jupiter</artifactId>
            <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>commons-logging-jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -432,12 +492,6 @@
         <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-naming-client</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.wildfly.arquillian</groupId>
-            <artifactId>wildfly-arquillian-container-managed</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/testsuite/integration/vdx/pom.xml
+++ b/testsuite/integration/vdx/pom.xml
@@ -35,6 +35,21 @@
 
     <dependencies>
         <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>wildfly-testsuite-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/web/pom.xml
+++ b/testsuite/integration/web/pom.xml
@@ -46,6 +46,41 @@
 
     <dependencies>
         <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>wildfly-testsuite-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>jandex</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>commons-logging-jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-naming</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/ws/pom.xml
+++ b/testsuite/integration/ws/pom.xml
@@ -33,6 +33,41 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>wildfly-testsuite-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>commons-logging-jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- These seem to be required first so that jbossws-cxf-client ends up on the class path first. The clients
              jakarta.xml.ws.spi.Provider needs to be the one used.
         -->

--- a/testsuite/integration/xts/pom.xml
+++ b/testsuite/integration/xts/pom.xml
@@ -32,6 +32,46 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>wildfly-testsuite-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-dmr</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- These seem to be required first so that jbossws-cxf-client ends up on the class path first. The clients
              jakarta.xml.ws.spi.Provider needs to be the one used.
         -->

--- a/testsuite/layers-expansion/pom.xml
+++ b/testsuite/layers-expansion/pom.xml
@@ -63,6 +63,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <scope>test</scope>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -63,6 +63,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <scope>test</scope>

--- a/testsuite/mixed-domain/pom.xml
+++ b/testsuite/mixed-domain/pom.xml
@@ -89,6 +89,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.launcher</groupId>
             <artifactId>wildfly-launcher</artifactId>
         </dependency>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -238,26 +238,9 @@
     </dependencyManagement>
 
     <dependencies>
-        <dependency>
-            <groupId>jakarta.inject</groupId>
-            <artifactId>jakarta.inject-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.enterprise</groupId>
-            <artifactId>jakarta.enterprise.cdi-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.persistence</groupId>
-            <artifactId>jakarta.persistence-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.transaction</groupId>
-            <artifactId>jakarta.transaction-api</artifactId>
-            <scope>test</scope>
-        </dependency>
+        <!-- DO NOT add dependencies here unless they are truly required by ALL child modules. -->
+        <!-- Declare dependencies in the specific module that requires them. See WFLY-22034. -->
+        <!-- The <dependencies> section is left empty intentionally so that anyone adding a dependency here will notice this message. -->
     </dependencies>
 
     <build>

--- a/testsuite/preview/basic/pom.xml
+++ b/testsuite/preview/basic/pom.xml
@@ -60,6 +60,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>jakarta.mvc</groupId>
             <artifactId>jakarta.mvc-api</artifactId>
             <scope>test</scope>
@@ -117,6 +122,11 @@
         <dependency>
             <groupId>${ee.maven.groupId}</groupId>
             <artifactId>wildfly-testsuite-shared</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/testsuite/preview/expansion/pom.xml
+++ b/testsuite/preview/expansion/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
@@ -61,6 +66,11 @@
         <dependency>
             <groupId>${ee.maven.groupId}</groupId>
             <artifactId>wildfly-testsuite-shared</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/testsuite/preview/manualmode/pom.xml
+++ b/testsuite/preview/manualmode/pom.xml
@@ -109,6 +109,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-controller</artifactId>
             <scope>test</scope>

--- a/testsuite/scripts/pom.xml
+++ b/testsuite/scripts/pom.xml
@@ -44,6 +44,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-controller-client</artifactId>
             <scope>test</scope>

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -48,6 +48,27 @@
     </dependencyManagement>
 
     <dependencies>
+        <!-- n.b. while this catch-all module is a dependency hell (e.g. JUnit 4 base classes and JUnit 5), fear not, this dependency is managed with * exclusion,
+         so anything used from a module that imports this still has to be explicit about its real dependencies.
+         All assertions in this module are `org.assertj` so they are reusable regardless of the actual testing framework. -->
+
+        <!-- Testing dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${version.org.junit}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
 
         <dependency>
             <groupId>commons-codec</groupId>
@@ -124,11 +145,6 @@
         <dependency>
             <groupId>org.wildfly.arquillian</groupId>
             <artifactId>wildfly-arquillian-container-managed</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
@@ -286,21 +302,13 @@
             <scope>compile</scope>
         </dependency>
 
-        <!-- test -->
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>${version.org.junit}</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
-                <!-- This enforcer.skip property was set to true in the properties. However this doesn't work if the
-                     property is passed on the command line. Therefore we need to explicitly skip it.
+                <!-- This enforcer.skip property was set to true in the properties. However, this doesn't work if the
+                     property is passed on the command line. Therefore, we need to explicitly skip it.
                 -->
                 <!-- Arquillian dependency versions -->
                 <artifactId>maven-enforcer-plugin</artifactId>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/base/AbstractExpressionSupportTestCase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/base/AbstractExpressionSupportTestCase.java
@@ -5,33 +5,8 @@
 
 package org.jboss.as.test.integration.management.base;
 
-import org.jboss.arquillian.container.test.api.ContainerController;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.as.arquillian.container.ManagementClient;
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
-import org.jboss.as.test.shared.ServerReload;
-import org.jboss.as.test.shared.TestSuiteEnvironment;
-import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.ModelType;
-import org.jboss.dmr.Property;
-import org.jboss.dmr.ValueExpression;
-import org.jboss.logging.Logger;
-import org.junit.Assert;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACCESS_TYPE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALTERNATIVES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
@@ -51,6 +26,32 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VAL
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.test.integration.domain.management.util.DomainTestUtils.createOperation;
 import static org.jboss.as.test.integration.domain.management.util.DomainTestUtils.executeForResult;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.dmr.Property;
+import org.jboss.dmr.ValueExpression;
+import org.jboss.logging.Logger;
 
 /**
  * Smoke test of expression support.
@@ -659,7 +660,7 @@ public abstract class AbstractExpressionSupportTestCase {
         int start = text.indexOf("${");
         if (start > -1) {
             if (text.indexOf("}") > start) {
-                Assert.fail(address + " attribute " + attrName + " is storing an unconverted expression: " + text);
+                fail(address + " attribute " + attrName + " is storing an unconverted expression: " + text);
             }
         }
     }
@@ -716,17 +717,17 @@ public abstract class AbstractExpressionSupportTestCase {
     private void validateAttributeValue(PathAddress address, String attrName, ModelNode expectedValue, ModelNode modelValue) {
         switch (expectedValue.getType()) {
             case EXPRESSION: {
-                Assert.assertEquals(address + " attribute " + attrName + " value " + modelValue + " is an unconverted expression",
-                        expectedValue, modelValue);
+                assertThat(modelValue).as(address + " attribute " + attrName + " value " + modelValue + " is an unconverted expression")
+                        .isEqualTo(expectedValue);
                 break;
             }
             case INT:
             case LONG:
-                Assert.assertTrue(address + " attribute " + attrName + " is a valid type", modelValue.getType() == ModelType.INT || modelValue.getType() == ModelType.LONG);
-                Assert.assertEquals(address + " -- " + attrName, expectedValue.asLong(), modelValue.asLong());
+                assertThat(modelValue.getType()).as(address + " attribute " + attrName + " is a valid type").isIn(ModelType.INT, ModelType.LONG);
+                assertThat(modelValue.asLong()).as(address + " -- " + attrName).isEqualTo(expectedValue.asLong());
                 break;
             default: {
-                Assert.assertEquals(address + " -- " + attrName, expectedValue, modelValue);
+                assertThat(modelValue).as(address + " -- " + attrName).isEqualTo(expectedValue);
             }
         }
     }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/RolesPrintingServletUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/RolesPrintingServletUtils.java
@@ -4,7 +4,7 @@
  */
 package org.jboss.as.test.integration.security.common;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Utils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Utils.java
@@ -5,8 +5,7 @@
 package org.jboss.as.test.integration.security.common;
 
 import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -311,7 +310,7 @@ public class Utils extends CoreUtils {
             // We should get the Login Page
             StatusLine statusLine = response.getStatusLine();
 
-            assertEquals(200, statusLine.getStatusCode());
+            assertThat(statusLine.getStatusCode()).isEqualTo(200);
 
             // We should now login with the user name and password
             HttpPost httpost = new HttpPost(URL + "/j_security_check");
@@ -329,7 +328,7 @@ public class Utils extends CoreUtils {
             statusLine = response.getStatusLine();
 
             // Post authentication - we have a 302
-            assertEquals(302, statusLine.getStatusCode());
+            assertThat(statusLine.getStatusCode()).isEqualTo(302);
             Header locationHeader = response.getFirstHeader("Location");
             String location = locationHeader.getValue();
 
@@ -341,7 +340,7 @@ public class Utils extends CoreUtils {
 
             // Either the authentication passed or failed based on the expected status code
             statusLine = response.getStatusLine();
-            assertEquals(expectedStatusCode, statusLine.getStatusCode());
+            assertThat(statusLine.getStatusCode()).isEqualTo(expectedStatusCode);
         }
     }
 
@@ -397,7 +396,7 @@ public class Utils extends CoreUtils {
         int statusCode = response.getStatusLine().getStatusCode();
         LOGGER.trace("Request to: " + url + " responds: " + statusCode);
 
-        assertEquals("Unexpected status code", expectedStatusCode, statusCode);
+        assertThat(statusCode).as("Unexpected status code").isEqualTo(expectedStatusCode);
 
         HttpEntity entity = response.getEntity();
         if (entity != null) {
@@ -457,7 +456,7 @@ public class Utils extends CoreUtils {
             HttpResponse response = httpClient.execute(httpGet);
             int statusCode = response.getStatusLine().getStatusCode();
             if (HttpServletResponse.SC_UNAUTHORIZED != statusCode || StringUtils.isEmpty(user)) {
-                assertEquals("Unexpected HTTP response status code.", expectedStatusCode, statusCode);
+                assertThat(statusCode).as("Unexpected HTTP response status code.").isEqualTo(expectedStatusCode);
                 return EntityUtils.toString(response.getEntity());
             }
             if (LOGGER.isDebugEnabled()) {
@@ -475,7 +474,7 @@ public class Utils extends CoreUtils {
             //enable auth
             response = httpClient.execute(httpGet, hc);
             statusCode = response.getStatusLine().getStatusCode();
-            assertEquals("Unexpected status code returned after the authentication.", expectedStatusCode, statusCode);
+            assertThat(statusCode).as("Unexpected status code returned after the authentication.").isEqualTo(expectedStatusCode);
 
             if (checkFollowupAuthState) {
                 // Let's disable authentication for this client as we already have all the context necessary to be
@@ -486,8 +485,7 @@ public class Utils extends CoreUtils {
                 httpGet.setConfig(reqConf);
                 response = httpClient.execute(httpGet, hc);
                 statusCode = response.getStatusLine().getStatusCode();
-                assertEquals("Unexpected status code returned after the authentication.", HttpURLConnection.HTTP_OK,
-                        statusCode);
+                assertThat(statusCode).as("Unexpected status code returned after the authentication.").isEqualTo(HttpURLConnection.HTTP_OK);
             }
 
             return EntityUtils.toString(response.getEntity());
@@ -515,10 +513,9 @@ public class Utils extends CoreUtils {
         try (CloseableHttpClient httpClient = HttpClientBuilder.create().setRedirectStrategy(REDIRECT_STRATEGY).build()) {
             final HttpGet httpGet = new HttpGet(url.toURI());
             HttpResponse response = httpClient.execute(httpGet);
-            assertEquals("Unexpected HTTP response status code.", SC_UNAUTHORIZED, response.getStatusLine().getStatusCode());
+            assertThat(response.getStatusLine().getStatusCode()).as("Unexpected HTTP response status code.").isEqualTo(SC_UNAUTHORIZED);
             Header[] authenticateHeaders = response.getHeaders("WWW-Authenticate");
-            assertTrue("Expected WWW-Authenticate header was not present in the HTTP response",
-                    authenticateHeaders != null && authenticateHeaders.length > 0);
+            assertThat(authenticateHeaders).as("Expected WWW-Authenticate header was not present in the HTTP response").isNotNull().isNotEmpty();
             boolean bearerAuthnHeaderFound = false;
             for (Header header : authenticateHeaders) {
                 final String headerVal = header.getValue();
@@ -527,8 +524,8 @@ public class Utils extends CoreUtils {
                     break;
                 }
             }
-            assertTrue("WWW-Authenticate response header didn't request expected Bearer token authentication",
-                    bearerAuthnHeaderFound);
+            assertThat(bearerAuthnHeaderFound).as("WWW-Authenticate response header didn't request expected Bearer token authentication").isTrue();
+
             HttpEntity entity = response.getEntity();
             if (entity != null) {
                 EntityUtils.consume(entity);
@@ -540,8 +537,7 @@ public class Utils extends CoreUtils {
 
             httpGet.addHeader("Authorization", "Bearer " + token);
             response = httpClient.execute(httpGet);
-            assertEquals("Unexpected status code returned after the authentication.", expectedStatusCode,
-                    response.getStatusLine().getStatusCode());
+            assertThat(response.getStatusLine().getStatusCode()).as("Unexpected status code returned after the authentication.").isEqualTo(expectedStatusCode);
             return EntityUtils.toString(response.getEntity());
         }
     }
@@ -695,7 +691,7 @@ public class Utils extends CoreUtils {
             final HttpGet httpget = new HttpGet(uri);
             final HttpResponse response = httpClient.execute(httpget);
             int statusCode = response.getStatusLine().getStatusCode();
-            assertEquals("Unexpected status code in HTTP response.", expectedStatusCode, statusCode);
+            assertThat(statusCode).as("Unexpected status code in HTTP response.").isEqualTo(expectedStatusCode);
             return EntityUtils.toString(response.getEntity());
         }
     }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/TxTestUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/TxTestUtil.java
@@ -5,6 +5,8 @@
 
 package org.jboss.as.test.integration.transactions;
 
+import static org.assertj.core.api.Assertions.fail;
+
 import javax.transaction.xa.XAResource;
 
 import jakarta.transaction.RollbackException;
@@ -14,7 +16,6 @@ import jakarta.transaction.Transaction;
 import jakarta.transaction.TransactionManager;
 import jakarta.transaction.TransactionSynchronizationRegistry;
 import org.jboss.as.test.shared.TimeoutUtil;
-import org.junit.Assert;
 
 /**
  * Transaction util class which works with transaction like
@@ -96,9 +97,9 @@ public final class TxTestUtil {
             Transaction tx = tm.getTransaction();
 
             if(!isExpectTransaction && tx != null && tx.getStatus() != Status.STATUS_NO_TRANSACTION) {
-                Assert.fail("We do not expect transaction would be active - we haven't activated it in BMT bean");
+                fail("We do not expect transaction would be active - we haven't activated it in BMT bean");
             } else if (isExpectTransaction && (tx == null || tx.getStatus() != Status.STATUS_ACTIVE)) {
-                Assert.fail("We do expect tranaction would be active - we have alredy activated it in BMT bean");
+                fail("We do expect tranaction would be active - we have alredy activated it in BMT bean");
             }
         } catch (SystemException e) {
             throw new RuntimeException("Cannot get the current transaction from injected TransationManager!", e);

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/web/sso/SSOTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/web/sso/SSOTestBase.java
@@ -4,14 +4,13 @@
  */
 package org.jboss.as.test.integration.web.sso;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.http.Header;
@@ -49,8 +48,8 @@ public final class SSOTestBase {
     public static final String PASSWORD_2 = "password2";
     public static final String ROLE = "Users";
 
-    /*
-     * Nothing extends this class or needs to instantiate it, instead publicstatic accessor methods are used.
+    /**
+     * Nothing extends this class or needs to instantiate it, instead public static accessor methods are used.
      */
     private SSOTestBase() {}
 
@@ -199,10 +198,10 @@ public final class SSOTestBase {
         HttpResponse response = httpConn.execute(logout);
         try {
             int statusCode = response.getStatusLine().getStatusCode();
-            assertTrue("Logout: Didn't see code 302 (HTTP_MOVED_TEMP), but saw instead " + statusCode, statusCode == HttpURLConnection.HTTP_MOVED_TEMP);
+            assertThat(statusCode).as("Logout: Didn't see code 302 (HTTP_MOVED_TEMP), but saw instead " + statusCode).isEqualTo(HttpURLConnection.HTTP_MOVED_TEMP);
 
             Header location = response.getFirstHeader("Location");
-            assertTrue("Get of " + warURL + "Logout not redirected to login page", location.getValue().contains("index.html"));
+            assertThat(location.getValue()).as("Get of " + warURL + "Logout not redirected to login page").contains("index.html");
         } finally {
             HttpClientUtils.closeQuietly(response);
         }
@@ -213,10 +212,10 @@ public final class SSOTestBase {
         HttpResponse response = httpConn.execute(getMethod);
         try {
             int statusCode = response.getStatusLine().getStatusCode();
-            assertTrue("Expected code == OK but got " + statusCode + " for request=" + url, statusCode == HttpURLConnection.HTTP_OK);
+            assertThat(statusCode).as("Expected code == OK but got " + statusCode + " for request=" + url).isEqualTo(HttpURLConnection.HTTP_OK);
 
             String body = EntityUtils.toString(response.getEntity());
-            assertTrue("Get of " + url + " redirected to login page", !body.contains("j_security_check"));
+            assertThat(body).as("Get of " + url + " redirected to login page").doesNotContain("j_security_check");
         } finally {
             HttpClientUtils.closeQuietly(response);
         }
@@ -236,8 +235,8 @@ public final class SSOTestBase {
         try {
             int statusCode = postResponse.getStatusLine().getStatusCode();
             Header[] errorHeaders = postResponse.getHeaders("X-NoJException");
-            assertTrue("Should see HTTP_MOVED_TEMP. Got " + statusCode, statusCode == HttpURLConnection.HTTP_MOVED_TEMP);
-            assertTrue("X-NoJException(" + Arrays.toString(errorHeaders) + ") is null", errorHeaders.length == 0);
+            assertThat(statusCode).as("Should see HTTP_MOVED_TEMP").isEqualTo(HttpURLConnection.HTTP_MOVED_TEMP);
+            assertThat(errorHeaders).as("X-NoJException").isEmpty();
             EntityUtils.consume(postResponse.getEntity());
 
             // Follow the redirect to the index.html page
@@ -247,11 +246,11 @@ public final class SSOTestBase {
 
             statusCode = redirectResponse.getStatusLine().getStatusCode();
             errorHeaders = redirectResponse.getHeaders("X-NoJException");
-            assertTrue("Wrong response code: " + statusCode, statusCode == HttpURLConnection.HTTP_OK);
-            assertTrue("X-NoJException(" + Arrays.toString(errorHeaders) + ") is null", errorHeaders.length == 0);
+            assertThat(statusCode).as("Wrong response code: " + statusCode).isEqualTo(HttpURLConnection.HTTP_OK);
+            assertThat(errorHeaders).as("X-NoJException").isEmpty();
 
             String body = EntityUtils.toString(redirectResponse.getEntity());
-            assertTrue("Get of " + indexURL + " redirected to login page", !body.contains("j_security_check"));
+            assertThat(body).as("Get of " + indexURL + " redirected to login page").doesNotContain("j_security_check");
         } finally {
             HttpClientUtils.closeQuietly(postResponse);
         }
@@ -262,10 +261,10 @@ public final class SSOTestBase {
         HttpResponse response = httpConn.execute(getMethod);
         try {
             int statusCode = response.getStatusLine().getStatusCode();
-            assertTrue("Expected code == OK but got " + statusCode + " for request=" + url, statusCode == HttpURLConnection.HTTP_OK);
+            assertThat(statusCode).as("Expected code == OK but got " + statusCode + " for request=" + url).isEqualTo(HttpURLConnection.HTTP_OK);
 
             String body = EntityUtils.toString(response.getEntity());
-            assertTrue("Redirected to login page for request=" + url + ", body[" + body + "]", body.indexOf("j_security_check") > 0);
+            assertThat(body).as("Redirected to login page for request=" + url).contains("j_security_check");
         } finally {
             HttpClientUtils.closeQuietly(response);
         }
@@ -284,7 +283,7 @@ public final class SSOTestBase {
             }
         }
 
-        assertTrue("Didn't see JSESSIONIDSSO: " + cookieStore.getCookies(), ssoID != null);
+        assertThat(ssoID).as("Didn't see JSESSIONIDSSO: " + cookieStore.getCookies()).isNotNull();
         return ssoID;
     }
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/IntermittentFailure.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/IntermittentFailure.java
@@ -5,7 +5,7 @@
 
 package org.jboss.as.test.shared;
 
-import org.junit.Assume;
+import org.assertj.core.api.Assumptions;
 
 /**
  * Utility class to disable (effectively @Ignore) intermittently failing tests unless explicitly enabled via a System property.
@@ -28,7 +28,7 @@ public final class IntermittentFailure {
      */
     public static void thisTestIsFailingIntermittently(String message) {
         boolean enableTest = System.getProperty("jboss.test.enableIntermittentFailingTests") != null;
-        Assume.assumeTrue(message, enableTest);
+        Assumptions.assumeThat(enableTest).as(message).isTrue();
     }
 
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -5,6 +5,8 @@
 
 package org.jboss.as.test.shared;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -16,7 +18,6 @@ import java.util.stream.Stream;
 
 import org.jboss.as.test.layers.LayersTest;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -568,7 +569,7 @@ public abstract class LayersTestBase {
     @Test
     public void checkBannedModules() throws Exception {
         final HashMap<String, String> results = LayersTest.checkBannedModules(root, BANNED_MODULES_CONF);
-        Assert.assertTrue("The following banned modules were provisioned " + results, results.isEmpty());
+        assertThat(results).as("The following banned modules were provisioned").isEmpty();
     }
 
     /**

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/SecurityManagerFailure.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/SecurityManagerFailure.java
@@ -5,12 +5,12 @@
 
 package org.jboss.as.test.shared;
 
-import org.junit.Assume;
+import org.assertj.core.api.Assumptions;
 
 /**
  * Utility class to disable tests failing when Security Manager is enabled.
  *
- * Important note: this should be used only in cases when tests are failing due to a thirdparty issues which are
+ * Important note: this should be used only in cases when tests are failing due to a third-party issues which are
  * unlikely to get fixed, e.g. WFLY-6192.
  *
  * @author Ivo Studensky
@@ -35,7 +35,7 @@ public final class SecurityManagerFailure {
         // either System.getSecurityManager is not null or system property 'security.manager' is set (in cases of RunAsClient)
         if (sm != null || securityManagerEnabled) {
             final boolean enableTest = System.getProperty("jboss.test.enableTestsFailingUnderSM") != null;
-            Assume.assumeTrue(message, enableTest);
+            Assumptions.assumeThat(enableTest).as(message).isTrue();
         }
     }
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/ServerReload.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/ServerReload.java
@@ -5,6 +5,8 @@
 
 package org.jboss.as.test.shared;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
@@ -13,7 +15,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUT
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
@@ -26,7 +27,6 @@ import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.helpers.ClientConstants;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
-import org.junit.Assert;
 import org.xnio.IoUtils;
 
 /**
@@ -198,7 +198,7 @@ public class ServerReload {
         }
     }
 
-    private static void waitForLiveServerToReload(int timeout, String serverAddress, int serverPort) {
+    public static void waitForLiveServerToReload(int timeout, String serverAddress, int serverPort) {
         int adjustedTimeout = TimeoutUtil.adjust(timeout);
         long start = System.currentTimeMillis();
         ModelNode operation = new ModelNode();
@@ -277,7 +277,7 @@ public class ServerReload {
             executeReloadAndWaitForCompletion(controllerClient);
         } else {
             log.debugf("Server reload is not required; server-state is %s", runningState);
-            Assert.assertEquals("Server state 'running' is expected", "running", runningState);
+            assertThat(runningState).as("Server state 'running' is expected").isEqualTo("running");
         }
     }
 
@@ -295,7 +295,7 @@ public class ServerReload {
             executeReloadAndWaitForCompletion(managementClient);
         } else {
             log.debugf("Server reload is not required; server-state is %s", runningState);
-            Assert.assertEquals("Server state 'running' is expected", "running", runningState);
+            assertThat(runningState).as("Server state 'running' is expected").isEqualTo("running");
         }
     }
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/ServerSnapshot.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/ServerSnapshot.java
@@ -5,7 +5,7 @@
 
 package org.jboss.as.test.shared;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.io.File;
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/integration/ejb/interceptor/serverside/AbstractServerInterceptorsSetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/integration/ejb/interceptor/serverside/AbstractServerInterceptorsSetupTask.java
@@ -12,7 +12,7 @@ import static org.jboss.as.controller.client.helpers.ClientConstants.UNDEFINE_AT
 import static org.jboss.as.controller.client.helpers.ClientConstants.VALUE;
 import static org.jboss.as.controller.client.helpers.ClientConstants.WRITE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MODULE;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.net.URL;
@@ -96,7 +96,7 @@ public abstract class AbstractServerInterceptorsSetupTask {
 
             final ModelNode operationResult = managementClient.getControllerClient().execute(op);
             // check whether the operation was successful
-            assertTrue(Operations.isSuccessfulOutcome(operationResult));
+            assertThat(Operations.isSuccessfulOutcome(operationResult)).as(operationResult.asString()).isTrue();
         }
 
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/integration/ejb/security/Util.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/integration/ejb/security/Util.java
@@ -4,7 +4,7 @@
  */
 package org.jboss.as.test.shared.integration.ejb.security;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Properties;
 import java.util.concurrent.Callable;
@@ -166,12 +166,13 @@ public class Util {
     private static void validateException(final Exception e, final boolean initialAuthSucceeded) {
         if (SecurityDomain.getCurrent() != null) {
             if (initialAuthSucceeded) {
-                assertTrue("Expected EJBException due to bad password not thrown.", e instanceof EJBException && e.getCause() instanceof SecurityException);
+                assertThat(e).as("Expected EJBException due to bad password not thrown.").isInstanceOf(EJBException.class);
+                assertThat(e.getCause()).as("Expected EJBException due to bad password not thrown.").isInstanceOf(SecurityException.class);
             } else {
-                assertTrue("Expected SecurityException due to bad password not thrown.", e instanceof SecurityException);
+                assertThat(e).as("Expected SecurityException due to bad password not thrown.").isInstanceOf(SecurityException.class);
             }
         } else {
-            assertTrue("Expected EJBAccessException due to bad password not thrown. (EJB 3.1 FR 17.6.9)", e instanceof EJBAccessException);
+            assertThat(e).as("Expected EJBAccessException due to bad password not thrown. (EJB 3.1 FR 17.6.9)").isInstanceOf(EJBAccessException.class);
         }
     }
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/integration/interceptor/clientside/AbstractClientInterceptorsSetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/integration/interceptor/clientside/AbstractClientInterceptorsSetupTask.java
@@ -12,7 +12,7 @@ import static org.jboss.as.controller.client.helpers.ClientConstants.UNDEFINE_AT
 import static org.jboss.as.controller.client.helpers.ClientConstants.VALUE;
 import static org.jboss.as.controller.client.helpers.ClientConstants.WRITE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MODULE;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.net.URL;
@@ -102,7 +102,7 @@ public abstract class AbstractClientInterceptorsSetupTask {
 
             final ModelNode operationResult = managementClient.getControllerClient().execute(op);
             // check whether the operation was successful
-            assertTrue(Operations.isSuccessfulOutcome(operationResult));
+            assertThat(Operations.isSuccessfulOutcome(operationResult)).as(operationResult.asString()).isTrue();
         }
 
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/OpenTelemetryCollectorContainer.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/OpenTelemetryCollectorContainer.java
@@ -4,7 +4,7 @@
  */
 package org.jboss.as.test.shared.observability.containers;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -27,7 +27,6 @@ import org.jboss.as.test.shared.observability.signals.PrometheusMetric;
 import org.jboss.as.test.shared.observability.signals.jaeger.JaegerTrace;
 import org.jboss.as.test.shared.observability.signals.logs.CollectorLogRecordParser;
 import org.jboss.as.test.shared.observability.signals.logs.OpenTelemetryLogRecord;
-import org.junit.Assert;
 import org.testcontainers.utility.MountableFile;
 
 /**
@@ -255,10 +254,9 @@ public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetry
     @Deprecated
     public List<PrometheusMetric> fetchMetrics(String nameToMonitor) throws InterruptedException {
         return assertMetrics(prometheusMetrics -> {
-            assertTrue(
-                    String.format("Metric %s not seen in Prometheus within timeout.", nameToMonitor),
-                    prometheusMetrics.stream().anyMatch(x -> x.getKey().contains(nameToMonitor))
-            );
+            assertThat(prometheusMetrics.stream().anyMatch(x -> x.getKey().contains(nameToMonitor)))
+                    .as("Metric %s not seen in Prometheus within timeout.", nameToMonitor)
+                    .isTrue();
         });
     }
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/util/AssumeTestGroupUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/util/AssumeTestGroupUtil.java
@@ -5,16 +5,16 @@
 
 package org.jboss.as.test.shared.util;
 
-import static org.junit.Assume.assumeTrue;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.function.Supplier;
+
+import org.assertj.core.api.Assumptions;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.AssumptionViolatedException;
 import org.testcontainers.DockerClientFactory;
 
 /**
@@ -23,7 +23,7 @@ import org.testcontainers.DockerClientFactory;
  * the failing test method, or if you want to skip whole test class, then put the method call into method annotated with
  * {@link org.junit.BeforeClass}.
  * <p>
- * Methods whose names begin with 'assume' throw {@link AssumptionViolatedException} if the described assumption is not
+ * Methods whose names begin with 'assume' throw {@link AssertionError} if the described assumption is not
  * met; otherwise they return normally.  Other methods and constants in this class are meant for related use cases.
  * </p>
  *
@@ -36,7 +36,7 @@ public class AssumeTestGroupUtil {
      * An empty deployment archive that can be returned from an @Deployment method if the normal deployment
      * returned from the method cannot be successfully deployed under certain conditions. Arquillian will deploy
      * managed deployments <strong>before executing any @BeforeClass method</strong>, so if a @BeforeClass
-     * method conditionally disables running the tests with an AssumptionViolatedException, the deployment will
+     * method conditionally disables running the tests with an AssertionError, the deployment will
      * still get deployed and may fail the test. So have it deploy this instead so your @BeforeClass gets called.
      * <p>
      * This is private so it can be lazy initialized when needed, in case this class is used for other reasons
@@ -119,7 +119,7 @@ public class AssumeTestGroupUtil {
      * done in a {@link org.junit.Before @Before} or {@link org.junit.BeforeClass @BeforeClass} method.
      * </p>
      *
-     * @throws AssumptionViolatedException if the security manager is enabled
+     * @throws AssertionError if the security manager is enabled
      */
     public static void assumeSecurityManagerDisabled() {
         assumeCondition("Tests failing if the security manager is enabled.", AssumeTestGroupUtil::isSecurityManagerDisabled);
@@ -163,7 +163,7 @@ public class AssumeTestGroupUtil {
      *
      * @param javaSpecificationVersion the JDK specification version
      *
-     * @throws AssumptionViolatedException if the security manager is enabled or the JDK version is greater than or equal to {@code javaSpecificationVersion}
+     * @throws AssertionError if the security manager is enabled or the JDK version is greater than or equal to {@code javaSpecificationVersion}
      */
     public static void assumeSecurityManagerDisabledOrAssumeJDKVersionBefore(int javaSpecificationVersion) {
         assumeCondition("Tests failing if the security manager is enabled and JDK in use is after " + javaSpecificationVersion + ".",
@@ -175,7 +175,7 @@ public class AssumeTestGroupUtil {
      *
      * @param javaSpecificationVersion the JDK specification version. Use 8 for JDK 8. Must be 8 or higher.
      *
-     * @throws AssumptionViolatedException if the JDK version is less than or equal to {@code javaSpecificationVersion}
+     * @throws AssertionError if the JDK version is less than or equal to {@code javaSpecificationVersion}
      */
     public static void assumeJDKVersionAfter(int javaSpecificationVersion) {
         assert javaSpecificationVersion >= 11; // we only support 11 or later
@@ -188,7 +188,7 @@ public class AssumeTestGroupUtil {
      *
      * @param javaSpecificationVersion the JDK specification version. Must be 9 or higher.
      *
-     * @throws AssumptionViolatedException if the JDK version is greater than or equal to {@code javaSpecificationVersion}
+     * @throws AssertionError if the JDK version is greater than or equal to {@code javaSpecificationVersion}
      */
     public static void assumeJDKVersionBefore(int javaSpecificationVersion) {
         assert javaSpecificationVersion > 11; // we only support 11 or later so no reason to call this for 11
@@ -221,7 +221,7 @@ public class AssumeTestGroupUtil {
      * a value containing {@code ee-only-server}, e.g. {@code legacy-ee-only-server-tests },
      * which means we are using ee-build/ee-dist modules as the source where to find the server under test.
      *
-     * @throws AssumptionViolatedException if property {@code testsuite.default.build.project.prefix} is set to a non-empty value
+     * @throws AssertionError if property {@code testsuite.default.build.project.prefix} is set to a non-empty value
      */
     public static void assumeFullDistribution() {
         assumeCondition("Tests requiring full distribution are disabled", AssumeTestGroupUtil::isFullDistribution);
@@ -245,7 +245,7 @@ public class AssumeTestGroupUtil {
      * a value starting with {@code legacy-ee}, which means we are not using legacy/* modules as
      * the source where to find the server under test.
      *
-     * @throws AssumptionViolatedException if property {@code testsuite.default.build.project.prefix} is set to a non-empty value
+     * @throws AssertionError if property {@code testsuite.default.build.project.prefix} is set to a non-empty value
      */
     public static void assumeLegacyEEDistribution() {
         assumeCondition("Tests requiring a non-legacy EE distribution are disabled", AssumeTestGroupUtil::isLegacyEEDistribution);
@@ -264,13 +264,13 @@ public class AssumeTestGroupUtil {
     /**
      * Assume for tests that require a docker installation.
      *
-     * @throws AssumptionViolatedException if a docker client cannot be initialized
+     * @throws AssertionError if a docker client cannot be initialized
      * @throws RuntimeException if a docker client is required but is unavailable or not properly configured
      */
     public static void assumeDockerAvailable() {
         try {
             assumeCondition("Docker is not available.", AssumeTestGroupUtil::isDockerAvailable);
-        } catch (AssumptionViolatedException ex) {
+        } catch (AssertionError ex) {
             if (System.getProperty("org.wildfly.test.require.docker") != null && System.getProperty("org.wildfly.test.require.docker").equals("true")){
                 throw new RuntimeException("Docker is required but it is not available or is not properly configured");
             } else {
@@ -282,7 +282,7 @@ public class AssumeTestGroupUtil {
     /**
      * Checks whether a docker installation is available.
      *
-     * @throws AssumptionViolatedException if a docker client cannot be initialized
+     * @throws AssertionError if a docker client cannot be initialized
      */
     public static boolean isDockerAvailable() {
         try {
@@ -297,7 +297,7 @@ public class AssumeTestGroupUtil {
     /**
      * Assume for tests that should not run against a WildFly Preview installation.
      *
-     * @throws AssumptionViolatedException if one of the system properties that indicates WildFly Preview is being tested is set
+     * @throws AssertionError if one of the system properties that indicates WildFly Preview is being tested is set
      */
     public static void assumeNotWildFlyPreview() {
         assumeCondition("Some tests are disabled on WildFly Preview",
@@ -331,7 +331,7 @@ public class AssumeTestGroupUtil {
         AccessController.doPrivileged(new PrivilegedAction<Void>() {
             @Override
             public Void run() {
-                assumeTrue(message, assumeTrueCondition.get());
+                Assumptions.assumeThat(assumeTrueCondition.get()).as(message).isTrue();
                 return null;
             }
         });

--- a/testsuite/shared/src/main/java/org/wildfly/test/arquillian/assertj/AssertJArchiveAppender.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/arquillian/assertj/AssertJArchiveAppender.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.arquillian.assertj;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.CachedAuxilliaryArchiveAppender;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+/**
+ * An {@link org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender} that appends @{code org.assertj}
+ * and its dependencies to the archive.
+ *
+ * @see <a href="https://github.com/arquillian/arquillian-core/issues/859">https://github.com/arquillian/arquillian-core/issues/859</a>
+ * @author Radoslav Husar
+ */
+class AssertJArchiveAppender extends CachedAuxilliaryArchiveAppender {
+    @Override
+    protected Archive<?> buildArchive() {
+        return ShrinkWrap.create(JavaArchive.class, "wildfly-integration-tests-assertj.jar")
+                .addPackages(true, "org.assertj")
+                .addPackages(true, "net.bytebuddy")
+                ;
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/arquillian/assertj/AssertJLoadableExtension.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/arquillian/assertj/AssertJLoadableExtension.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.arquillian.assertj;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+/**
+ * A {@link LoadableExtension} that registers {@link AssertJArchiveAppender}.
+ *
+ * @see <a href="https://github.com/arquillian/arquillian-core/issues/859">https://github.com/arquillian/arquillian-core/issues/859</a>
+ * @author Radoslav Husar
+ */
+public class AssertJLoadableExtension implements LoadableExtension {
+    @Override
+    public void register(ExtensionBuilder extensionBuilder) {
+        extensionBuilder.service(AuxiliaryArchiveAppender.class, AssertJArchiveAppender.class);
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/distribution/validation/AbstractValidationUnitTest.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/distribution/validation/AbstractValidationUnitTest.java
@@ -5,9 +5,8 @@
 
 package org.wildfly.test.distribution.validation;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -237,13 +236,13 @@ public class AbstractValidationUnitTest {
     /**
      * The base directory, e.g. {@literal $user.home/../../build/target/jboss-*}.
      * <p/>
-     * Executes {@link org.junit.Assert#fail()} if the base directory is null.
+     * Fails if the base directory is null.
      *
      * @return the base directory.
      */
     protected static File getBaseDir() {
-        assertNotNull("'" + JBOSS_DIST_PROP_NAME + "' is not set.", JBOSS_DIST_DIR);
-        assertTrue("Directory set in '" + JBOSS_DIST_PROP_NAME + "' does not exist: " + JBOSS_DIST_DIR.getAbsolutePath(), JBOSS_DIST_DIR.exists());
+        assertThat(JBOSS_DIST_DIR).as("'" + JBOSS_DIST_PROP_NAME + "' is not set.").isNotNull();
+        assertThat(JBOSS_DIST_DIR).as("Directory set in '" + JBOSS_DIST_PROP_NAME + "' does not exist: " + JBOSS_DIST_DIR.getAbsolutePath()).exists();
         return JBOSS_DIST_DIR;
     }
 
@@ -297,7 +296,7 @@ public class AbstractValidationUnitTest {
                 }
             }
         }
-        assertNotNull(xsdName + " not found", url);
+        assertThat(url).as(xsdName + " not found").isNotNull();
         return url;
     }
 
@@ -408,7 +407,7 @@ public class AbstractValidationUnitTest {
     private static URL getXMLSchemaResource() {
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         final URL resource = classLoader.getResource("schema/XMLSchema.xsd");
-        assertNotNull("Can't locate resource schema/XMLSchema.xsd on " + classLoader, resource);
+        assertThat(resource).as("Can't locate resource schema/XMLSchema.xsd on " + classLoader).isNotNull();
         return resource;
     }
 

--- a/testsuite/shared/src/main/java/org/wildfly/test/distribution/validation/ProvisioningConsistencyBaseTest.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/distribution/validation/ProvisioningConsistencyBaseTest.java
@@ -5,11 +5,10 @@
 
 package org.wildfly.test.distribution.validation;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.jboss.as.test.shared.FileUtils.computeHash;
 import static org.jboss.as.test.shared.FileUtils.unzipFile;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,8 +26,8 @@ import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.io.FileUtils;
+import org.assertj.core.api.Assumptions;
 import org.jboss.logging.Logger;
-import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -81,7 +80,9 @@ public abstract class ProvisioningConsistencyBaseTest {
     private static void assumeJbossDistIsNotExternallySet() throws IOException {
         Path jbossDist = new File(System.getProperty("jboss.dist")).getCanonicalFile().toPath();
         Path defaultJbossDist = SOURCE_HOME.resolve(System.getProperty("build.output.dir"));
-        Assume.assumeTrue(jbossDist.equals(defaultJbossDist));
+        Assumptions.assumeThat(jbossDist.equals(defaultJbossDist))
+                .as("jboss.dist is externally set")
+                .isTrue();
     }
 
     /**
@@ -104,7 +105,7 @@ public abstract class ProvisioningConsistencyBaseTest {
                     Set<String> channelChildren = new TreeSet<>(Arrays.asList(Objects.requireNonNull(dir.toFile().list())));
                     channelChildren.remove(PROVISIONING);
                     Set<String> distChildren = new TreeSet<>(Arrays.asList(Objects.requireNonNull(distRoot.list())));
-                    assertEquals(dir.toString(), channelChildren, distChildren);
+                    assertThat(distChildren).as(dir.toString()).isEqualTo(channelChildren);
                     return FileVisitResult.CONTINUE;
                 } else if (dir.equals(INSTALLATION_METADATA)) {
                     installationMetadata.set(dir);
@@ -126,7 +127,7 @@ public abstract class ProvisioningConsistencyBaseTest {
                 } else {
                     File distDir = getDistFile(dir, true, true, errors);
                     if (distDir != null) {
-                        assertTrue(dir.toString(), Objects.deepEquals(dir.toFile().list(), distDir.list()));
+                        assertThat(dir.toFile().list()).as(dir.toString()).isEqualTo(distDir.list());
                         return FileVisitResult.CONTINUE;
                     } else {
                         return FileVisitResult.SKIP_SUBTREE;
@@ -185,8 +186,8 @@ public abstract class ProvisioningConsistencyBaseTest {
         File test = path.toFile();
         File result = null;
         if (distRoot.equals(path)) {
-            assertTrue(path + " does not exist", test.exists());
-            assertTrue(path + " is not a directory", test.isDirectory());
+            assertThat(test).as(path + " does not exist").exists();
+            assertThat(test).as(path + " is not a directory").isDirectory();
             result = test;
         } else {
             if (exists) {
@@ -245,12 +246,12 @@ public abstract class ProvisioningConsistencyBaseTest {
                     File distRoot = getDistFile(currentRoot, dir, dist, true, true, errors);
                     Set<String> channelChildren = new TreeSet<>(Arrays.asList(Objects.requireNonNull(dir.toFile().list())));
                     Set<String> distChildren = new TreeSet<>(Arrays.asList(Objects.requireNonNull(distRoot.list())));
-                    assertEquals(dir.toString(), channelChildren, distChildren);
+                    assertThat(distChildren).as(dir.toString()).isEqualTo(channelChildren);
                     return FileVisitResult.CONTINUE;
                 } else {
                     File distDir = getDistFile(currentRoot, dir, dist, true, true, errors);
                     if (distDir != null) {
-                        assertTrue(dir.toString(), Objects.deepEquals(dir.toFile().list(), distDir.list()));
+                        assertThat(dir.toFile().list()).as(dir.toString()).isEqualTo(distDir.list());
                         return FileVisitResult.CONTINUE;
                     } else {
                         return FileVisitResult.SKIP_SUBTREE;

--- a/testsuite/shared/src/main/java/org/wildfly/test/stabilitylevel/StabilityServerSetupSnapshotRestoreTasks.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/stabilitylevel/StabilityServerSetupSnapshotRestoreTasks.java
@@ -5,18 +5,23 @@
 
 package org.wildfly.test.stabilitylevel;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_OPERATION_DESCRIPTION_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_OPERATION_NAMES_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELOAD_ENHANCED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STABILITY;
-import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
 
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Assumptions;
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.PathAddress;
@@ -25,11 +30,10 @@ import org.jboss.as.controller.client.helpers.ClientConstants;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.integration.management.ManagementOperations;
-import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelNode;
-import org.junit.Assert;
-import org.junit.Assume;
 
 /**
  * For tests that need to run under a specific server stability level,
@@ -57,19 +61,21 @@ public class StabilityServerSetupSnapshotRestoreTasks implements ServerSetupTask
     public final void setup(ManagementClient managementClient, String containerId) throws Exception {
         // Make sure the desired stability level is one of the ones supported by the server
         Set<Stability> supportedStabilityLevels = getSupportedStabilityLevels(managementClient);
-        Assume.assumeTrue(
-                String.format("%s is not a supported stability level. Supported levels: %s", desiredStability, supportedStabilityLevels),
-                supportedStabilityLevels.contains(desiredStability));
+        Assumptions.assumeThat(supportedStabilityLevels.contains(desiredStability))
+                .as("%s is not a supported stability level. Supported levels: %s", desiredStability, supportedStabilityLevels)
+                .isTrue();
 
         // Check the reload-enhanced operation exists in the current stability level
-        Assume.assumeTrue(
-                "The reload-enhanced operation is not registered at this stability level",
-                checkReloadEnhancedOperationIsAvailable(managementClient));
+        Assumptions.assumeThat(checkReloadEnhancedOperationIsAvailable(managementClient))
+                .as("The reload-enhanced operation is not registered at this stability level")
+                .isTrue();
 
         // Check the reload-enhanced operation exists in the stability level we want to load to so that
         // we can reload back to the current one
         Stability reloadOpStability = getReloadEnhancedOperationStabilityLevel(managementClient);
-        Assume.assumeTrue(desiredStability.enables(reloadOpStability));
+        Assumptions.assumeThat(desiredStability.enables(reloadOpStability))
+                .as("The reload-enhanced operation is not available at the desired stability level")
+                .isTrue();
 
         originalStability = readCurrentStability(managementClient.getControllerClient());
 
@@ -79,7 +85,7 @@ public class StabilityServerSetupSnapshotRestoreTasks implements ServerSetupTask
         // We only want to reload to lower stability levels if necessary (e.g. when running the ts.preview tests,
         // container that contains any configuration at 'preview' level the reload to 'community' would fail)
         if (!originalStability.enables(desiredStability)) {
-            reloadToDesiredStability(managementClient.getControllerClient(), desiredStability);
+            reloadToDesiredStability(managementClient, desiredStability);
         }
 
         // Do any additional setup from the subclasses
@@ -120,6 +126,7 @@ public class StabilityServerSetupSnapshotRestoreTasks implements ServerSetupTask
         return Stability.fromString(stability);
 
     }
+
     private Set<Stability> getSupportedStabilityLevels(ManagementClient managementClient) throws Exception {
         ModelNode op = Util.getReadAttributeOperation(PathAddress.pathAddress(CORE_SERVICE, SERVER_ENVIRONMENT), "permissible-stability-levels");
         ModelNode result = ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
@@ -130,21 +137,18 @@ public class StabilityServerSetupSnapshotRestoreTasks implements ServerSetupTask
         return set;
     }
 
-    private Stability reloadToDesiredStability(ModelControllerClient client, Stability stability) throws Exception {
+    private Stability reloadToDesiredStability(ManagementClient managementClient, Stability stability) throws Exception {
         // Check the stability
-        Stability currentStability = readCurrentStability(client);
+        Stability currentStability = readCurrentStability(managementClient.getControllerClient());
         if (currentStability == stability) {
             return originalStability;
         }
 
         //Reload the server to the desired stability level
-        ServerReload.Parameters parameters = new ServerReload.Parameters()
-                .setStability(stability);
-        // Execute the reload
-        ServerReload.executeReloadAndWaitForCompletion(client, parameters);
+        reloadEnhancedAndWaitForCompletion(managementClient, stability, null);
 
-        Stability reloadedStability = readCurrentStability(client);
-        Assert.assertEquals(stability, reloadedStability);
+        Stability reloadedStability = readCurrentStability(managementClient.getControllerClient());
+        assertThat(reloadedStability).isEqualTo(stability);
         return originalStability;
     }
 
@@ -197,33 +201,24 @@ public class StabilityServerSetupSnapshotRestoreTasks implements ServerSetupTask
             node.get(ModelDescriptionConstants.OP).set("take-snapshot");
             ModelNode result = client.getControllerClient().execute(node);
             if (!"success".equals(result.get(ClientConstants.OUTCOME).asString())) {
-                fail("take-snapshot operation didn't finish successfully: " + result.asString());
+                Assertions.fail("take-snapshot operation didn't finish successfully: " + result.asString());
             }
             String snapshot = result.get(ModelDescriptionConstants.RESULT).asString();
             final String fileName = snapshot.contains(File.separator) ? snapshot.substring(snapshot.lastIndexOf(File.separator) + 1) : snapshot;
             return new AutoCloseable() {
                 @Override
                 public void close() throws Exception {
-                    ServerReload.Parameters parameters = new ServerReload.Parameters();
-                    parameters.setServerConfig(fileName);
                     if (reloadToStability != null) {
-                        parameters.setStability(reloadToStability);
+                        reloadEnhancedAndWaitForCompletion(client, reloadToStability, fileName);
+                    } else {
+                        ServerReload.executeReloadAndWaitForCompletion(client.getControllerClient(), ServerReload.TIMEOUT, false, client.getMgmtAddress(), client.getMgmtPort(), fileName);
                     }
 
-                    if (client.getMgmtAddress() != null) {
-                        parameters.setServerAddress(client.getMgmtAddress());
-                    }
-                    if (client.getMgmtPort() > 0) {
-                        parameters.setServerPort(client.getMgmtPort());
-                    }
-
-                    ServerReload.executeReloadAndWaitForCompletion(client.getControllerClient(), parameters);
-
-                    ModelNode node = new ModelNode();
-                    node.get(ModelDescriptionConstants.OP).set("write-config");
-                    ModelNode result = client.getControllerClient().execute(node);
-                    if (!"success".equals(result.get(ClientConstants.OUTCOME).asString())) {
-                        fail("Failed to write config after restoring from snapshot " + result.asString());
+                    ModelNode node1 = new ModelNode();
+                    node1.get(ModelDescriptionConstants.OP).set("write-config");
+                    ModelNode result1 = client.getControllerClient().execute(node1);
+                    if (!"success".equals(result1.get(ClientConstants.OUTCOME).asString())) {
+                        Assertions.fail("Failed to write config after restoring from snapshot " + result1.asString());
                     }
                 }
             };
@@ -231,4 +226,30 @@ public class StabilityServerSetupSnapshotRestoreTasks implements ServerSetupTask
             throw new RuntimeException("Failed to take snapshot", e);
         }
     }
+
+    // Temporary duplication until org.jboss.as.test.integration.management.util.ServerReload removed hard dependency on legacy JUnit 4
+    private static void reloadEnhancedAndWaitForCompletion(ManagementClient client, Stability stability, String serverConfig) {
+        ModelNode operation = new ModelNode();
+        operation.get(ModelDescriptionConstants.OP_ADDR).setEmptyList();
+        operation.get(ModelDescriptionConstants.OP).set(RELOAD_ENHANCED);
+        operation.get(STABILITY).set(stability.toString());
+        if (serverConfig != null) {
+            operation.get("server-config").set(serverConfig);
+        }
+        try {
+            ModelNode result = client.getControllerClient().execute(operation);
+            if (!"success".equals(result.get(ClientConstants.OUTCOME).asString())) {
+                Assertions.fail("Reload operation didn't finish successfully: " + result.asString());
+            }
+        } catch (IOException e) {
+            final Throwable cause = e.getCause();
+            if (!(cause instanceof ExecutionException) && !(cause instanceof CancellationException)) {
+                throw new RuntimeException(e);
+            }
+        }
+        ServerReload.waitForLiveServerToReload(ServerReload.TIMEOUT,
+                client.getMgmtAddress() != null ? client.getMgmtAddress() : TestSuiteEnvironment.getServerAddress(),
+                client.getMgmtPort() > 0 ? client.getMgmtPort() : TestSuiteEnvironment.getServerPort());
+    }
+
 }

--- a/testsuite/shared/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/testsuite/shared/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -3,4 +3,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+org.wildfly.test.arquillian.assertj.AssertJLoadableExtension
 org.jboss.as.test.shared.SnapshotRestoreLoadableExtension


### PR DESCRIPTION
I know a few people tried and failed, but not this time!

Been long on my list and this poor Maven practice should be cleaned up. The problem is people randomly adding dependencies to parent poms which are creating dependency hell in the individual modules. Practical example is leaking JUnit 4 into modules so people don’t realize that some suites are already moved from JUnit 4 yet their PRs compile.

testsuite/pom.xml and testsuite/integration/pom.xml declare dependencies in <dependencies> which are unconditionally inherited by all child modules with no way to exclude in Maven inheritance, regardless of whether those modules actually need them while only wildfly-arquillian-container-managed and wildfly-arquillian-protocol-jmx are required by all child modules.

The fix is to remove all shared dependencies from the parent POMs and declare each dependency only in the modules that actually need it.

The bigger chunk of the work is *decoupling* the shared module from hard dependency on JUnit 4 version and standardizing it on testing-platform-agnostic `assertj-core` favored by many on the team.

More details on the Jira
https://redhat.atlassian.net/browse/WFLY-22034
