### PR TITLE
[WFLY-21799] Remove MP REST Client 3.0 logic from testsuite/integration/microprofile-tck/rest-client/pom.xml

### DIFF
--- a/boms/standard-test/pom.xml
+++ b/boms/standard-test/pom.xml
@@ -300,14 +300,6 @@
                 </exclusions>
             </dependency>
 
-            <!-- used in the MicroProfile REST Client TCK -->
-            <dependency>
-                <groupId>org.jboss.spec.javax.servlet</groupId>
-                <artifactId>jboss-servlet-api_4.0_spec</artifactId>
-                <version>${version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec}</version>
-                <scope>test</scope>
-            </dependency>
-
             <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,6 @@
              versions of the Shrinkwrap Resolvers. -->
         <version.org.jboss.shrinkwrap.resolvers>2.2.7</version.org.jboss.shrinkwrap.resolvers>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
-        <version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>2.0.0.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>
         <version.org.junit>5.14.4</version.org.junit>
         <version.org.keycloak>25.0.6</version.org.keycloak>
         <version.org.mockito>5.21.0</version.org.mockito>

--- a/testsuite/integration/microprofile-tck/rest-client/pom.xml
+++ b/testsuite/integration/microprofile-tck/rest-client/pom.xml
@@ -422,13 +422,6 @@
                                     <groupId>org.wiremock</groupId>
                                     <artifactId>wiremock</artifactId>
                                 </artifactItem>
-                                <!-- This is required for the MicroProfile REST Client 3.0 TCK. This will always copy it,
-                                     but we'll only use it in the 3.0 TCK runner.
-                                 -->
-                                <artifactItem>
-                                    <groupId>org.jboss.spec.javax.servlet</groupId>
-                                    <artifactId>jboss-servlet-api_4.0_spec</artifactId>
-                                </artifactItem>
                             </artifactItems>
                             <stripVersion>true</stripVersion>
                             <outputDirectory>${wiremock.lib.path}</outputDirectory>


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/WFLY-21799

The references to the old jboss-servlet-api_4.0_spec artifact have been removed