### PR TITLE
[WFLY-20962] optimize the JPA/Persistence Statistics SPI to better handle higher hibernate.statistics.query_max_size settings

### DIFF
--- a/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/management/HibernateAbstractStatistics.java
+++ b/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/management/HibernateAbstractStatistics.java
@@ -15,6 +15,7 @@ import java.util.Set;
 
 import jakarta.persistence.EntityManagerFactory;
 
+import org.hibernate.SessionFactory;
 import org.jipijapa.management.spi.EntityManagerFactoryAccess;
 import org.jipijapa.management.spi.Operation;
 import org.jipijapa.management.spi.PathAddress;
@@ -121,9 +122,44 @@ public abstract class HibernateAbstractStatistics implements Statistics {
         return null;
     }
 
+    protected org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress) {
+        if (entityManagerFactoryLookup == null || pathAddress == null) {
+            return null;
+        }
+        return getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL)));
+    }
+
+    protected org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
+        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
+        if (sessionFactory != null) {
+            return sessionFactory.getStatistics();
+        }
+        return null;
+    }
+
     @Override
     public Set<String> getChildrenNames() {
         return Collections.unmodifiableSet(childrenNames);
+    }
+
+    @Override
+    public boolean hasChildName(String name) {
+        return childrenNames.contains(name);
+    }
+
+    protected static boolean existsInDynamicChildren(String childName, String[] dynamicChildrenNames) {
+        if (dynamicChildrenNames == null) {
+            return false;
+        }
+        for (String name : dynamicChildrenNames) {
+            if (name.equals(childName)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/management/HibernateCollectionStatistics.java
+++ b/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/management/HibernateCollectionStatistics.java
@@ -12,6 +12,7 @@ import jakarta.persistence.EntityManagerFactory;
 
 import org.hibernate.SessionFactory;
 import org.hibernate.stat.CollectionStatistics;
+import org.hibernate.stat.Statistics;
 import org.jipijapa.management.spi.EntityManagerFactoryAccess;
 import org.jipijapa.management.spi.Operation;
 import org.jipijapa.management.spi.PathAddress;
@@ -62,15 +63,11 @@ public class HibernateCollectionStatistics extends HibernateAbstractStatistics {
         return Collections.unmodifiableCollection(Arrays.asList(stats.getCollectionRoleNames()));
     }
 
-    private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
-        if (entityManagerFactory == null) {
-            return null;
-        }
-        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
-        if (sessionFactory != null) {
-            return sessionFactory.getStatistics();
-        }
-        return null;
+    @Override
+    public boolean hasDynamicChildName(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress,
+            String childName) {
+        Statistics stats = getBaseStatistics(entityManagerFactoryLookup, pathAddress);
+        return stats == null ? false : existsInDynamicChildren(childName, stats.getCollectionRoleNames());
     }
 
     private CollectionStatistics getStatistics(final EntityManagerFactory entityManagerFactory, PathAddress pathAddress) {

--- a/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/management/HibernateEntityCacheStatistics.java
+++ b/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/management/HibernateEntityCacheStatistics.java
@@ -8,9 +8,9 @@ package org.jboss.as.jpa.hibernate.management;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import jakarta.persistence.EntityManagerFactory;
 
 import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
 import org.jipijapa.management.spi.EntityManagerFactoryAccess;
 import org.jipijapa.management.spi.Operation;
 import org.jipijapa.management.spi.PathAddress;
@@ -62,15 +62,11 @@ public class HibernateEntityCacheStatistics extends HibernateAbstractStatistics 
         return Collections.unmodifiableCollection(Arrays.asList(stats.getEntityNames()));
     }
 
-    private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
-        if (entityManagerFactory == null) {
-            return null;
-        }
-        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
-        if (sessionFactory != null) {
-            return sessionFactory.getStatistics();
-        }
-        return null;
+    @Override
+    public boolean hasDynamicChildName(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress,
+            String childName) {
+        Statistics stats = getBaseStatistics(entityManagerFactoryLookup, pathAddress);
+        return stats == null ? false : existsInDynamicChildren(childName, stats.getEntityNames());
     }
 
     org.hibernate.stat.CacheRegionStatistics getStatistics(EntityManagerFactoryAccess entityManagerFactoryaccess, PathAddress pathAddress) {

--- a/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/management/HibernateEntityStatistics.java
+++ b/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/management/HibernateEntityStatistics.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import jakarta.persistence.EntityManagerFactory;
 
 import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
 import org.jipijapa.management.spi.EntityManagerFactoryAccess;
 import org.jipijapa.management.spi.Operation;
 import org.jipijapa.management.spi.PathAddress;
@@ -52,17 +53,6 @@ public class HibernateEntityStatistics extends HibernateAbstractStatistics {
 
         operations.put(OPERATION_OPTIMISTIC_FAILURE_COUNT, optimisticFailureCount);
         types.put(OPERATION_OPTIMISTIC_FAILURE_COUNT, Long.class);
-    }
-
-    private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
-        if (entityManagerFactory == null) {
-            return null;
-        }
-        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
-        if (sessionFactory != null) {
-            return sessionFactory.getStatistics();
-        }
-        return null;
     }
 
     private org.hibernate.stat.EntityStatistics getStatistics(EntityManagerFactory entityManagerFactory, PathAddress pathAddress) {
@@ -134,8 +124,15 @@ public class HibernateEntityStatistics extends HibernateAbstractStatistics {
     public Collection<String> getDynamicChildrenNames(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress) {
         org.hibernate.stat.Statistics statistics = getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL)));
         return statistics != null ?
-            Collections.unmodifiableCollection(Arrays.asList( statistics.getEntityNames())) :
-                Collections.EMPTY_LIST;
+            Collections.unmodifiableCollection(Arrays.asList(statistics.getEntityNames())) :
+                Collections.emptyList();
 
+    }
+
+    @Override
+    public boolean hasDynamicChildName(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress,
+            String childName) {
+        Statistics stats = getBaseStatistics(entityManagerFactoryLookup, pathAddress);
+        return stats == null ? false : existsInDynamicChildren(childName, stats.getEntityNames());
     }
 }

--- a/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/management/HibernateQueryCacheStatistics.java
+++ b/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/management/HibernateQueryCacheStatistics.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import jakarta.persistence.EntityManagerFactory;
 
 import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
 import org.jipijapa.management.spi.EntityManagerFactoryAccess;
 import org.jipijapa.management.spi.Operation;
 import org.jipijapa.management.spi.PathAddress;
@@ -80,15 +81,24 @@ public class HibernateQueryCacheStatistics extends HibernateAbstractStatistics {
         return result;
     }
 
-    private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
-        if (entityManagerFactory == null) {
-            return null;
+    @Override
+    public boolean hasDynamicChildName(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress,
+            String childName) {
+        Statistics stats = getBaseStatistics(entityManagerFactoryLookup, pathAddress);
+        if (stats == null) {
+            return false;
         }
-        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
-        if (sessionFactory != null) {
-            return sessionFactory.getStatistics();
+        String[] queries = stats.getQueries();
+        if (queries == null) {
+            return false;
         }
-        return null;
+        // we cant call existsInDynamicChildren() because we need to match by display names
+        for (String name : queries) {
+            if (childName.equals(QueryName.queryName(name).getDisplayName())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private org.hibernate.stat.QueryStatistics getStatistics(EntityManagerFactory entityManagerFactory, String displayQueryName) {

--- a/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/management/HibernateStatistics.java
+++ b/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/management/HibernateStatistics.java
@@ -209,9 +209,15 @@ public class HibernateStatistics extends HibernateAbstractStatistics {
     }
 
     @Override
-    public Collection<String> getDynamicChildrenNames(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress) {
+    public Collection<String> getDynamicChildrenNames(EntityManagerFactoryAccess entityManagerFactoryAccess,
+            PathAddress pathAddress) {
+        return Collections.emptyList();
+    }
 
-        return Collections.EMPTY_LIST;
+    @Override
+    public boolean hasDynamicChildName(EntityManagerFactoryAccess entityManagerFactoryAccess, PathAddress pathAddress,
+            String childName) {
+        return false;
     }
 
     private Operation clear = new Operation() {

--- a/jpa/hibernate6/src/test/java/org/jboss/as/jpa/hibernate/management/HibernateStatisticsTestCase.java
+++ b/jpa/hibernate6/src/test/java/org/jboss/as/jpa/hibernate/management/HibernateStatisticsTestCase.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.jpa.hibernate.management;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test class for verifying the operations of the Statistics classes.
+ *
+ * @author Ilias Bourdakos
+ */
+public class HibernateStatisticsTestCase {
+
+    /** The available statistics classes */
+    // in the future maybe each statistics class will require its own test class
+    HibernateAbstractStatistics[] testStats = new HibernateAbstractStatistics[] {
+        new HibernateStatistics(),
+        new HibernateEntityStatistics(),
+        new HibernateCollectionStatistics(),
+        new HibernateEntityCacheStatistics(),
+        new HibernateQueryCacheStatistics()
+    };
+
+    /**
+     * Verifies that {@code hasChildName} correctly identifies known children for each
+     * statistics class, rejects non-existing and null names, and produces results consistent
+     * with {@code getChildrenNames().contains()}.
+     */
+    @Test
+    public void testHibernateStatisticshasChildName() {
+        for (HibernateAbstractStatistics stats : testStats) {
+            String statsClass = stats.getClass().getName();
+
+            if (stats instanceof HibernateStatistics) {
+                assertTrue(stats.hasChildName("entity"), "Should find 'entity' child (statistics class=" + statsClass + ")");
+                assertTrue(stats.hasChildName("collection"), "Should find 'collection' child (statistics class=" + statsClass + ")");
+                assertTrue(stats.hasChildName("entity-cache"), "Should find 'entity-cache' child (statistics class=" + statsClass + ")");
+                assertTrue(stats.hasChildName("query-cache"), "Should find 'query-cache' child (statistics class=" + statsClass + ")");
+            }
+
+            assertFalse(stats.hasChildName("non-existing-child"), "Should not find non-existing child (statistics class=" + statsClass + ")");
+            assertFalse(stats.hasChildName(null), "Should not find null child (statistics class=" + statsClass + ")");
+
+            for (String childName : stats.getChildrenNames()) {
+                assertEquals(stats.hasChildName(childName), stats.getChildrenNames().contains(childName),
+                    "hasChildName should give same result as getChildrenNames().contains() for existing child (statistics class=" + statsClass + ")");
+            }
+            assertEquals(stats.hasChildName("non-existing"), stats.getChildrenNames().contains("non-existing"),
+                "hasChildName should give same result as getChildrenNames().contains() for non-existing child (statistics class=" + statsClass + ")");
+        }
+    }
+
+    /**
+     * Verifies that {@code hasDynamicChildName} returns false for all statistics classes
+     * when both the {@code EntityManagerFactoryAccess} and {@code PathAddress} are null.
+     */
+    @Test
+    public void testHibernateStatisticsHasDynamicChildNameNullFactoryPath() {
+        for (HibernateAbstractStatistics stats : testStats) {
+            String statsClass = stats.getClass().getName();
+
+            assertFalse(stats.hasDynamicChildName(null, null, "any-name"),
+            "HibernateStatistics should not have dynamic children (statistics class=" + statsClass + ")");
+        }
+    }
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateAbstractStatistics.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateAbstractStatistics.java
@@ -14,6 +14,8 @@ import java.util.ResourceBundle;
 import java.util.Set;
 
 import jakarta.persistence.EntityManagerFactory;
+
+import org.hibernate.SessionFactory;
 import org.jipijapa.management.spi.EntityManagerFactoryAccess;
 import org.jipijapa.management.spi.Operation;
 import org.jipijapa.management.spi.PathAddress;
@@ -120,9 +122,44 @@ public abstract class HibernateAbstractStatistics implements Statistics {
         return null;
     }
 
+    protected org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress) {
+        if (entityManagerFactoryLookup == null || pathAddress == null) {
+            return null;
+        }
+        return getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL)));
+    }
+
+    protected org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
+        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
+        if (sessionFactory != null) {
+            return sessionFactory.getStatistics();
+        }
+        return null;
+    }
+
     @Override
     public Set<String> getChildrenNames() {
         return Collections.unmodifiableSet(childrenNames);
+    }
+
+    @Override
+    public boolean hasChildName(String name) {
+        return childrenNames.contains(name);
+    }
+
+    protected static boolean existsInDynamicChildren(String childName, String[] dynamicChildrenNames) {
+        if (dynamicChildrenNames == null) {
+            return false;
+        }
+        for (String name : dynamicChildrenNames) {
+            if (name.equals(childName)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateCollectionStatistics.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateCollectionStatistics.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import jakarta.persistence.EntityManagerFactory;
 import org.hibernate.SessionFactory;
 import org.hibernate.stat.CollectionStatistics;
+import org.hibernate.stat.Statistics;
 import org.jipijapa.management.spi.EntityManagerFactoryAccess;
 import org.jipijapa.management.spi.Operation;
 import org.jipijapa.management.spi.PathAddress;
@@ -62,15 +63,11 @@ public class HibernateCollectionStatistics extends HibernateAbstractStatistics {
         return Collections.unmodifiableCollection(Arrays.asList(stats.getCollectionRoleNames()));
     }
 
-    private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
-        if (entityManagerFactory == null) {
-            return null;
-        }
-        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
-        if (sessionFactory != null) {
-            return sessionFactory.getStatistics();
-        }
-        return null;
+    @Override
+    public boolean hasDynamicChildName(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress,
+            String childName) {
+        Statistics stats = getBaseStatistics(entityManagerFactoryLookup, pathAddress);
+        return stats == null ? false : existsInDynamicChildren(childName, stats.getCollectionRoleNames());
     }
 
     private CollectionStatistics getStatistics(final EntityManagerFactory entityManagerFactory, PathAddress pathAddress) {

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateEntityCacheStatistics.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateEntityCacheStatistics.java
@@ -9,8 +9,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
-import jakarta.persistence.EntityManagerFactory;
 import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
 import org.jipijapa.management.spi.EntityManagerFactoryAccess;
 import org.jipijapa.management.spi.Operation;
 import org.jipijapa.management.spi.PathAddress;
@@ -62,15 +62,11 @@ public class HibernateEntityCacheStatistics extends HibernateAbstractStatistics 
         return Collections.unmodifiableCollection(Arrays.asList(stats.getEntityNames()));
     }
 
-    private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
-        if (entityManagerFactory == null) {
-            return null;
-        }
-        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
-        if (sessionFactory != null) {
-            return sessionFactory.getStatistics();
-        }
-        return null;
+    @Override
+    public boolean hasDynamicChildName(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress,
+            String childName) {
+        Statistics stats = getBaseStatistics(entityManagerFactoryLookup, pathAddress);
+        return stats == null ? false : existsInDynamicChildren(childName, stats.getEntityNames());
     }
 
     org.hibernate.stat.CacheRegionStatistics getStatistics(EntityManagerFactoryAccess entityManagerFactoryaccess, PathAddress pathAddress) {

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateEntityStatistics.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateEntityStatistics.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import jakarta.persistence.EntityManagerFactory;
 import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
 import org.jipijapa.management.spi.EntityManagerFactoryAccess;
 import org.jipijapa.management.spi.Operation;
 import org.jipijapa.management.spi.PathAddress;
@@ -52,17 +53,6 @@ public class HibernateEntityStatistics extends HibernateAbstractStatistics {
 
         operations.put(OPERATION_OPTIMISTIC_FAILURE_COUNT, optimisticFailureCount);
         types.put(OPERATION_OPTIMISTIC_FAILURE_COUNT, Long.class);
-    }
-
-    private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
-        if (entityManagerFactory == null) {
-            return null;
-        }
-        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
-        if (sessionFactory != null) {
-            return sessionFactory.getStatistics();
-        }
-        return null;
     }
 
     private org.hibernate.stat.EntityStatistics getStatistics(EntityManagerFactory entityManagerFactory, PathAddress pathAddress) {
@@ -134,8 +124,15 @@ public class HibernateEntityStatistics extends HibernateAbstractStatistics {
     public Collection<String> getDynamicChildrenNames(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress) {
         org.hibernate.stat.Statistics statistics = getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL)));
         return statistics != null ?
-            Collections.unmodifiableCollection(Arrays.asList( statistics.getEntityNames())) :
-                Collections.EMPTY_LIST;
+            Collections.unmodifiableCollection(Arrays.asList(statistics.getEntityNames())) :
+                Collections.emptyList();
 
+    }
+
+    @Override
+    public boolean hasDynamicChildName(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress,
+            String childName) {
+        Statistics stats = getBaseStatistics(entityManagerFactoryLookup, pathAddress);
+        return stats == null ? false : existsInDynamicChildren(childName, stats.getEntityNames());
     }
 }

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateQueryCacheStatistics.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateQueryCacheStatistics.java
@@ -12,6 +12,7 @@ import java.util.Set;
 
 import jakarta.persistence.EntityManagerFactory;
 import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
 import org.jipijapa.management.spi.EntityManagerFactoryAccess;
 import org.jipijapa.management.spi.Operation;
 import org.jipijapa.management.spi.PathAddress;
@@ -80,15 +81,24 @@ public class HibernateQueryCacheStatistics extends HibernateAbstractStatistics {
         return result;
     }
 
-    private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
-        if (entityManagerFactory == null) {
-            return null;
+    @Override
+    public boolean hasDynamicChildName(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress,
+            String childName) {
+        Statistics stats = getBaseStatistics(entityManagerFactoryLookup, pathAddress);
+        if (stats == null) {
+            return false;
         }
-        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
-        if (sessionFactory != null) {
-            return sessionFactory.getStatistics();
+        String[] queries = stats.getQueries();
+        if (queries == null) {
+            return false;
         }
-        return null;
+        // we cant call existsInDynamicChildren() because we need to match by display names
+        for (String name : queries) {
+            if (childName.equals(QueryName.queryName(name).getDisplayName())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private org.hibernate.stat.QueryStatistics getStatistics(EntityManagerFactory entityManagerFactory, String displayQueryName) {

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateStatistics.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateStatistics.java
@@ -209,9 +209,15 @@ public class HibernateStatistics extends HibernateAbstractStatistics {
     }
 
     @Override
-    public Collection<String> getDynamicChildrenNames(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress) {
+    public Collection<String> getDynamicChildrenNames(EntityManagerFactoryAccess entityManagerFactoryAccess,
+            PathAddress pathAddress) {
+        return Collections.emptyList();
+    }
 
-        return Collections.EMPTY_LIST;
+    @Override
+    public boolean hasDynamicChildName(EntityManagerFactoryAccess entityManagerFactoryAccess, PathAddress pathAddress,
+            String childName) {
+        return false;
     }
 
     private Operation clear = new Operation() {

--- a/jpa/hibernate7/src/test/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateStatisticsTestCase.java
+++ b/jpa/hibernate7/src/test/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateStatisticsTestCase.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.persistence.jipijapa.hibernate7.management;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test class for verifying the operations of the Statistics classes.
+ *
+ * @author Ilias Bourdakos
+ */
+public class HibernateStatisticsTestCase {
+
+    /** The available statistics classes */
+    // in the future maybe each statistics class will require its own test class
+    HibernateAbstractStatistics[] testStats = new HibernateAbstractStatistics[] {
+        new HibernateStatistics(),
+        new HibernateEntityStatistics(),
+        new HibernateCollectionStatistics(),
+        new HibernateEntityCacheStatistics(),
+        new HibernateQueryCacheStatistics()
+    };
+
+    /**
+     * Verifies that {@code hasChildName} correctly identifies known children for each
+     * statistics class, rejects non-existing and null names, and produces results consistent
+     * with {@code getChildrenNames().contains()}.
+     */
+    @Test
+    public void testHibernateStatisticsHasChildName() {
+        for (HibernateAbstractStatistics stats : testStats) {
+            String statsClass = stats.getClass().getName();
+
+            if (stats instanceof HibernateStatistics) {
+                assertTrue(stats.hasChildName("entity"), "Should find 'entity' child (statistics class=" + statsClass + ")");
+                assertTrue(stats.hasChildName("collection"), "Should find 'collection' child (statistics class=" + statsClass + ")");
+                assertTrue(stats.hasChildName("entity-cache"), "Should find 'entity-cache' child (statistics class=" + statsClass + ")");
+                assertTrue(stats.hasChildName("query-cache"), "Should find 'query-cache' child (statistics class=" + statsClass + ")");
+            }
+
+            assertFalse(stats.hasChildName("non-existing-child"), "Should not find non-existing child (statistics class=" + statsClass + ")");
+            assertFalse(stats.hasChildName(null), "Should not find null child (statistics class=" + statsClass + ")");
+
+            for (String childName : stats.getChildrenNames()) {
+                assertEquals(stats.hasChildName(childName), stats.getChildrenNames().contains(childName),
+                    "hasChildName should give same result as getChildrenNames().contains() for existing child (statistics class=" + statsClass + ")");
+            }
+            assertEquals(stats.hasChildName("non-existing"), stats.getChildrenNames().contains("non-existing"),
+                "hasChildName should give same result as getChildrenNames().contains() for non-existing child (statistics class=" + statsClass + ")");
+        }
+    }
+
+    /**
+     * Verifies that {@code hasDynamicChildName} returns false for all statistics classes
+     * when both the {@code EntityManagerFactoryAccess} and {@code PathAddress} are null.
+     */
+    @Test
+    public void testHibernateStatisticsHasDynamicChildNameNullFactoryPath() {
+        for (HibernateAbstractStatistics stats : testStats) {
+            String statsClass = stats.getClass().getName();
+
+            assertFalse(stats.hasDynamicChildName(null, null, "any-name"),
+            "HibernateStatistics should not have dynamic children (statistics class=" + statsClass + ")");
+        }
+    }
+}

--- a/jpa/spi/src/main/java/org/jipijapa/management/spi/Statistics.java
+++ b/jpa/spi/src/main/java/org/jipijapa/management/spi/Statistics.java
@@ -26,6 +26,14 @@ public interface Statistics {
     Collection<String> getDynamicChildrenNames(EntityManagerFactoryAccess entityManagerFactoryAccess, PathAddress pathAddress);
 
     /**
+     * Check if the specified name appears in the list of dynamic children statistics.
+     * @see #getDynamicChildrenNames(EntityManagerFactoryAccess, PathAddress)
+     * @param childName name of the statistic to check
+     * @return true if found, false otherwise
+     */
+    boolean hasDynamicChildName(EntityManagerFactoryAccess entityManagerFactoryAccess, PathAddress pathAddress, String childName);
+
+    /**
      * Get the type
      *
      * @param name of the statistic
@@ -90,6 +98,14 @@ public interface Statistics {
      * @return set of names
      */
     Set<String> getChildrenNames();
+
+    /**
+     * Check if the specified name appears in the list of children statistics.
+     * @see #getChildrenNames()
+     * @param childName name of the statistic to check
+     * @return true if found, false otherwise
+     */
+    boolean hasChildName(String childName);
 
     /**
      * get the specified children statistics

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/management/DynamicManagementStatisticsResource.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/management/DynamicManagementStatisticsResource.java
@@ -60,9 +60,9 @@ public class DynamicManagementStatisticsResource extends PlaceholderResource.Pla
         try {
             Statistics statistics = getStatistics();
             // if element key matches, check if element value also matches
-            if (statistics.getChildrenNames().contains(element.getKey())) {
+            if (statistics.hasChildName(element.getKey())) {
                 Statistics childStatistics = statistics.getChild(element.getKey());
-                return childStatistics != null && childStatistics.getDynamicChildrenNames(entityManagerFactoryLookup, PathWrapper.path(puName)).contains(element.getValue());
+                return childStatistics != null && childStatistics.hasDynamicChildName(entityManagerFactoryLookup, PathWrapper.path(puName), element.getValue());
             } else {
                 return super.hasChild(element);
             }
@@ -80,9 +80,9 @@ public class DynamicManagementStatisticsResource extends PlaceholderResource.Pla
     public Resource getChild(PathElement element) {
         try {
             Statistics statistics = getStatistics();
-            if (statistics.getChildrenNames().contains(element.getKey())) {
+            if (statistics.hasChildName(element.getKey())) {
                 Statistics childStatistics = statistics.getChild(element.getKey());
-                return childStatistics != null && childStatistics.getDynamicChildrenNames(entityManagerFactoryLookup, PathWrapper.path(puName)).contains(element.getValue())
+                return childStatistics != null && childStatistics.hasDynamicChildName(entityManagerFactoryLookup, PathWrapper.path(puName), element.getValue())
                         ? PlaceholderResource.INSTANCE : null;
             } else {
                 return super.getChild(element);
@@ -100,9 +100,9 @@ public class DynamicManagementStatisticsResource extends PlaceholderResource.Pla
     public Resource requireChild(PathElement element) {
         try {
             Statistics statistics = getStatistics();
-            if (statistics.getChildrenNames().contains(element.getKey())) {
+            if (statistics.hasChildName(element.getKey())) {
                 Statistics childStatistics = statistics.getChild(element.getKey());
-                if (childStatistics != null && childStatistics.getDynamicChildrenNames(entityManagerFactoryLookup, PathWrapper.path(puName)).contains(element.getValue())) {
+                if (childStatistics != null && childStatistics.hasDynamicChildName(entityManagerFactoryLookup, PathWrapper.path(puName), element.getValue())) {
                     return PlaceholderResource.INSTANCE;
                 }
                 throw new NoSuchResourceException(element);
@@ -122,7 +122,7 @@ public class DynamicManagementStatisticsResource extends PlaceholderResource.Pla
     public boolean hasChildren(String childType) {
         try {
             Statistics statistics = getStatistics();
-            if (statistics.getChildrenNames().contains(childType)) {
+            if (statistics.hasChildName(childType)) {
                 Statistics childStatistics = statistics.getChild(childType);
                 return childStatistics != null && !childStatistics.getNames().isEmpty();
             } else {
@@ -140,7 +140,7 @@ public class DynamicManagementStatisticsResource extends PlaceholderResource.Pla
     @Override
     public Resource navigate(PathAddress address) {
         Statistics statistics = getStatistics();
-        if (address.size() > 0 && statistics.getChildrenNames().contains(address.getElement(0).getKey())) {
+        if (address.size() > 0 && statistics.hasChildName(address.getElement(0).getKey())) {
             if (address.size() > 1) {
                 throw new NoSuchResourceException(address.getElement(1));
             }
@@ -170,7 +170,7 @@ public class DynamicManagementStatisticsResource extends PlaceholderResource.Pla
     public Set<String> getChildrenNames(String childType) {
         try {
             Statistics statistics = getStatistics();
-            if (statistics.getChildrenNames().contains(childType)) {
+            if (statistics.hasChildName(childType)) {
                 Statistics childStatistics = statistics.getChild(childType);
                 Set<String>result = new HashSet<String>();
                 for(String name:childStatistics.getDynamicChildrenNames(entityManagerFactoryLookup, PathWrapper.path(puName))) {
@@ -193,7 +193,7 @@ public class DynamicManagementStatisticsResource extends PlaceholderResource.Pla
     public Set<ResourceEntry> getChildren(String childType) {
         try {
             Statistics statistics = getStatistics();
-            if (statistics.getChildrenNames().contains(childType)) {
+            if (statistics.hasChildName(childType)) {
                 Set<ResourceEntry> result = new HashSet<ResourceEntry>();
                 Statistics childStatistics = statistics.getChild(childType);
                 for (String name : childStatistics.getDynamicChildrenNames(entityManagerFactoryLookup, PathWrapper.path(puName))) {
@@ -216,7 +216,7 @@ public class DynamicManagementStatisticsResource extends PlaceholderResource.Pla
     public void registerChild(PathElement address, Resource resource) {
         try {
             Statistics statistics = getStatistics();
-            if (statistics.getChildrenNames().contains(address.getKey())) {
+            if (statistics.hasChildName(address.getKey())) {
                 throw JpaLogger.ROOT_LOGGER.resourcesOfTypeCannotBeRegistered(address.getKey());
             } else {
                 super.registerChild(address, resource);
@@ -232,7 +232,7 @@ public class DynamicManagementStatisticsResource extends PlaceholderResource.Pla
     @Override
     public Resource removeChild(PathElement address) {
         Statistics statistics = getStatistics();
-        if (statistics.getChildrenNames().contains(address.getKey())) {
+        if (statistics.hasChildName(address.getKey())) {
             throw JpaLogger.ROOT_LOGGER.resourcesOfTypeCannotBeRemoved(address.getKey());
         } else {
             return super.removeChild(address);


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/WFLY-20962

Besides the optimization of the new `hasDynamicChildName()` and `hasChildrenName()` methods, I also modified the existing method structure, to take better advantage of the `HibernateAbstractStatistics.java` inheritance.