### PR TITLE
WFLY-22138 Document how to configure JGroups diagnostics

### DIFF
--- a/docs/src/main/asciidoc/_high-availability/jgroups/JGroups_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_high-availability/jgroups/JGroups_Subsystem.adoc
@@ -289,3 +289,34 @@ Following is an example of fine-tuning the `RED` protocol's `min_treshold` to in
 ----
 /subsystem=jgroups/stack=udp/protocol=RED:map-put(name=properties, key=min_threshold, value=0.6)
 ----
+
+[[enabling-diagnostics]]
+=== Enabling diagnostics
+
+JGroups ships with a `probe.sh` tool that can query and manipulate running protocol stacks.
+Diagnostics support is disabled by default; to enable it, add a socket binding and reference it from the transport.
+
+[source,options="nowrap"]
+----
+# Create jgroups-diagnostics multicast socket binding
+/socket-binding-group=standard-sockets/socket-binding=jgroups-diagnostics:add(port=0, multicast-address=224.0.75.75, multicast-port=7500)
+
+# Configure tcp stack
+/subsystem=jgroups/stack=tcp/transport=TCP:write-attribute(name=diagnostics-socket-binding, value=jgroups-diagnostics)
+
+# Configure udp stack
+/subsystem=jgroups/stack=udp/transport=UDP:write-attribute(name=diagnostics-socket-binding, value=jgroups-diagnostics)
+----
+
+
+[IMPORTANT]
+====
+The configured diagnostics port (typically `7500`) must be open in the firewall on all cluster nodes for `probe.sh` to reach them.
+====
+
+For further information on the `probe.sh` tool see the http://www.jgroups.org/manual5/index.html#Probe[JGroups documentation].
+
+[WARNING]
+====
+The diagnostics endpoint is unauthenticated; restrict access to trusted hosts via firewall rules.
+====

--- a/docs/src/main/asciidoc/_testsuite/WildFly_Integration_Testsuite_User_Guide.adoc
+++ b/docs/src/main/asciidoc/_testsuite/WildFly_Integration_Testsuite_User_Guide.adoc
@@ -384,9 +384,6 @@ and the following defaults, overridable by respective parameter:
 |-Dmcast |230.0.0.4 |ff01::1 |ff01::1 is IPv6 Node-Local scope mcast
 addr.
 
-|-Dmcast.jgroupsDiag |224.0.75.75 |ff01::2 |JGroups diagnostics
-multicast address.
-
 |-Dmcast.modcluster |224.0.1.105 |ff01::3 |mod_cluster multicast
 address.
 |=======================================================================


### PR DESCRIPTION
Add a CLI-based how-to for enabling the JGroups diagnostics endpoint, covering the jgroups-diagnostics socket binding, wiring it to both the UDP and TCP transports, a link to the JGroups probe.sh documentation, and a note that the port must be opened in the firewall.

Also remove the dead -Dmcast.jgroupsDiag parameter from the testsuite user guide, as the diagnostics socket binding was removed from the default configuration back in AS7-5577.

Hopefully the warning is big enough. Let me know if people thing it should be bigger.

Resolves
https://redhat.atlassian.net/browse/WFLY-22138