### PR TITLE
[WFLY-22126] Address review feedback for EJB-over-HTTP path normalization

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/http/HttpInvokerCookiePathTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/http/HttpInvokerCookiePathTestCase.java
@@ -55,6 +55,13 @@ public class HttpInvokerCookiePathTestCase {
             HttpGet request = new HttpGet(wildflyServicesUrl);
 
             try (CloseableHttpResponse response = httpClient.execute(request)) {
+                // The HTTP invoker endpoint requires authentication, so it returns 401 Unauthorized.
+                // The JSESSIONID cookie is only set on 401 responses to avoid sticky session issues.
+                Assert.assertEquals(
+                    "Expected 401 Unauthorized from the HTTP invoker endpoint",
+                    401, response.getStatusLine().getStatusCode()
+                );
+
                 // Inspect Set-Cookie headers
                 Header[] setCookieHeaders = response.getHeaders("Set-Cookie");
 
@@ -68,12 +75,12 @@ public class HttpInvokerCookiePathTestCase {
                     if (cookieValue.contains("JSESSIONID=")) {
                         foundJSessionId = true;
 
-                        // Extract path attribute
+                        // Extract path attribute — lower-case the segment for case-insensitive matching
                         String[] parts = cookieValue.split(";");
                         for (String part : parts) {
-                            String trimmed = part.trim();
-                            if (trimmed.toLowerCase().startsWith(PATH_PREFIX)) {
-                                actualPath = trimmed.substring(PATH_PREFIX.length());
+                            String lower = part.trim().toLowerCase();
+                            if (lower.startsWith(PATH_PREFIX)) {
+                                actualPath = lower.substring(PATH_PREFIX.length());
                                 break;
                             }
                         }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/Host.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/Host.java
@@ -292,15 +292,15 @@ public class Host implements Service<Host>, FilterLocation, SuspendableActivity 
     }
 
     void registerLocation(String path) {
-        String realPath = UndertowUtils.normalizePath(path);
-        locations.put(realPath, null);
-        server.get().getUndertowService().fireEvent(listener -> listener.onDeploymentStart(realPath, Host.this));
+        assert path.startsWith("/") : "path must be normalized before calling registerLocation";
+        locations.put(path, null);
+        server.get().getUndertowService().fireEvent(listener -> listener.onDeploymentStart(path, Host.this));
     }
 
     void unregisterLocation(String path) {
-        String realPath = UndertowUtils.normalizePath(path);
-        locations.remove(realPath);
-        server.get().getUndertowService().fireEvent(listener -> listener.onDeploymentStop(realPath, Host.this));
+        assert path.startsWith("/") : "path must be normalized before calling unregisterLocation";
+        locations.remove(path);
+        server.get().getUndertowService().fireEvent(listener -> listener.onDeploymentStop(path, Host.this));
     }
 
     public void registerHandler(String path, HttpHandler handler) {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpInvokerDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpInvokerDefinition.java
@@ -96,7 +96,7 @@ public class HttpInvokerDefinition extends PersistentResourceDefinition {
             final PathAddress address = context.getCurrentAddress();
             final PathAddress hostAddress = address.getParent();
             final PathAddress serverAddress = hostAddress.getParent();
-            String path = PATH.resolveModelAttribute(context, model).asString();
+            String path = UndertowUtils.normalizePath(PATH.resolveModelAttribute(context, model).asString());
             String httpAuthenticationFactory = null;
             final ModelNode authFactory = HTTP_AUTHENTICATION_FACTORY.resolveModelAttribute(context, model);
             final ModelNode securityRealm = SECURITY_REALM.resolveModelAttribute(context, model);

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpInvokerHostService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpInvokerHostService.java
@@ -64,7 +64,8 @@ final class HttpInvokerHostService implements Service {
         }
 
         SessionCookieConfig sessionConfig = new SessionCookieConfig();
-        sessionConfig.setPath(UndertowUtils.normalizePath(this.path));
+        assert this.path.startsWith("/") : "path must be normalized before constructing HttpInvokerHostService";
+        sessionConfig.setPath(this.path);
         Server server = this.host.get().getServer();
         ServletContainerService container = server.getServletContainer();
         CookieConfig affinityCookeConfig = container.getAffinityCookieConfig();

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowUtils.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowUtils.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.wildfly.extension.undertow;
 
 public final class UndertowUtils {


### PR DESCRIPTION
JIRA Issues:

* Upstream: [WFLY-22126](https://redhat.atlassian.net/browse/WFLY-22126)

Follow-up to [WFLY-21930](https://github.com/wildfly/wildfly/pull/20058):
- Add missing copyright header
- Trace path value to HttpInvokerDefinition.java and normalize it there
- Replace remaining normalizations with asserts


____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21930](https://redhat.atlassian.net/browse/WFLY-21930)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)