### PR TITLE
[WFLY-21954] Fix xs:all minOccurs default in elytron-oidc-client XSD schemas to allow empty root elements

### DIFF
--- a/elytron-oidc-client/src/main/resources/schema/wildfly-elytron-oidc-client_1_0.xsd
+++ b/elytron-oidc-client/src/main/resources/schema/wildfly-elytron-oidc-client_1_0.xsd
@@ -50,7 +50,7 @@
     </xs:complexType>
 
     <xs:complexType name="realm-type">
-        <xs:all>
+        <xs:all minOccurs="0">
             <xs:element name="cors-allowed-headers" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
@@ -381,7 +381,7 @@
     </xs:complexType>
 
     <xs:complexType name="provider-type">
-        <xs:all>
+        <xs:all minOccurs="0">
             <xs:element name="cors-allowed-headers" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
@@ -712,7 +712,7 @@
     </xs:complexType>
 
     <xs:complexType name="secure-deployment-type">
-        <xs:all>
+        <xs:all minOccurs="0">
             <xs:element name="client-keystore-password" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>

--- a/elytron-oidc-client/src/main/resources/schema/wildfly-elytron-oidc-client_2_0.xsd
+++ b/elytron-oidc-client/src/main/resources/schema/wildfly-elytron-oidc-client_2_0.xsd
@@ -59,7 +59,7 @@
     </xs:complexType>
 
     <xs:complexType name="realm-type">
-        <xs:all>
+        <xs:all minOccurs="0">
             <xs:element name="cors-allowed-headers" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
@@ -390,7 +390,7 @@
     </xs:complexType>
 
     <xs:complexType name="provider-type">
-        <xs:all>
+        <xs:all minOccurs="0">
             <xs:element name="cors-allowed-headers" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
@@ -721,7 +721,7 @@
     </xs:complexType>
 
     <xs:complexType name="secure-deployment-type">
-        <xs:all>
+        <xs:all minOccurs="0">
             <xs:element name="client-keystore-password" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>

--- a/elytron-oidc-client/src/main/resources/schema/wildfly-elytron-oidc-client_preview_2_0.xsd
+++ b/elytron-oidc-client/src/main/resources/schema/wildfly-elytron-oidc-client_preview_2_0.xsd
@@ -54,7 +54,7 @@
     </xs:complexType>
 
     <xs:complexType name="realm-type">
-        <xs:all>
+        <xs:all minOccurs="0">
             <xs:element name="cors-allowed-headers" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
@@ -385,7 +385,7 @@
     </xs:complexType>
 
     <xs:complexType name="provider-type">
-        <xs:all>
+        <xs:all minOccurs="0">
             <xs:element name="cors-allowed-headers" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
@@ -716,7 +716,7 @@
     </xs:complexType>
 
     <xs:complexType name="secure-deployment-type">
-        <xs:all>
+        <xs:all minOccurs="0">
             <xs:element name="client-keystore-password" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>

--- a/elytron-oidc-client/src/main/resources/schema/wildfly-elytron-oidc-client_preview_3_0.xsd
+++ b/elytron-oidc-client/src/main/resources/schema/wildfly-elytron-oidc-client_preview_3_0.xsd
@@ -54,7 +54,7 @@
     </xs:complexType>
 
     <xs:complexType name="realm-type">
-        <xs:all>
+        <xs:all minOccurs="0">
             <xs:element name="authentication-request-format" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
@@ -473,7 +473,7 @@
     </xs:complexType>
 
     <xs:complexType name="provider-type">
-        <xs:all>
+        <xs:all minOccurs="0">
             <xs:element name="authentication-request-format" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
@@ -892,7 +892,7 @@
     </xs:complexType>
 
     <xs:complexType name="secure-deployment-type">
-        <xs:all>
+        <xs:all minOccurs="0">
             <xs:element name="authentication-request-format" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>

--- a/elytron-oidc-client/src/main/resources/schema/wildfly-elytron-oidc-client_preview_4_0.xsd
+++ b/elytron-oidc-client/src/main/resources/schema/wildfly-elytron-oidc-client_preview_4_0.xsd
@@ -54,7 +54,7 @@
     </xs:complexType>
 
     <xs:complexType name="realm-type">
-        <xs:all>
+        <xs:all minOccurs="0">
             <xs:element name="authentication-request-format" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
@@ -499,7 +499,7 @@
     </xs:complexType>
 
     <xs:complexType name="provider-type">
-        <xs:all>
+        <xs:all minOccurs="0">
             <xs:element name="authentication-request-format" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
@@ -935,7 +935,7 @@
     </xs:complexType>
 
     <xs:complexType name="secure-deployment-type">
-        <xs:all>
+        <xs:all minOccurs="0">
             <xs:element name="authentication-request-format" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>


### PR DESCRIPTION
JIRA Issue: [WFLY-21954](https://redhat.atlassian.net/browse/WFLY-21954)

Description: 

- Fixed `xs:all` compositor in `elytron-oidc-client` XSD schemas to allow empty root elements (`<realm/>, <provider/>, <secure-deployment/>`) by adding `minOccurs="0"` to the `<xs:all>` opening tag.
- Applied the fix to the three affected complex types (`realm-type, provider-type, secure-deployment-type`) across 5 schema files: `wildfly-elytron-oidc-client_1_0.xsd, _2_0.xsd, _preview_2_0.xsd, _preview_3_0.xsd, _preview_4_0.xsd`

Root Cause:

In XML Schema 1.0, the `xs:all` compositor defaults to `minOccurs="1"` for the group itself. Xerces interprets this as "the group must be evaluated and at least one match must occur", rejecting elements with no children, even though every child element within the group already has `minOccurs="0"`. This caused schema validation failures for minimal configuration entries containing only the name attribute (e.g., <realm name="minimal-realm"/>).

Note:

Two additional schema files — `wildfly-elytron-oidc-client_3_0.xsd` and `wildfly-elytron-oidc-client_community_2_0.xsd` have the same `<xs:all>` pattern in the same three complex types but were not modified in this PR. Would appreciate input on whether these files should also receive the same fix.