### PR TITLE
Fix for WFLY-22109, Upgrade to Galleon 7.0.10.Final and WildFly Galleon Plugins 8.2.0.Beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,11 +328,11 @@
         <version.asciidoctor.plugin>2.2.6</version.asciidoctor.plugin>
         <version.central.publishing.maven.plugin>0.9.0</version.central.publishing.maven.plugin>
         <version.org.jacoco>0.8.15</version.org.jacoco>
-        <version.org.jboss.galleon>7.0.9.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>7.0.10.Final</version.org.jboss.galleon>
         <version.org.wildfly.bom-builder-plugin>2.0.11.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.galleon-plugins>8.1.7.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>8.2.0.Beta1</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.glow>2.1.0.Final</version.org.wildfly.glow>
         <version.org.wildfly.licenses.plugin>2.4.4.Final</version.org.wildfly.licenses.plugin>
         <version.org.wildfly.plugin>6.0.0.Final</version.org.wildfly.plugin>


### PR DESCRIPTION
ISSUE: https://redhat.atlassian.net/browse/WFLY-22109
