### PR TITLE
(41.x) - [WFLY-22150][WFLY-22154] - Upgrade Apache CXF from 4.1.6 to 4.1.8 and JBossWS-CXF from 7.4.0 to 7.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -474,7 +474,7 @@
         <version.org.apache.activemq.artemis>2.54.0</version.org.apache.activemq.artemis>
         <version.org.apache.activemq.artemis.native>2.0.0</version.org.apache.activemq.artemis.native>
         <version.org.apache.avro>1.12.1</version.org.apache.avro>
-        <version.org.apache.cxf>4.1.8-jbossorg-1</version.org.apache.cxf>
+        <version.org.apache.cxf>4.1.8</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>4.1.3</version.org.apache.cxf.xjcplugins>
         <version.org.apache.httpcomponents.httpasyncclient>4.1.5</version.org.apache.httpcomponents.httpasyncclient>
         <version.org.apache.james.apache-mime4j>0.8.14</version.org.apache.james.apache-mime4j>
@@ -549,7 +549,7 @@
         <version.org.jboss.ws.api>3.1.0.Final</version.org.jboss.ws.api>
         <version.org.jboss.ws.common>5.2.0.Final</version.org.jboss.ws.common>
         <version.org.jboss.ws.common.tools>2.2.0.Final</version.org.jboss.ws.common.tools>
-        <version.org.jboss.ws.cxf>7.4.0.Final</version.org.jboss.ws.cxf>
+        <version.org.jboss.ws.cxf>7.4.1.Final</version.org.jboss.ws.cxf>
         <version.org.jboss.ws.jaxws-undertow-httpspi>3.0.1.Final</version.org.jboss.ws.jaxws-undertow-httpspi>
         <version.org.jboss.ws.spi>5.1.0.Final</version.org.jboss.ws.spi>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.10.Final</version.org.jboss.xnio.netty.netty-xnio-transport>


### PR DESCRIPTION
Upstream issues:
- https://redhat.atlassian.net/browse/WFLY-22150
- https://redhat.atlassian.net/browse/WFLY-22154

~Still a draft because we use JBossWS-CXF Beta1.~
:information_source: - We're using jbossws-cxf-7.4.1.Final now, which ATM is only available via the JBoss public Maven repository.