### PR TITLE
WFLY-22117 - Update to Micrometer 1.17.0

### DIFF
--- a/boms/common-expansion/pom.xml
+++ b/boms/common-expansion/pom.xml
@@ -662,7 +662,7 @@
 
             <dependency>
                 <groupId>io.prometheus</groupId>
-                <artifactId>prometheus-metrics-exposition-formats</artifactId>
+                <artifactId>prometheus-metrics-exposition-textformats</artifactId>
                 <version>${version.io.prometheus}</version>
                 <exclusions>
                     <exclusion>

--- a/galleon-pack/galleon-shared/pom.xml
+++ b/galleon-pack/galleon-shared/pom.xml
@@ -56,7 +56,7 @@
         <dependency><groupId>io.micrometer</groupId><artifactId>micrometer-core</artifactId></dependency>
         <dependency><groupId>io.micrometer</groupId><artifactId>micrometer-registry-otlp</artifactId></dependency>
         <dependency><groupId>io.micrometer</groupId><artifactId>micrometer-registry-prometheus</artifactId></dependency>
-        <dependency><groupId>io.prometheus</groupId><artifactId>prometheus-metrics-exposition-formats</artifactId></dependency>
+        <dependency><groupId>io.prometheus</groupId><artifactId>prometheus-metrics-exposition-textformats</artifactId></dependency>
         <dependency><groupId>io.prometheus</groupId><artifactId>prometheus-metrics-config</artifactId></dependency>
         <dependency><groupId>io.prometheus</groupId><artifactId>prometheus-metrics-model</artifactId></dependency>
 

--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/prometheus/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/prometheus/main/module.xml
@@ -12,7 +12,7 @@
     </properties>
 
     <resources>
-        <artifact name="${io.prometheus:prometheus-metrics-exposition-formats}"/>
+        <artifact name="${io.prometheus:prometheus-metrics-exposition-textformats}"/>
         <artifact name="${io.prometheus:prometheus-metrics-model}"/>
         <artifact name="${io.prometheus:prometheus-metrics-config}"/>
     </resources>

--- a/observability/micrometer/pom.xml
+++ b/observability/micrometer/pom.xml
@@ -66,7 +66,7 @@
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
-            <artifactId>prometheus-metrics-exposition-formats</artifactId>
+            <artifactId>prometheus-metrics-exposition-textformats</artifactId>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry.proto</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -430,13 +430,13 @@
         <version.io.agroal>2.0</version.io.agroal>
         <version.io.github.resilience4j>2.3.0</version.io.github.resilience4j>
         <version.io.grpc>1.70.0</version.io.grpc>
-        <version.io.micrometer>1.16.6</version.io.micrometer>
+        <version.io.micrometer>1.17.0</version.io.micrometer>
         <version.io.netty>4.1.136.Final</version.io.netty>
         <version.io.opentelemetry.instrumentation>2.14.0</version.io.opentelemetry.instrumentation>
         <version.io.opentelemetry.opentelemetry-semconv>1.32.0</version.io.opentelemetry.opentelemetry-semconv>
         <version.io.opentelemetry.opentelemetry>1.48.0</version.io.opentelemetry.opentelemetry>
         <version.io.opentelemetry.proto>1.5.0-alpha</version.io.opentelemetry.proto>
-        <version.io.prometheus>1.3.3</version.io.prometheus>
+        <version.io.prometheus>1.7.0</version.io.prometheus>
         <version.io.reactivex.rxjava2>2.2.21</version.io.reactivex.rxjava2>
         <version.io.reactivex.rxjava3>3.1.12</version.io.reactivex.rxjava3>
         <version.io.smallrye.open-api>4.3.5</version.io.smallrye.open-api>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-22117

- Bump Micrometer version
- Update io.prometheus to match Micrometer's dep version 
- Modify included artifact to reflect upstream package move