### PR TITLE
WFLY-22099 Cache listeners not re-registered on resume.

### DIFF
--- a/clustering/infinispan/embedded/service/src/main/java/org/wildfly/clustering/infinispan/service/CacheServiceInstaller.java
+++ b/clustering/infinispan/embedded/service/src/main/java/org/wildfly/clustering/infinispan/service/CacheServiceInstaller.java
@@ -243,7 +243,7 @@ public class CacheServiceInstaller implements ServiceInstaller {
 
         @Override
         public CompletionStage<Void> addListenerAsync(Object listener) {
-            return super.addListenerAsync(listener, new CacheEventFilter<>() {
+            return this.addListenerAsync(listener, new CacheEventFilter<>() {
                 @Override
                 public boolean accept(K key, V oldValue, Metadata oldMetadata, V newValue, Metadata newMetadata, EventType eventType) {
                     return true;


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-22099