### PR TITLE
Test/cxf 4.1.8 jbossorg 1 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -475,7 +475,7 @@
         <version.org.apache.activemq.artemis>2.54.0</version.org.apache.activemq.artemis>
         <version.org.apache.activemq.artemis.native>2.0.0</version.org.apache.activemq.artemis.native>
         <version.org.apache.avro>1.12.1</version.org.apache.avro>
-        <version.org.apache.cxf>4.1.6</version.org.apache.cxf>
+        <version.org.apache.cxf>4.1.8-jbossorg-1</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>4.1.3</version.org.apache.cxf.xjcplugins>
         <version.org.apache.httpcomponents.httpasyncclient>4.1.5</version.org.apache.httpcomponents.httpasyncclient>
         <version.org.apache.james.apache-mime4j>0.8.14</version.org.apache.james.apache-mime4j>

--- a/pom.xml
+++ b/pom.xml
@@ -1023,6 +1023,12 @@
             <url>${maven.repository.url}</url>
             <layout>default</layout>
         </repository>
+        <repository>
+            <id>jboss-staging</id>
+            <name>JBoss Staging Repository</name>
+            <url>https://repository.jboss.org/nexus/repository/jboss-io/</url>
+            <layout>default</layout>
+        </repository>
     </repositories>
 
     <pluginRepositories>


### PR DESCRIPTION
Test to validate the `org.apache.cxf` 4.1.8-jbossorg-1 release
