### PR TITLE
[WFLY-21471] Include boot-errors in liveness health check response

### DIFF
--- a/health/src/main/java/org/wildfly/extension/health/HealthContextService.java
+++ b/health/src/main/java/org/wildfly/extension/health/HealthContextService.java
@@ -142,12 +142,22 @@ public class HealthContextService implements Service {
                     response.add(probeOutcome);
                 }
             }
-            if (HEALTH.equals(requestPath) || HEALTH_LIVE.equals(requestPath)) {
-                // always respond to the /health/live positively
-                ModelNode probeOutcome = new ModelNode();
-                probeOutcome.get(NAME).set("live-server");
-                probeOutcome.get(OUTCOME).set(true);
-                response.add(probeOutcome);
+            if (HEALTH_LIVE.equals(requestPath)) {
+                for (ServerProbe serverProbe : serverProbes.getServerProbes()) {
+                    if (serverProbe.isLivenessProbe()) {
+                        ServerProbe.Outcome outcome = serverProbe.getOutcome();
+                        if (!outcome.isSuccess()) {
+                            globalOutcome = false;
+                        }
+                        ModelNode probeOutcome = new ModelNode();
+                        probeOutcome.get(NAME).set(serverProbe.getName());
+                        probeOutcome.get(OUTCOME).set(outcome.isSuccess());
+                        if (outcome.getData().isDefined()) {
+                            probeOutcome.get("data").set(outcome.getData());
+                        }
+                        response.add(probeOutcome);
+                    }
+                }
             }
             if (HEALTH.equals(requestPath) || HEALTH_STARTED.equals(requestPath)) {
                 // always respond to the /health/started positively

--- a/health/src/main/java/org/wildfly/extension/health/ServerProbe.java
+++ b/health/src/main/java/org/wildfly/extension/health/ServerProbe.java
@@ -11,6 +11,10 @@ public interface ServerProbe {
 
     String getName();
 
+    default boolean isLivenessProbe() {
+        return false;
+    }
+
     static class Outcome {
         final ModelNode data;
         final boolean success;

--- a/health/src/main/java/org/wildfly/extension/health/ServerProbes.java
+++ b/health/src/main/java/org/wildfly/extension/health/ServerProbes.java
@@ -175,6 +175,11 @@ class ServerProbes {
         public String getName() {
             return "boot-errors";
         }
+
+        @Override
+        public boolean isLivenessProbe() {
+            return true;
+        }
     }
 
 

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthReporter.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthReporter.java
@@ -40,6 +40,7 @@ public class MicroProfileHealthReporter {
     private final Map<HealthCheck, ClassLoader> readinessChecks = new HashMap<>();
     private final Map<HealthCheck, ClassLoader> startupChecks = new HashMap<>();
     private final Map<HealthCheck, ClassLoader> serverReadinessChecks = new HashMap<>();
+    private final Map<HealthCheck, ClassLoader> serverLivenessChecks = new HashMap<>();
 
     private final HealthCheck emptyDeploymentLivenessCheck;
     private final HealthCheck emptyDeploymentReadinessCheck;
@@ -137,6 +138,7 @@ public class MicroProfileHealthReporter {
         HashMap<HealthCheck, ClassLoader> serverChecks = new HashMap<>();
         if (defaultProceduresShouldBeAdded()) {
             serverChecks.putAll(serverReadinessChecks);
+            serverChecks.putAll(serverLivenessChecks);
             if (deploymentChecks.size() == 0) {
                 serverChecks.put(emptyDeploymentLivenessCheck, Thread.currentThread().getContextClassLoader());
                 serverChecks.put(emptyDeploymentReadinessCheck, Thread.currentThread().getContextClassLoader());
@@ -147,11 +149,13 @@ public class MicroProfileHealthReporter {
     }
 
     public SmallRyeHealth getLiveness() {
-        final Map<HealthCheck, ClassLoader> serverChecks;
-        if (livenessChecks.size() == 0 && defaultProceduresShouldBeAdded()) {
-            serverChecks = Collections.singletonMap(emptyDeploymentLivenessCheck, Thread.currentThread().getContextClassLoader());
-        } else {
-            serverChecks = Collections.emptyMap();
+        final Map<HealthCheck, ClassLoader> serverChecks = new HashMap<>();
+        final boolean addDefaultProcedures = defaultProceduresShouldBeAdded();
+        if (addDefaultProcedures) {
+            serverChecks.putAll(serverLivenessChecks);
+        }
+        if (livenessChecks.isEmpty() && serverChecks.isEmpty() && addDefaultProcedures) {
+            serverChecks.put(emptyDeploymentLivenessCheck, Thread.currentThread().getContextClassLoader());
         }
         return getHealth(serverChecks, livenessChecks);
     }
@@ -304,6 +308,12 @@ public class MicroProfileHealthReporter {
     public void addServerReadinessCheck(HealthCheck check, ClassLoader moduleClassLoader) {
         if (check != null) {
             serverReadinessChecks.put(check, moduleClassLoader);
+        }
+    }
+
+    public void addServerLivenessCheck(HealthCheck check, ClassLoader moduleClassLoader) {
+        if (check != null) {
+            serverLivenessChecks.put(check, moduleClassLoader);
         }
     }
 

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthReporterService.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthReporterService.java
@@ -57,7 +57,11 @@ public class MicroProfileHealthReporterService implements Service {
         if (!defaultServerProceduresDisabled) {
             ClassLoader tccl = Thread.currentThread().getContextClassLoader();
             for (ServerProbe serverProbe : serverProbesService.get().getServerProbes()) {
-                healthReporter.addServerReadinessCheck(wrap(serverProbe), tccl);
+                HealthCheck wrapped = wrap(serverProbe);
+                healthReporter.addServerReadinessCheck(wrapped, tccl);
+                if (serverProbe.isLivenessProbe()) {
+                    healthReporter.addServerLivenessCheck(wrapped, tccl);
+                }
             }
         }
 


### PR DESCRIPTION
JIRA Issue: [WFLY-21471](https://redhat.atlassian.net/browse/WFLY-21471)

### Description

When WildFly encounters errors during startup, these boot-errors are recorded and reported through the health check endpoints. However, they were only reported as part of /health/ready (readiness), not /health/live (liveness). This meant a server that failed to start would forever report itself as live but not ready. Since the liveness check returned UP, Kubernetes would not restart the server, and since boot-errors are irrecoverable without a restart, the server remained stuck until manually restarted.

This fix ensures boot-errors are reported as a liveness failure so that container orchestrators like Kubernetes will automatically restart the affected pod.

### Changes

- Added `isLivenessProbe()` default method to the `ServerProbe` interface, returning `false` for all existing probes
- Overridden `isLivenessProbe()` in `NoBootErrorsCheck` to return `true`, marking it as a liveness probe
- Introduced a `serverLivenessChecks` map in `MicroProfileHealthReporter` and updated `getLiveness()` and `getHealth()` to include liveness probes in their responses
- Updated `MicroProfileHealthReporterService` to register liveness-flagged probes into both readiness and liveness maps during startup
- Replaced the hardcoded `live-server: UP` dummy response in `HealthContextService` with real liveness probe evaluation on `/health/live`

### Behavior

- Boot errors present: `/health/live` returns `503` with `boot-errors: DOWN` (previously returned `200` with hardcoded `live server: UP`). `/health/ready` returns `503` with `boot-errors: DOWN` (unchanged). `/health` returns `503` with `boot-errors: DOWN` appearing once.
- Clean server: `/health/live` returns `200` with `boot-errors: UP`. `/health/ready` returns `200` with all probes UP. `/health` returns `200` with all probes UP.
- Server suspended: `/health/live` returns `200`. `/health/ready` returns `503` with `suspend-state: DOWN`. Unchanged behavior.
- disable-default-procedures=true: All server probes are skipped. Unchanged behavior.

### What does not change

  - `ServerStateCheck`, `SuspendStateCheck`, `DeploymentsStatusCheck` remain readiness-only probes
  - Application `@Liveness,` `@Readiness`, `@Startup` checks are untouched
  - `mp.health.disable-default-procedures` continues to guard all server probe registration
  - `/health/started` endpoint is unchanged
  - No schema, subsystem attribute, or management operation changes