### PR TITLE
[WFLY-22149] ProtoStreamJSFFailoverTestCase failures on Windows

### DIFF
--- a/clustering/weld/core/src/main/java/org/wildfly/clustering/weld/contexts/PassivationCapableSerializableMarshaller.java
+++ b/clustering/weld/core/src/main/java/org/wildfly/clustering/weld/contexts/PassivationCapableSerializableMarshaller.java
@@ -94,9 +94,14 @@ public class PassivationCapableSerializableMarshaller<SC extends SerializableCon
             writer.writeAny(CONTEXTUAL_INDEX, instance);
         } else {
             BeanIdentifier identifier = contextual.getIdentifier();
-            Container container = Container.instance(contextId);
-            BeanIdentifierIndex index = container.services().get(BeanIdentifierIndex.class);
-            Integer beanIndex = (index != null) && index.isBuilt() ? index.getIndex(identifier) : null;
+            Integer beanIndex = null;
+            try {
+                Container container = Container.instance(contextId);
+                BeanIdentifierIndex index = container.services().get(BeanIdentifierIndex.class);
+                beanIndex = (index != null) && index.isBuilt() ? index.getIndex(identifier) : null;
+            } catch (IllegalStateException e) {
+                // Container may not be available if TCCL is not the deployment's classloader
+            }
             if (beanIndex != null) {
                 int value = beanIndex.intValue();
                 if (value != 0) {


### PR DESCRIPTION
[WFLY-22149] ProtoStreamJSFFailoverTestCase.testGracefulSimpleFailover seemed to be one of those tests that would fail every now and then on a PR job, but it looks like recently it's failing a lot, often on nightly jobs, and always on Windows:

https://ci.wildfly.org/project.html?projectId=WF&buildTypeId=&tab=testDetails&testNameId=3369504733365641228&order=TEST_STATUS_DESC&branch_WF=__all_branches__&itemsCount=50

Issue Link: https://redhat.atlassian.net/browse/WFLY-22149
____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-22149](https://redhat.atlassian.net/browse/WFLY-22149)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)