### PR TITLE
WFLY-22076 Bootable Jar CI jobs failing due to wildfly-cleanup-marker not being deleted in time

### DIFF
--- a/testsuite/integration/microprofile-tck/pom.xml
+++ b/testsuite/integration/microprofile-tck/pom.xml
@@ -31,7 +31,7 @@
              So exclude ${testsuite.default.build.project.prefix} from the path -->
         <wildfly.build.output.dir>${testsuite.default.build.project.root}build/target/${server.output.dir.prefix}-${server.output.dir.qualifier}${server.output.dir.version}</wildfly.build.output.dir>
         <maven.repo.local>${settings.localRepository}</maven.repo.local>
-        <microprofile.jvm.args>-server -Xms64m -Xmx512m ${modular.jdk.args} -Dmaven.repo.local=${maven.repo.local}</microprofile.jvm.args>
+        <microprofile.jvm.args>-server -Xms64m -Xmx512m ${modular.jdk.args} -Dmaven.repo.local=${maven.repo.local} ${jvm.args.timeouts}</microprofile.jvm.args>
         <!-- Properties that set the phase used for different plugin executions.
              Profiles can override the values here to enable/disable executions.
              A value of 'none' disables the execution; to enable set the value to the

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -176,7 +176,8 @@
 
         <!-- Timeout ratios. 100 will leave the timeout as it was coded. -->
         <timeout.factor>100</timeout.factor>
-        <jvm.args.timeouts>-Dts.timeout.factor=${timeout.factor}</jvm.args.timeouts>
+        <!-- WFLY-22076 Bump bootable jar cleanup marker timeout from default 10s to avoid spurious failures on slow CI agents. -->
+        <jvm.args.timeouts>-Dts.timeout.factor=${timeout.factor} -Dorg.wildfly.core.bootable.jar.timeout=60</jvm.args.timeouts>
 
         <!-- Common surefire properties. -->
         <surefire.memory.args>-Xmx512m</surefire.memory.args>


### PR DESCRIPTION
More details on https://redhat.atlassian.net/browse/WFLY-22076