### PR TITLE
[WFLY-22067] Upgrade WildFly Core to 33.0.0.Final

### DIFF
--- a/legacy/security/subsystem/src/test/java/org/jboss/as/security/JSSEParsingUnitTestCase.java
+++ b/legacy/security/subsystem/src/test/java/org/jboss/as/security/JSSEParsingUnitTestCase.java
@@ -58,7 +58,8 @@ public class JSSEParsingUnitTestCase {
     public void initializeParser() throws Exception {
         //Initialize the parser
         xmlMapper = XMLMapper.Factory.create();
-        extensionParsingRegistry = new ExtensionRegistry(ProcessType.EMBEDDED_SERVER, new RunningModeControl(RunningMode.NORMAL), null, null, null, null);
+        // legacy extensions require ADMIN-ONLY to initialize parsers on servers other than domain server
+        extensionParsingRegistry = new ExtensionRegistry(ProcessType.EMBEDDED_SERVER, new RunningModeControl(RunningMode.ADMIN_ONLY), null, null, null, null);
         testParser = new TestParser(mainSubsystemName, extensionParsingRegistry);
         xmlMapper.registerRootElement(new QName(TEST_NAMESPACE, "test"), testParser);
         mainExtension.initializeParsers(extensionParsingRegistry.getExtensionParsingContext("Test", xmlMapper));

--- a/pom.xml
+++ b/pom.xml
@@ -570,7 +570,7 @@
         <!--
             Maintain separation between these two frequently updated artifacts to avoid merge conflicts.
         -->
-        <version.org.wildfly.core>33.0.0.Beta5</version.org.wildfly.core>
+        <version.org.wildfly.core>33.0.0.Final</version.org.wildfly.core>
         <!--
             Maintain separation between these two frequently updated artifacts to avoid merge conflicts.
         -->


### PR DESCRIPTION
Jira issue: https://redhat.atlassian.net/browse/WFLY-22067

Supersedes 
https://redhat.atlassian.net/browse/WFLY-22068
https://github.com/wildfly/wildfly/pull/20229

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/33.0.0.Final
Diff: https://github.com/wildfly/wildfly-core/compare/33.0.0.Beta5...33.0.0.Final

---

<details>
<div class="csg-wrapper" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif; font-size: 14px; font-weight: 400; line-height: 24px; vertical-align: baseline;"><h1 class="csg-h1" style="font-style: inherit; color: #172B4D; font-weight: 600; margin-bottom: 0; font-size: 29px; line-height: 1.10; margin-top: 40px; letter-spacing: -0.01em;">Release notes - WildFly Core - 33.0.0.Final</h1><h3 class="csg-h3" style="font-style: inherit; color: #172B4D; font-weight: 600; margin-bottom: 0; font-size: 20px; line-height: 1.20; font-weight: 500; letter-spacing: -0.008em;">Bug</h3><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7638" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7638</a> AbstractLegacyExtension don't throw UnsupportedOperationException when added on Embedded (and other server process types)</p><h3 class="csg-h3" style="font-style: inherit; color: #172B4D; font-weight: 600; margin-bottom: 0; font-size: 20px; line-height: 1.20; font-weight: 500; letter-spacing: -0.008em;">Component Upgrade</h3><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7635" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7635</a> Upgrade to aesh-readline 2.6.3</p><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7636" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7636</a> Upgrade wildfly-bom-builder-plugin to 2.0.11</p><h3 class="csg-h3" style="font-style: inherit; color: #172B4D; font-weight: 600; margin-bottom: 0; font-size: 20px; line-height: 1.20; font-weight: 500; letter-spacing: -0.008em;">Enhancement</h3><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-7625" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-7625</a> TimeoutUtil.adjust(int) loses precision; add Duration-based API</p><h3 class="csg-h3" style="font-style: inherit; color: #172B4D; font-weight: 600; margin-bottom: 0; font-size: 20px; line-height: 1.20; font-weight: 500; letter-spacing: -0.008em;">Task</h3><p class="csg-p" style="margin: 0; padding: 0px; margin-bottom: 7px; padding-top: 7px; mso-line-height-rule: exactly; line-height: 24px; font-size: 14px;"><a href="https://redhat.atlassian.net/browse/WFCORE-6089" class="csg-mark-link" style="border: none; background: transparent; color: #0052cc; text-decoration: none;">WFCORE-6089</a> Ban transitive dependencies in the controller-client module</p></div>
</details>


