### PR TITLE
[WFLY-22122] Remove use of StabilityServerSetupSnaphotRestoreTasks.Pr…

### DIFF
--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/logout/EnvSetupUtils.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/logout/EnvSetupUtils.java
@@ -85,8 +85,6 @@ public class EnvSetupUtils {
 
         /**
          * @param value        The name of the logout claim typ for elytron to use
-         * @param providerFlag flags that a "provider" server config xml should be
-         *                     created and not a "secure-deployment" config xml
          */
         public static void setProviderJwtClaimsTyp(String value) {
             providerJwtClaimsTyp = value;
@@ -167,6 +165,8 @@ public class EnvSetupUtils {
 
                 operation = createOpNode("system-property=" + Constants.CLIENT_SECRET_PROP, ModelDescriptionConstants.REMOVE);
                 Utils.applyUpdate(operation, client);
+            } else {
+                removeOidcServerDeploymentConfig(managementClient);
             }
         }
 
@@ -283,6 +283,22 @@ public class EnvSetupUtils {
 
                 operation = createOpNode(SECURE_DEPLOYMENT_ADDRESS + app + ".war/credential=secret", ModelDescriptionConstants.ADD);
                 operation.get("secret").set(CLIENT_SECRET);
+                Utils.applyUpdate(operation, client);
+            }
+
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
+        }
+
+        private static void removeOidcServerDeploymentConfig(ManagementClient managementClient) throws Exception {
+            ModelControllerClient client = managementClient.getControllerClient();
+
+            for (String app : APP_NAMES.keySet()) {
+
+                ModelNode operation = createOpNode(SECURE_DEPLOYMENT_ADDRESS + app + ".war/credential=secret", ModelDescriptionConstants.REMOVE);
+                Utils.applyUpdate(operation, client);
+
+                operation = createOpNode(
+                        SECURE_DEPLOYMENT_ADDRESS + app + ".war", ModelDescriptionConstants.REMOVE);
                 Utils.applyUpdate(operation, client);
             }
 

--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/logout/JsonConfigLogoutNoCallbackTest.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/logout/JsonConfigLogoutNoCallbackTest.java
@@ -30,7 +30,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.security.common.servlets.SimpleServlet;
 import org.jboss.as.test.integration.security.common.servlets.SimpleSecuredServlet;
 import org.jboss.as.test.http.util.TestHttpClientUtils;
@@ -41,7 +40,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import org.wildfly.test.integration.elytron.oidc.client.KeycloakConfiguration;
-import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -53,9 +51,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@ServerSetup({ JsonConfigLogoutNoCallbackTest.PreviewStabilitySetupTask.class,
-        EnvSetupUtils.KeycloakAndSubsystemSetup.class,
-        EnvSetupUtils.WildFlyServerSetupTask.class})
+@ServerSetup({EnvSetupUtils.KeycloakAndSubsystemSetup.class, EnvSetupUtils.WildFlyServerSetupTask.class})
 public class JsonConfigLogoutNoCallbackTest extends LoginLogoutBasics {
 
     @ArquillianResource
@@ -205,16 +201,6 @@ public class JsonConfigLogoutNoCallbackTest extends LoginLogoutBasics {
         } finally {
             deployer.undeploy(BACK_CHANNEL_LOGOUT_APP_TWO);
             deployer.undeploy(BACK_CHANNEL_LOGOUT_APP);
-        }
-    }
-
-    //-------------- Server Setup -------------------------
-    public static class PreviewStabilitySetupTask extends StabilityServerSetupSnapshotRestoreTasks.Preview {
-        @Override
-        protected void doSetup(ManagementClient managementClient) throws Exception {
-            // Write a system property so the model gets stored with a lower stability level.
-            // This is to make sure we can reload back to the higher level from the snapshot
-            LoginLogoutBasics.addSystemProperty(managementClient, JsonConfigLogoutNoCallbackTest.class);
         }
     }
 }

--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/logout/JsonConfigLogoutTest.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/logout/JsonConfigLogoutTest.java
@@ -31,7 +31,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.security.common.servlets.SimpleServlet;
 import org.jboss.as.test.integration.security.common.servlets.SimpleSecuredServlet;
 import org.jboss.as.test.http.util.TestHttpClientUtils;
