### PR TITLE
[TEST] Upgrade Apache CXF from 4.1.8-jbossorg-1 to 4.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -473,7 +473,7 @@
         <version.org.apache.activemq.artemis>2.55.0</version.org.apache.activemq.artemis>
         <version.org.apache.activemq.artemis.native>2.0.0</version.org.apache.activemq.artemis.native>
         <version.org.apache.avro>1.12.1</version.org.apache.avro>
-        <version.org.apache.cxf>4.1.8-jbossorg-1</version.org.apache.cxf>
+        <version.org.apache.cxf>4.1.8</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>4.1.3</version.org.apache.cxf.xjcplugins>
         <version.org.apache.httpcomponents.httpasyncclient>4.1.5</version.org.apache.httpcomponents.httpasyncclient>
         <version.org.apache.james.apache-mime4j>0.8.14</version.org.apache.james.apache-mime4j>


### PR DESCRIPTION
## CXF CR Validation

Validation PR to test Apache CXF 4.1.8 (tag `cxf-4.1.8`) against WildFly CI.

### Version change
- `version.org.apache.cxf`: `4.1.8-jbossorg-1` → `4.1.8`

### JBossWS-CXF local test results (JDK 21)
- 265 tests run, 1 failure, 3 errors, 3 skipped
- Known failures: decoupled WS-Addressing ReplyTo now blocked by default in CXF 4.1.8

---
*Draft PR for CI validation. Will be converted to a proper upgrade PR with a WFLY JIRA tracker if checks pass.*