### PR TITLE
[WFLY-22110]: Upgrade to Apache Artemis 2.55.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -471,7 +471,7 @@
         <version.joda-time>2.12.7</version.joda-time>
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>8.4.2</version.net.shibboleth.utilities.java-support>
-        <version.org.apache.activemq.artemis>2.54.0</version.org.apache.activemq.artemis>
+        <version.org.apache.activemq.artemis>2.55.0</version.org.apache.activemq.artemis>
         <version.org.apache.activemq.artemis.native>2.0.0</version.org.apache.activemq.artemis.native>
         <version.org.apache.avro>1.12.1</version.org.apache.avro>
         <version.org.apache.cxf>4.1.8-jbossorg-1</version.org.apache.cxf>


### PR DESCRIPTION
Artemis release note: https://artemis.apache.org/components/artemis/download/release-notes-2.55.0

Jira: https://redhat.atlassian.net/browse/WFLY-22110
Upstream PR: https://github.com/wildfly/wildfly/pull/20274
