### PR TITLE
WFLY-21965 Workaround premature exchange completion on HttpServletResponse.sendRedirect(...).

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/SimpleServlet.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/SimpleServlet.java
@@ -107,7 +107,7 @@ public class SimpleServlet extends HttpServlet {
     }
 
     @Override
-    protected void doPost(HttpServletRequest request, HttpServletResponse response) {
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         Function<HttpSession, Mutable> accessor = session -> {
             Mutable mutable = (Mutable) session.getAttribute(ATTRIBUTE);
             if (mutable == null) {
@@ -116,6 +116,8 @@ public class SimpleServlet extends HttpServlet {
             return (mutable == null) ? (Mutable) session.getAttribute(ATTRIBUTE) : mutable;
         };
         this.increment(request, response, accessor);
+        // Validate WFLY-21965, ensure session locks are released on request completion in the event that Undertow triggers exchange completion events prematurely.
+        response.sendError(HttpServletResponse.SC_OK);
     }
 
     private void increment(HttpServletRequest request, HttpServletResponse response, Function<HttpSession, Mutable> accessor) {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/ControlPointDeploymentInfoConfigurator.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/ControlPointDeploymentInfoConfigurator.java
@@ -24,10 +24,13 @@ import io.undertow.server.session.SessionManagerStatistics;
 import io.undertow.server.session.SessionReference;
 import io.undertow.servlet.api.Deployment;
 import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.ListenerInfo;
 import io.undertow.servlet.api.SessionManagerFactory;
 import io.undertow.servlet.api.ThreadSetupHandler;
 import io.undertow.servlet.handlers.ServletRequestContext;
+import io.undertow.servlet.spec.HttpServletRequestImpl;
 import io.undertow.servlet.spec.HttpSessionImpl;
+import io.undertow.servlet.util.ImmediateInstanceFactory;
 import io.undertow.util.AttachmentKey;
 
 import org.jboss.logging.Logger;
@@ -55,6 +58,10 @@ public class ControlPointDeploymentInfoConfigurator implements UnaryOperator<Dep
 
     @Override
     public DeploymentInfo apply(DeploymentInfo deployment) {
+        if (LOGGER.isTraceEnabled()) {
+            // Log application boundaries
+            deployment.addListener(new ListenerInfo(RequestLoggingListener.class, new ImmediateInstanceFactory<>(RequestLoggingListener.INSTANCE)));
+        }
         // ControlPoint.beginRequest() triggered within initial handler chain
         // ControlPoint.requestComplete() will be triggered by the later of 2 events: ExchangeCompletionListener or ThreadSetupHandler.Action
         // This complexity is needed to workaround a quirk in Undertow, where io.undertow.servlet.spec.HttpServletResponseImpl#responseDone() triggers Session.requestDone() even if request processing is not complete, e.g. application events have yet to be emitted.
@@ -75,7 +82,7 @@ public class ControlPointDeploymentInfoConfigurator implements UnaryOperator<Dep
             }
             boolean accepted = result == RunResult.RUN;
             if (accepted) {
-                LOGGER.tracef("Request #%s BEGIN", exchange.getRequestId());
+                LOGGER.tracef("Request #%s BEGIN [%s] %s%s%s", exchange.getRequestId(), exchange.getRequestMethod(), exchange.getRequestURI(), exchange.getQueryString().isEmpty() ? "" : "?", exchange.getQueryString());
                 // Used to distinguish between mid-request and post-request exchange completion
                 // Used to workaround unwanted post-ExchangeCompletionListener invocation of Session.requestDone(...)
                 exchange.putAttachment(COMPLETE, Boolean.FALSE);
@@ -421,6 +428,26 @@ public class ControlPointDeploymentInfoConfigurator implements UnaryOperator<Dep
         @Override
         public SessionReference getReference() {
             return this.session.getReference();
+        }
+    }
+
+    private enum RequestLoggingListener implements jakarta.servlet.ServletRequestListener {
+        INSTANCE;
+
+        @Override
+        public void requestInitialized(jakarta.servlet.ServletRequestEvent event) {
+            if (event.getServletRequest() instanceof HttpServletRequestImpl request) {
+                HttpServerExchange exchange = request.getExchange();
+                LOGGER.tracef("Request #%s ServletRequestListener.requestInitialized(...)", exchange.getRequestId());
+            }
+        }
+
+        @Override
+        public void requestDestroyed(jakarta.servlet.ServletRequestEvent event) {
+            if (event.getServletRequest() instanceof HttpServletRequestImpl request) {
+                HttpServerExchange exchange = request.getExchange();
+                LOGGER.tracef("Request #%s ServletRequestListener.requestDestroyed(...)", exchange.getRequestId());
+            }
         }
     }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/ControlPointDeploymentInfoConfigurator.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/ControlPointDeploymentInfoConfigurator.java
@@ -123,7 +123,8 @@ public class ControlPointDeploymentInfoConfigurator implements UnaryOperator<Dep
         } finally {
             // If exchange completes outside of handler chain, trigger ControlPoint.requestComplete() (if required)
             // Otherwise, defer completion signal until ThreadSetupHandler.Action tear-down.
-            if (!exchange.isDispatched() && (exchange.removeAttachment(ControlPointDeploymentInfoConfigurator.RUN_RESULT_KEY) == RunResult.RUN)) {
+            ServletRequestContext context = exchange.getAttachment(ServletRequestContext.ATTACHMENT_KEY);
+            if (((context == null) || !context.isRunningInsideHandler()) && (exchange.removeAttachment(ControlPointDeploymentInfoConfigurator.RUN_RESULT_KEY) == RunResult.RUN)) {
                 this.complete(exchange);
                 LOGGER.tracef("Request #%s END via ExchangeCompleteListener", exchange.getRequestId());
             }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21965

Works around another issue in Undertow, where ExchangeCompletionListener.complete(...) are invoked immediately following HttpServletResponse.sendRedirect(...), even though request processing is not yet complete.
This otherwise interferes with the lifecycle of the distributed session.

Verified using reproducer attached to issue.