### PR TITLE
WFLY-22130 - Update Mojarra to WildFly to 4.0.22 and 4.1.13

### DIFF
--- a/boms/legacy-ee/pom.xml
+++ b/boms/legacy-ee/pom.xml
@@ -56,7 +56,7 @@
         <version.org.elasticsearch.client.rest-client>8.15.4</version.org.elasticsearch.client.rest-client>
         <version.org.glassfish.expressly>5.0.0</version.org.glassfish.expressly>
         <version.org.glassfish.jakarta.enterprise.concurrent>3.0.2</version.org.glassfish.jakarta.enterprise.concurrent>
-        <version.org.glassfish.jakarta.faces>4.0.20</version.org.glassfish.jakarta.faces>
+        <version.org.glassfish.jakarta.faces>4.0.22</version.org.glassfish.jakarta.faces>
         <version.org.glassfish.soteria>3.0.3</version.org.glassfish.soteria>
         <version.org.jboss.resteasy>6.2.16.Final</version.org.jboss.resteasy>
         <version.org.jboss.spec.jakarta.el.jboss-el-api_5.0_spec>4.0.2.Final</version.org.jboss.spec.jakarta.el.jboss-el-api_5.0_spec>

--- a/boms/standard-preview-ee/pom.xml
+++ b/boms/standard-preview-ee/pom.xml
@@ -57,7 +57,7 @@
         <version.org.bytebuddy>1.18.8</version.org.bytebuddy>
         <version.org.elasticsearch.client.rest-client>9.3.1</version.org.elasticsearch.client.rest-client>
         <version.org.glassfish.expressly>6.0.0</version.org.glassfish.expressly>
-        <version.org.glassfish.jakarta.faces>4.1.11</version.org.glassfish.jakarta.faces>
+        <version.org.glassfish.jakarta.faces>4.1.13</version.org.glassfish.jakarta.faces>
         <version.org.glassfish.soteria>4.0.2</version.org.glassfish.soteria>
         <version.org.hibernate.search>8.4.0.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>9.1.1.Final</version.org.hibernate.validator>

--- a/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/JSFMetadataProcessor.java
+++ b/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/JSFMetadataProcessor.java
@@ -8,9 +8,9 @@ package org.jboss.as.jsf.deployment;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.sun.faces.config.WebConfiguration;
 import jakarta.faces.application.ViewHandler;
 import org.jboss.as.controller.ModuleIdentifierUtil;
-import org.jboss.as.jsf.logging.JSFLogger;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
@@ -20,8 +20,6 @@ import org.jboss.metadata.javaee.spec.ParamValueMetaData;
 import org.jboss.metadata.web.jboss.JBossServletMetaData;
 import org.jboss.metadata.web.jboss.JBossWebMetaData;
 import org.jboss.metadata.web.spec.MultipartConfigMetaData;
-
-import com.sun.faces.config.WebConfiguration;
 
 /**
  * @author Stuart Douglas
@@ -85,13 +83,6 @@ public class JSFMetadataProcessor implements DeploymentUnitProcessor {
             setContextParameterIfAbsent(webMetaData, WebConfiguration.BooleanWebContextInitParameter.DisallowDoctypeDecl.getQualifiedName(), disallowDoctypeDecl.toString());
         }
         if (webMetaData.getDistributable() != null) {
-            // Auto-disable lazy bean validation for distributable web application.
-            // This can otherwise cause missing @PreDestroy events.
-            String disabled = Boolean.toString(false);
-            if (!setContextParameterIfAbsent(webMetaData, WebConfiguration.BooleanWebContextInitParameter.EnableLazyBeanValidation.getQualifiedName(), disabled).equals(disabled)) {
-                JSFLogger.ROOT_LOGGER.lazyBeanValidationEnabled();
-            }
-
             String version = JsfVersionMarker.getVersion(deploymentUnit);
             // Disable counter-productive "distributable" logic in Mojarra implementation
             if (version.equals(JsfVersionMarker.JSF_4_0)) {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-22130

- Update Mojarra versions
- Remove references to deleted context param (see https://github.com/eclipse-ee4j/mojarra/commit/19fea7dd2)
