### PR TITLE
WFLY-22103 Enable deprecation warnings for ajp-listener and EJB3 legacy passivation store resources

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/LegacyPassivationStoreResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/LegacyPassivationStoreResourceDefinition.java
@@ -69,7 +69,7 @@ public abstract class LegacyPassivationStoreResourceDefinition extends SimpleRes
                 .setRemoveHandler(removeHandler)
                 .setAddRestartLevel(addRestartLevel)
                 .setRemoveRestartLevel(removeRestartLevel)
-                .setDeprecationData(new DeprecationData(DEPRECATED_VERSION)));
+                .setDeprecationData(new DeprecationData(DEPRECATED_VERSION, true)));
         this.attributes = attributes;
     }
 
@@ -79,7 +79,7 @@ public abstract class LegacyPassivationStoreResourceDefinition extends SimpleRes
                 .setRemoveHandler(removeHandler)
                 .setAddRestartLevel(addRestartLevel)
                 .setRemoveRestartLevel(removeRestartLevel)
-                .setDeprecationData(new DeprecationData(DEPRECATED_VERSION))
+                .setDeprecationData(new DeprecationData(DEPRECATED_VERSION, true))
                 .setCapabilities(capability));
         this.attributes = attributes;
     }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerResourceDefinition.java
@@ -58,7 +58,7 @@ public class AjpListenerResourceDefinition extends ListenerResourceDefinition {
 
     AjpListenerResourceDefinition() {
         super(new SimpleResourceDefinition.Parameters(PATH_ELEMENT, UndertowExtension.getResolver(Constants.LISTENER))
-                        .setDeprecationData(new DeprecationData(UndertowSubsystemModel.VERSION_15_0_0.getVersion())),
+                        .setDeprecationData(new DeprecationData(UndertowSubsystemModel.VERSION_15_0_0.getVersion(), true)),
                 new AjpListenerAdd(),
                 Map.of()
         );


### PR DESCRIPTION

DeprecationData was constructed without setting notificationUseful to true, causing it to silently default to false and suppressing deprecation warnings on server start for the ajp-listener resource in the Undertow subsystem and legacy passivation store resources in the EJB3 subsystem.

https://redhat.atlassian.net/browse/WFLY-22103