### PR TITLE
WFLY-21093 Fix validation.xml not found in WAR within EAR deployment

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/ValidationCheckServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/ValidationCheckServlet.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.beanvalidation;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Set;
+
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.ValidatorFactory;
+
+/**
+ * Servlet that validates a {@link ValidationXmlEarBean} with a null {@code name} field
+ * and returns the violation count and messages as plain text.
+ * <p>
+ * Uses {@link Validation#buildDefaultValidatorFactory()} so that the thread context
+ * classloader (TCCL) determines which {@code validation.xml} is discovered.
+ * <p>
+ * Response format:
+ * <pre>
+ * &lt;violation-count&gt;
+ * &lt;property-path&gt;=&lt;message-1&gt;
+ * &lt;property-path&gt;=&lt;message-2&gt;
+ * ...
+ * </pre>
+ */
+@WebServlet("/validate")
+public class ValidationCheckServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        ValidationXmlEarBean bean = new ValidationXmlEarBean();
+
+        ValidatorFactory vf = Validation.buildDefaultValidatorFactory();
+        try {
+            Set<ConstraintViolation<ValidationXmlEarBean>> violations = vf.getValidator().validate(bean);
+
+            resp.setContentType("text/plain");
+            PrintWriter writer = resp.getWriter();
+            writer.println(violations.size());
+            for (ConstraintViolation<ValidationXmlEarBean> violation : violations) {
+                writer.println(violation.getPropertyPath() + "=" + violation.getMessage());
+            }
+        } finally {
+            vf.close();
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/ValidationXmlEarBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/ValidationXmlEarBean.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.beanvalidation;
+
+/**
+ * A simple bean with no annotation-based validation constraints.
+ * Constraints are configured via validation.xml / constraint-mapping.xml
+ * to verify that validation.xml is properly located in WAR-in-EAR deployments.
+ */
+public class ValidationXmlEarBean {
+
+    private String name;
+    private String description;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/ValidationXmlEarBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/ValidationXmlEarBean.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.beanvalidation;
+
+/**
+ * A simple bean with no annotation-based validation constraints.
+ * Constraints are configured via validation.xml / constraint-mapping.xml
+ * to verify that validation.xml is properly located in WAR-in-EAR deployments.
+ */
+public class ValidationXmlEarBean {
+
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/ValidationXmlWarInEarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/ValidationXmlWarInEarTestCase.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.beanvalidation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URL;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that {@code validation.xml} inside WAR sub-deployments within an EAR is properly
+ * located and processed by the Bean Validation provider, and that each WAR's constraints
+ * are isolated from other WARs in the same EAR.
+ * <p>
+ * Deploys an EAR containing three WARs, each constraining a <em>different</em> field:
+ * <ul>
+ *   <li><b>war1</b> — constrains {@code name} via {@code @NotNull}. Tested in-container.</li>
+ *   <li><b>war2</b> — constrains {@code description} via {@code @NotNull}. Tested via HTTP.</li>
+ *   <li><b>war3</b> — has <em>no</em> {@code validation.xml}. Tested via HTTP.</li>
+ * </ul>
+ * Each test verifies that only the constraints defined in <em>that</em> WAR's
+ * {@code validation.xml} are applied, and that constraints from other WARs do not leak
+ * across classloader boundaries.
+ *
+ * @see <a href="https://issues.redhat.com/browse/WFLY-21093">WFLY-21093</a>
+ */
+@RunWith(Arquillian.class)
+public class ValidationXmlWarInEarTestCase {
+
+    @Inject
+    private ValidatorFactory validatorFactory;
+
+    @Inject
+    private Validator validator;
+
+    private static final String WAR1_CONTEXT = "validation-war1";
+    private static final String WAR2_CONTEXT = "validation-war2";
+    private static final String WAR3_CONTEXT = "no-validation-war3";
+
+    private static final String WAR1_MESSAGE = "Name must not be null (war1)";
+    private static final String WAR2_MESSAGE = "Description is required (war2)";
+
+    private static final String VALIDATION_XML = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                               version="3.0">
+                <constraint-mapping>META-INF/constraint-mapping.xml</constraint-mapping>
+            </validation-config>
+            """;
+
+    private static final String CONSTRAINT_MAPPING_XML_WAR1 = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <constraint-mappings xmlns="https://jakarta.ee/xml/ns/validation/mapping"
+                                 version="3.0">
+                <bean class="org.jboss.as.test.integration.beanvalidation.ValidationXmlEarBean">
+                    <field name="name">
+                        <constraint annotation="jakarta.validation.constraints.NotNull">
+                            <message>%s</message>
+                        </constraint>
+                    </field>
+                </bean>
+            </constraint-mappings>
+            """.formatted(WAR1_MESSAGE);
+
+    private static final String CONSTRAINT_MAPPING_XML_WAR2 = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <constraint-mappings xmlns="https://jakarta.ee/xml/ns/validation/mapping"
+                                 version="3.0">
+                <bean class="org.jboss.as.test.integration.beanvalidation.ValidationXmlEarBean">
+                    <field name="description">
+                        <constraint annotation="jakarta.validation.constraints.NotNull">
+                            <message>%s</message>
+                        </constraint>
+                    </field>
+                </bean>
+            </constraint-mappings>
+            """.formatted(WAR2_MESSAGE);
+
+    @Deployment
+    public static EnterpriseArchive deployment() {
+        WebArchive war1 = ShrinkWrap.create(WebArchive.class, WAR1_CONTEXT + ".war")
+                .addClasses(ValidationXmlWarInEarTestCase.class, ValidationXmlEarBean.class)
+                .addAsWebInfResource(new StringAsset("<beans bean-discovery-mode=\"all\"></beans>"), "beans.xml")
+                .addAsResource(new StringAsset(VALIDATION_XML), "META-INF/validation.xml")
+                .addAsResource(new StringAsset(CONSTRAINT_MAPPING_XML_WAR1), "META-INF/constraint-mapping.xml");
+
+        WebArchive war2 = ShrinkWrap.create(WebArchive.class, WAR2_CONTEXT + ".war")
+                .addClasses(ValidationCheckServlet.class, ValidationXmlEarBean.class)
+                .addAsWebInfResource(new StringAsset("<beans bean-discovery-mode=\"all\"></beans>"), "beans.xml")
+                .addAsResource(new StringAsset(VALIDATION_XML), "META-INF/validation.xml")
+                .addAsResource(new StringAsset(CONSTRAINT_MAPPING_XML_WAR2), "META-INF/constraint-mapping.xml");
+
+        WebArchive war3 = ShrinkWrap.create(WebArchive.class, WAR3_CONTEXT + ".war")
+                .addClasses(ValidationCheckServlet.class, ValidationXmlEarBean.class)
+                .addAsWebInfResource(new StringAsset("<beans bean-discovery-mode=\"all\"></beans>"), "beans.xml");
+
+        return ShrinkWrap.create(EnterpriseArchive.class, "validation-xml-multi-war.ear")
+                .addAsModule(war1)
+                .addAsModule(war2)
+                .addAsModule(war3);
+    }
+
+    @Test
+    public void testCdiInjection() {
+        assertNotNull("ValidatorFactory should be injectable via CDI", validatorFactory);
+        assertNotNull("Validator should be injectable via CDI", validator);
+        assertNotNull("CDI ValidatorFactory should produce a Validator", validatorFactory.getValidator());
+    }
+
+    /**
+     * WAR1 constrains {@code name} — a bean with null name should produce exactly one violation.
+     */
+    @Test
+    public void testWar1NameConstraintApplied() {
+        ValidationXmlEarBean bean = new ValidationXmlEarBean();
+        Set<ConstraintViolation<ValidationXmlEarBean>> violations = validateBean(bean);
+        assertEquals("Expected one constraint violation from war1 validation.xml", 1, violations.size());
+
+        ConstraintViolation<ValidationXmlEarBean> violation = violations.iterator().next();
+        assertEquals(WAR1_MESSAGE, violation.getMessage());
+        assertEquals("name", violation.getPropertyPath().toString());
+    }
+
+    /**
+     * WAR1 does NOT constrain {@code description} — that is WAR2's rule.
+     * A bean with null description but non-null name should have zero violations in WAR1.
+     */
+    @Test
+    public void testWar1DescriptionConstraintNotLeaked() {
+        ValidationXmlEarBean bean = new ValidationXmlEarBean();
+        bean.setName("present");
+
+        Set<ConstraintViolation<ValidationXmlEarBean>> violations = validateBean(bean);
+        assertTrue("WAR1 should not enforce WAR2's description constraint", violations.isEmpty());
+    }
+
+    /**
+     * A fully valid bean (both fields set) should pass WAR1 validation.
+     */
+    @Test
+    public void testWar1ValidBeanPassesValidation() {
+        ValidationXmlEarBean bean = new ValidationXmlEarBean();
+        bean.setName("test");
+        bean.setDescription("test");
+        Set<ConstraintViolation<ValidationXmlEarBean>> violations = validateBean(bean);
+        assertTrue("Expected no violations for valid bean", violations.isEmpty());
+    }
+
+    private static Set<ConstraintViolation<ValidationXmlEarBean>> validateBean(ValidationXmlEarBean bean) {
+        ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+        try {
+            return validatorFactory.getValidator().validate(bean);
+        } finally {
+            validatorFactory.close();
+        }
+    }
+
+    /**
+     * WAR2 constrains {@code description} — should produce exactly one violation on that field,
+     * and must NOT contain WAR1's {@code name} constraint.
+     */
+    @Test
+    @RunAsClient
+    public void testWar2DescriptionConstraintApplied(@ArquillianResource URL url) throws Exception {
+        String response = fetchValidation(url, WAR2_CONTEXT);
+        String[] lines = response.trim().split("\\R");
+
+        assertEquals("WAR2 should report exactly one violation", "1", lines[0].trim());
+        assertTrue("WAR2 violation should be on 'description' field", response.contains("description="));
+        assertTrue("WAR2 should use its own constraint message", response.contains(WAR2_MESSAGE));
+        assertFalse("WAR2 must not contain WAR1's name constraint", response.contains("name="));
+        assertFalse("WAR2 must not contain WAR1's constraint message", response.contains(WAR1_MESSAGE));
+    }
+
+    /**
+     * WAR3 has no {@code validation.xml} — should report zero violations for any field.
+     */
+    @Test
+    @RunAsClient
+    public void testWar3WithoutValidationXmlHasNoConstraints(@ArquillianResource URL url) throws Exception {
+        String response = fetchValidation(url, WAR3_CONTEXT);
+        assertEquals("WAR3 without validation.xml should have no violations", "0",
+                response.trim().split("\\R")[0].trim());
+    }
+
+    private static String fetchValidation(URL url, String context) throws Exception {
+        URL targetUrl = new URL(url.getProtocol(), url.getHost(), url.getPort(),
+                "/" + context + "/validate");
+        return HttpRequest.get(targetUrl.toString(), 10, TimeUnit.SECONDS);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/ValidationXmlWarInEarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/ValidationXmlWarInEarTestCase.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.beanvalidation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Set;
+
+import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ValidatorFactory;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that {@code validation.xml} inside a WAR sub-deployment within an EAR is properly
+ * located and processed by the Bean Validation provider.
+ * <p>
+ * The bean {@link ValidationXmlEarBean} has no annotation-based constraints. A constraint
+ * mapping declared in {@code validation.xml} adds a {@code @NotNull} constraint to its
+ * {@code name} field. If {@code validation.xml} is found, validating a bean with a null
+ * name produces a violation. If not found (the pre-fix behavior), no violation occurs.
+ *
+ * @see <a href="https://issues.redhat.com/browse/WFLY-21093">WFLY-21093</a>
+ */
+@RunWith(Arquillian.class)
+public class ValidationXmlWarInEarTestCase {
+
+    private static final String VALIDATION_XML =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<validation-config xmlns=\"https://jakarta.ee/xml/ns/validation/configuration\"\n" +
+            "                   version=\"3.0\">\n" +
+            "    <constraint-mapping>META-INF/constraint-mapping.xml</constraint-mapping>\n" +
+            "</validation-config>";
+
+    private static final String CONSTRAINT_MAPPING_XML =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<constraint-mappings xmlns=\"https://jakarta.ee/xml/ns/validation/mapping\"\n" +
+            "                     version=\"3.0\">\n" +
+            "    <bean class=\"org.jboss.as.test.integration.beanvalidation.ValidationXmlEarBean\">\n" +
+            "        <field name=\"name\">\n" +
+            "            <constraint annotation=\"jakarta.validation.constraints.NotNull\">\n" +
+            "                <message>Name must not be null (configured via validation.xml)</message>\n" +
+            "            </constraint>\n" +
+            "        </field>\n" +
+            "    </bean>\n" +
+            "</constraint-mappings>";
+
+    @Inject
+    private ValidatorFactory validatorFactory;
+
+    @Deployment
+    public static EnterpriseArchive deployment() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, "validation-xml-war-in-ear.war")
+                .addClasses(ValidationXmlWarInEarTestCase.class, ValidationXmlEarBean.class)
+                .addAsWebInfResource(new StringAsset("<beans bean-discovery-mode=\"all\"></beans>"), "beans.xml")
+                .addAsResource(new StringAsset(VALIDATION_XML), "META-INF/validation.xml")
+                .addAsResource(new StringAsset(CONSTRAINT_MAPPING_XML), "META-INF/constraint-mapping.xml");
+
+        return ShrinkWrap.create(EnterpriseArchive.class, "validation-xml-war-in-ear.ear")
+                .addAsModule(war);
+    }
+
+    /**
+     * Validates that the {@code @NotNull} constraint declared in the XML constraint mapping
+     * (referenced by {@code validation.xml}) is applied when the {@code name} field is null.
+     */
+    @Test
+    public void testValidationXmlConstraintsApplied() {
+        ValidationXmlEarBean bean = new ValidationXmlEarBean();
+        Set<ConstraintViolation<ValidationXmlEarBean>> violations = validatorFactory.getValidator().validate(bean);
+        assertEquals("Expected one constraint violation from validation.xml mapping", 1, violations.size());
+        assertEquals("Name must not be null (configured via validation.xml)",
+                violations.iterator().next().getMessage());
+    }
+
+    /**
+     * Validates that a bean with a non-null name passes validation (no violations).
+     */
+    @Test
+    public void testValidBeanPassesValidation() {
+        ValidationXmlEarBean bean = new ValidationXmlEarBean();
+        bean.setName("test");
+        Set<ConstraintViolation<ValidationXmlEarBean>> violations = validatorFactory.getValidator().validate(bean);
+        assertTrue("Expected no violations for valid bean", violations.isEmpty());
+    }
+}

--- a/weld/bean-validation/src/main/java/org/jboss/as/weld/deployment/processor/CdiBeanValidationFactoryProcessor.java
+++ b/weld/bean-validation/src/main/java/org/jboss/as/weld/deployment/processor/CdiBeanValidationFactoryProcessor.java
@@ -51,6 +51,13 @@ public class CdiBeanValidationFactoryProcessor implements DeploymentUnitProcesso
             return;
         }
 
+        // Don't add the CDI bean validation module to top-level EAR deployments.
+        // Let sub-deployments discover ValidationExtension with their own classloader
+        // as the TCCL, so that validation.xml within WARs/EJB-JARs is found.
+        if (!deploymentUnit.getAttachmentList(Attachments.SUB_DEPLOYMENTS).isEmpty()) {
+            return;
+        }
+
         if (!deploymentUnit.hasAttachment(BeanValidationAttachments.VALIDATOR_FACTORY)) {
             return;
         }

--- a/weld/bean-validation/src/main/java/org/jboss/as/weld/deployment/processor/CdiBeanValidationFactoryProcessor.java
+++ b/weld/bean-validation/src/main/java/org/jboss/as/weld/deployment/processor/CdiBeanValidationFactoryProcessor.java
@@ -51,6 +51,10 @@ public class CdiBeanValidationFactoryProcessor implements DeploymentUnitProcesso
             return;
         }
 
+        if (!deploymentUnit.getAttachmentList(Attachments.SUB_DEPLOYMENTS).isEmpty()) {
+            return;
+        }
+
         if (!deploymentUnit.hasAttachment(BeanValidationAttachments.VALIDATOR_FACTORY)) {
             return;
         }

--- a/weld/bean-validation/src/main/java/org/jboss/as/weld/deployment/processor/WeldBeanValidationDependencyProcessor.java
+++ b/weld/bean-validation/src/main/java/org/jboss/as/weld/deployment/processor/WeldBeanValidationDependencyProcessor.java
@@ -45,6 +45,13 @@ public class WeldBeanValidationDependencyProcessor implements DeploymentUnitProc
             return; // Skip if there are no beans.xml files in the deployment
         }
 
+        // Don't add the CDI bean validation module to top-level EAR deployments.
+        // Let sub-deployments discover ValidationExtension with their own classloader
+        // as the TCCL, so that validation.xml within WARs/EJB-JARs is found.
+        if (!deploymentUnit.getAttachmentList(Attachments.SUB_DEPLOYMENTS).isEmpty()) {
+            return;
+        }
+
         ModuleDependency cdiBeanValidationDep = ModuleDependency.Builder.of(moduleLoader, CDI_BEAN_VALIDATION_ID).setImportServices(true).build();
         moduleSpecification.addSystemDependency(cdiBeanValidationDep);
     }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21093

Skip adding the `org.hibernate.validator.cdi` module dependency and CDI `ValidatorFactory` registration for top-level EAR deployments. This ensures `ValidationExtension` is discovered by sub-deployments with their own classloader as TCCL, allowing `validation.xml` within WARs to be found.