### PR TITLE
WildFly Bot skip field and paths-ignore addition

### DIFF
--- a/.github/wildfly-bot.yml
+++ b/.github/wildfly-bot.yml
@@ -252,6 +252,7 @@ wildfly:
     - brian.stansberry@redhat.com
   
   format:
+    skip: "(?i)no\\s+(?:jira|issue)\\s+(?:required|needed)"
     description:
       regexes:
         - pattern: "https://redhat.atlassian.net/browse/WFLY-\\d+"

--- a/.github/workflows/cloud-test-pr-trigger.yml
+++ b/.github/workflows/cloud-test-pr-trigger.yml
@@ -8,6 +8,7 @@ on:
       - "docs/**"
       - ".github/workflows/build-manual.yml"
       - ".github/workflows/shared-wildfly-build.yml"
+      - ".github/wildfly-bot.yml"
       - '.gitattributes'
       - '.gitignore'
       - '.gitleaks.toml'

--- a/.github/workflows/jdk-jre-build.yml
+++ b/.github/workflows/jdk-jre-build.yml
@@ -9,6 +9,7 @@ on:
       - "docs/**"
       - ".github/workflows/build-manual.yml"
       - ".github/workflows/shared-wildfly-build.yml"
+      - ".github/wildfly-bot.yml"
       - '.gitattributes'
       - '.gitignore'
       - '.gitleaks.toml'
@@ -33,6 +34,7 @@ on:
       - "docs/**"
       - ".github/workflows/build-manual.yml"
       - ".github/workflows/shared-wildfly-build.yml"
+      - ".github/wildfly-bot.yml"
       - '.gitattributes'
       - '.gitignore'
       - '.gitleaks.toml'


### PR DESCRIPTION
No JIRA required(*)

\* Note that the format check will still fail because the bot only looks up the file defined in the WildFly repository (which is still the old one). However, this will be updated once the PR has been merged.

Another thing, note that there is going to be a need for a change in the https://github.com/wildfly/wildfly/blob/main/docs/src/main/asciidoc/_hacking/pullrequest_standards.adoc docs, but I will leave that probably for another time, since I think the (case insensitive) regex pattern (skip) is something that more WF maintainers need to agree on, current (this PR) `"No (JIRA|issue) (required|needed)"` is more of a "temporary" solution.

[#wildfly-developers > WildFly Bot – format check failed based on incorrect premise](https://wildfly.zulipchat.com/#narrow/channel/174184-wildfly-developers/topic/WildFly.20Bot.20.E2.80.93.20format.20check.20failed.20based.20on.20incorrect.20premise/with/605770719)