@@ -42,7 +41,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import org.wildfly.test.integration.elytron.oidc.client.KeycloakConfiguration;
-import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -54,9 +52,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@ServerSetup({ JsonConfigLogoutTest.PreviewStabilitySetupTask.class,
-        EnvSetupUtils.KeycloakAndSubsystemSetup.class,
-        EnvSetupUtils.WildFlyServerSetupTask.class})
+@ServerSetup({ EnvSetupUtils.KeycloakAndSubsystemSetup.class, EnvSetupUtils.WildFlyServerSetupTask.class})
 public class JsonConfigLogoutTest extends LoginLogoutBasics {
 
     @ArquillianResource
@@ -257,16 +253,6 @@ public class JsonConfigLogoutTest extends LoginLogoutBasics {
         } finally {
             deployer.undeploy(BACK_CHANNEL_LOGOUT_APP_TWO);
             deployer.undeploy(BACK_CHANNEL_LOGOUT_APP);
-        }
-    }
-
-    //-------------- Server Setup -------------------------
-    public static class PreviewStabilitySetupTask extends StabilityServerSetupSnapshotRestoreTasks.Preview {
-        @Override
-        protected void doSetup(ManagementClient managementClient) throws Exception {
-            // Write a system property so the model gets stored with a lower stability level.
-            // This is to make sure we can reload back to the higher level from the snapshot
-            LoginLogoutBasics.addSystemProperty(managementClient, JsonConfigLogoutTest.class);
         }
     }
 }

--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/logout/ServerConfigLogoutNoCallbackTest.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/logout/ServerConfigLogoutNoCallbackTest.java
@@ -30,7 +30,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.security.common.servlets.SimpleServlet;
 import org.jboss.as.test.integration.security.common.servlets.SimpleSecuredServlet;
 import org.jboss.as.test.http.util.TestHttpClientUtils;
@@ -41,7 +40,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import org.wildfly.test.integration.elytron.oidc.client.KeycloakConfiguration;
-import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -53,9 +51,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@ServerSetup({ ServerConfigLogoutNoCallbackTest.PreviewStabilitySetupTask.class,
-        EnvSetupUtils.KeycloakAndSubsystemSetup.class,
-        EnvSetupUtils.WildFlyServerSetupTask.class})
+@ServerSetup({ EnvSetupUtils.KeycloakAndSubsystemSetup.class, EnvSetupUtils.WildFlyServerSetupTask.class})
 public class ServerConfigLogoutNoCallbackTest extends LoginLogoutBasics {
 
     @ArquillianResource
@@ -202,17 +198,6 @@ public class ServerConfigLogoutNoCallbackTest extends LoginLogoutBasics {
         } finally {
             deployer.undeploy(BACK_CHANNEL_LOGOUT_APP_TWO);
             deployer.undeploy(BACK_CHANNEL_LOGOUT_APP);
-        }
-    }
-
-
-    //-------------- Server Setup -------------------------
-    public static class PreviewStabilitySetupTask extends StabilityServerSetupSnapshotRestoreTasks.Preview {
-        @Override
-        protected void doSetup(ManagementClient managementClient) throws Exception {
-            // Write a system property so the model gets stored with a lower stability level.
-            // This is to make sure we can reload back to the higher level from the snapshot
-            LoginLogoutBasics.addSystemProperty(managementClient, ServerConfigLogoutNoCallbackTest.class);
         }
     }
 }

--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/logout/ServerConfigLogoutTest.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/logout/ServerConfigLogoutTest.java
@@ -29,7 +29,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.security.common.servlets.SimpleServlet;
 import org.jboss.as.test.integration.security.common.servlets.SimpleSecuredServlet;
 import org.jboss.as.test.http.util.TestHttpClientUtils;
@@ -40,7 +39,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import org.wildfly.test.integration.elytron.oidc.client.KeycloakConfiguration;
-import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -52,9 +50,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@ServerSetup({ ServerConfigLogoutTest.PreviewStabilitySetupTask.class,
-        EnvSetupUtils.KeycloakAndSubsystemSetup.class,
-        EnvSetupUtils.WildFlyServerSetupTask.class})
+@ServerSetup({ EnvSetupUtils.KeycloakAndSubsystemSetup.class, EnvSetupUtils.WildFlyServerSetupTask.class})
 public class ServerConfigLogoutTest extends LoginLogoutBasics {
 
     @ArquillianResource
@@ -214,17 +210,6 @@ public class ServerConfigLogoutTest extends LoginLogoutBasics {
         } finally {
             deployer.undeploy(BACK_CHANNEL_LOGOUT_APP_TWO);
             deployer.undeploy(BACK_CHANNEL_LOGOUT_APP);
-        }
-    }
-
-
-    //-------------- Server Setup -------------------------
-    public static class PreviewStabilitySetupTask extends StabilityServerSetupSnapshotRestoreTasks.Preview {
-        @Override
-        protected void doSetup(ManagementClient managementClient) throws Exception {
-            // Write a system property so the model gets stored with a lower stability level.
-            // This is to make sure we can reload back to the higher level from the snapshot
-            LoginLogoutBasics.addSystemProperty(managementClient, ServerConfigLogoutTest.class);
         }
     }
 }


### PR DESCRIPTION
…eview for the OIDC logout tests

https://redhat.atlassian.net/browse/WFLY-22122


____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21222](https://redhat.atlassian.net/browse/WFLY-21222)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)