### PR TITLE
[WFLY-21350] Restore the LegacyJMSTestCase for windows OS

### DIFF
--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/legacy/LegacyConnectionFactoryService.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/legacy/LegacyConnectionFactoryService.java
@@ -308,6 +308,15 @@ public class LegacyConnectionFactoryService implements Service<ConnectionFactory
                 // property specific to ActiveMQ that can not be mapped to HornetQ
                 continue;
             }
+            if (TransportConstants.HOST_PROP_NAME.equals(legacyKey) && value instanceof String) {
+                String host = (String) value;
+                // The legacy HornetQ NettyConnector sets the HTTP Host header to the bare host value.
+                // A bare IPv6 address (e.g. "::1") produces a malformed Host header; wrapping in
+                // brackets makes it valid per RFC 7230 and InetAddress.getByName() strips them.
+                if (host.contains(":") && !host.startsWith("[")) {
+                    value = "[" + host + "]";
+                }
+            }
             legacyParams.put(legacyKey, value);
         }
         return legacyParams;

--- a/testsuite/integration/hornetq-client/src/test/java/org/jboss/as/test/integration/messaging/jms/legacy/LegacyJMSTestCase.java
+++ b/testsuite/integration/hornetq-client/src/test/java/org/jboss/as/test/integration/messaging/jms/legacy/LegacyJMSTestCase.java
@@ -14,7 +14,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 
 import javax.jms.ConnectionFactory;
@@ -37,11 +36,9 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
-import org.jboss.as.test.shared.IntermittentFailure;
 import org.jboss.dmr.ModelNode;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -74,14 +71,6 @@ public class LegacyJMSTestCase {
 
     @ContainerResource
     private ManagementClient managementClient;
-
-    @BeforeClass
-    public static void ignoreOnWindows() {
-        if (System.getProperty("os.name", null).toLowerCase(Locale.ENGLISH).contains("windows")) {
-            // this isn't actually an intermittent failure, but might as well allow it to be enabled via the IntermittentFailure sys prop
-            IntermittentFailure.thisTestIsFailingIntermittently("WFLY-21350");
-        }
-    }
 
     @Before
     public void setUp() throws IOException {


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/WFLY-21350

Since  WFCORE `34.0.0.Beta1` (used by origin/main branch in WFLY) uses undertow `2.4.2.Final`, the test should pass using undertow 2.4.x (because the jira ticket above mentioned that `LegacyJMSTestCase` failed on undertow `2.3.21`). I ran the test locally on my windows machine and it passed without any issues. 

If `LegacyJMSTestCase` passes on the CI as well, we can remove the windows ignore method. If not, i could check the failure on the CI and try to investigate what went wrong (since this URL: https://ci.wildfly.org/viewLog.html?buildId=538589&buildTypeId=WildFlyCore_PullRequest_WildFlyCoreFullIntegrationWindowsJdk17&fromSakuraUI=true is expired). 
