### PR TITLE
WFLY-22080 Add missing UFC protocol to the xsite tcp-bridge test stack

### DIFF
--- a/testsuite/integration/clustering/clustering-ha-bootable-jar.cli
+++ b/testsuite/integration/clustering/clustering-ha-bootable-jar.cli
@@ -35,6 +35,7 @@ batch
 /subsystem=jgroups/stack=tcp-bridge/protocol=UNICAST3:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=pbcast.STABLE:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=pbcast.GMS:add
+/subsystem=jgroups/stack=tcp-bridge/protocol=UFC:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=MFC:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=FRAG4:add
 run-batch

--- a/testsuite/integration/clustering/clustering-ha.cli
+++ b/testsuite/integration/clustering/clustering-ha.cli
@@ -37,6 +37,7 @@ batch
 /subsystem=jgroups/stack=tcp-bridge/protocol=UNICAST3:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=pbcast.STABLE:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=pbcast.GMS:add
+/subsystem=jgroups/stack=tcp-bridge/protocol=UFC:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=MFC:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=FRAG4:add
 run-batch
@@ -88,6 +89,7 @@ batch
 /subsystem=jgroups/stack=tcp-bridge/protocol=UNICAST3:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=pbcast.STABLE:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=pbcast.GMS:add
+/subsystem=jgroups/stack=tcp-bridge/protocol=UFC:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=MFC:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=FRAG4:add
 run-batch

--- a/testsuite/integration/clustering/clustering-microprofile-ha.cli
+++ b/testsuite/integration/clustering/clustering-microprofile-ha.cli
@@ -37,6 +37,7 @@ batch
 /subsystem=jgroups/stack=tcp-bridge/protocol=UNICAST3:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=pbcast.STABLE:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=pbcast.GMS:add
+/subsystem=jgroups/stack=tcp-bridge/protocol=UFC:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=MFC:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=FRAG4:add
 run-batch


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-22080

Stumbled upon when investigating dropped messages in xsite tests in recent runs. Unlikely to be the culprit though. So; treat as minor.