### PR TITLE
[WFLY-21999] Upgrade Apache CXF component to 4.1.8-jbossorg-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -474,7 +474,7 @@
         <version.org.apache.activemq.artemis>2.54.0</version.org.apache.activemq.artemis>
         <version.org.apache.activemq.artemis.native>2.0.0</version.org.apache.activemq.artemis.native>
         <version.org.apache.avro>1.12.1</version.org.apache.avro>
-        <version.org.apache.cxf>4.1.6</version.org.apache.cxf>
+        <version.org.apache.cxf>4.1.8-jbossorg-1</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>4.1.3</version.org.apache.cxf.xjcplugins>
         <version.org.apache.httpcomponents.httpasyncclient>4.1.5</version.org.apache.httpcomponents.httpasyncclient>
         <version.org.apache.james.apache-mime4j>0.8.14</version.org.apache.james.apache-mime4j>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21999

This is #20228 but without the staging repo stuff. It looks like 4.1.8-jbossorg-1 is available from the normal JBoss Nexus repo now since I was able to build this locally.

@fabiobrz I sent this up because I'd like to get it into tonight's TCK run so tomorrow can just be a buffer day before tagging WF 41 on Wed. I kept the existing WFLY-21999 Jira, figuring we could just tweak its title and description.