### PR TITLE
(41.x) WFLY-22163 Bump io.netty:netty-bom from 4.1.136.Final to 4.1.137.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -432,7 +432,7 @@
         <version.io.github.resilience4j>2.3.0</version.io.github.resilience4j>
         <version.io.grpc>1.70.0</version.io.grpc>
         <version.io.micrometer>1.16.6</version.io.micrometer>
-        <version.io.netty>4.1.136.Final</version.io.netty>
+        <version.io.netty>4.1.137.Final</version.io.netty>
         <version.io.opentelemetry.instrumentation>2.14.0</version.io.opentelemetry.instrumentation>
         <version.io.opentelemetry.opentelemetry-semconv>1.32.0</version.io.opentelemetry.opentelemetry-semconv>
         <version.io.opentelemetry.opentelemetry>1.48.0</version.io.opentelemetry.opentelemetry>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-22163
Upstream: #20312

Bumps [io.netty:netty-bom](https://github.com/netty/netty) from 4.1.136.Final to 4.1.137.Final.
- [Release notes](https://github.com/netty/netty/releases)
- [Commits](https://github.com/netty/netty/compare/netty-4.1.136.Final...netty-4.1.137.Final)

---
updated-dependencies:
- dependency-name: io.netty:netty-bom dependency-version: 4.1.137.Final dependency-type: direct:production update-type: version-update:semver-patch ...

Thanks for submitting your Pull Request!

Please delete this text, and add a link to the Jira issue solved by this PR.

If this PR is not for the 'main' branch you must add a link to the equivalent change in 'main'.

Remember to use the Jira issue ID in the PR title and any commits.
