### PR TITLE
Fix stale directory reference in wildfly-bot.yml

### DIFF
--- a/.github/wildfly-bot.yml
+++ b/.github/wildfly-bot.yml
@@ -83,7 +83,7 @@ wildfly:
     - id: messaging-activemq
       directories:
         - messaging-activemq
-        - testsuite/integration/legacy
+        - testsuite/integration/hornetq-client
       notify: [ ehsavoie ]
 
     - id: metrics


### PR DESCRIPTION
The directory `testsuite/integration/legacy` was renamed to `testsuite/integration/hornetq-client` in PR #20085 (WFLY-21944), but `wildfly-bot.yml` was not updated to reflect this change. That causes an error when parsing the config file.

@wildfly-bot[bot] skip format