### PR TITLE
[WFLY-21090] Mention GitHub issues in the Pull Request Standards doc

### DIFF
--- a/docs/src/main/asciidoc/_hacking/pullrequest_standards.adoc
+++ b/docs/src/main/asciidoc/_hacking/pullrequest_standards.adoc
@@ -20,6 +20,8 @@ Fixes: https://redhat.atlassian.net/browse/WFLY-815
 === Commit message
 The commit message for each commit should also reference a JIRA number.
 
+NOTE: Some WildFly projects, such as https://github.com/wildfly/wildfly-glow[WildFly Glow], track work in GitHub Issues instead of JIRA. For those projects, reference the GitHub issue number in the PR title (e.g. `Fix for Issue #123, <description>`) instead of a JIRA key, and link the issue in the PR description.
+
 == Make sure it builds and tests pass first
 It is highly annoying to reviewers when they find they've spent a great deal of time reviewing some code only to discover that it doesn't even compile. In particular, it's common for a patch to trip CheckStyle if it hadn't been previously compile-tested at the least.
 

--- a/docs/src/main/asciidoc/_hacking/pullrequest_standards.adoc
+++ b/docs/src/main/asciidoc/_hacking/pullrequest_standards.adoc
@@ -20,7 +20,7 @@ Fixes: https://redhat.atlassian.net/browse/WFLY-815
 === Commit message
 The commit message for each commit should also reference a JIRA number.
 
-NOTE: Some WildFly projects, such as https://github.com/wildfly/wildfly-glow[WildFly Glow], track work in GitHub Issues instead of JIRA. For those projects, reference the GitHub issue number in the PR title (e.g. `Fix for Issue #123, <description>`) instead of a JIRA key, and link the issue in the PR description.
+NOTE: Some WildFly projects, such as https://github.com/wildfly/wildfly-glow[WildFly Glow], track work in GitHub Issues instead of JIRA. For those projects, reference the GitHub issue number in the PR title (e.g. `[#123] Add awesome feature`) instead of a JIRA key, and link the issue in the PR description.
 
 == Make sure it builds and tests pass first
 It is highly annoying to reviewers when they find they've spent a great deal of time reviewing some code only to discover that it doesn't even compile. In particular, it's common for a patch to trip CheckStyle if it hadn't been previously compile-tested at the least.


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/WFLY-21090

Modified GitHub issues in the Pull Request Standards doc.

wildfly-glow was used as a concrete example and that its actual convention differs slightly from the ticket's illustrative Issue_101/Resolves #10 wording.
<img width="1070" height="211" alt="Screenshot 2026-07-27 at 14 23 11" src="https://github.com/user-attachments/assets/3c353eb0-58a3-4d2a-b684-07604b8e0261" />


____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21090](https://redhat.atlassian.net/browse/WFLY-21090)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)