### PR TITLE
[WFLY-22173] Upgrade version.io.vertx.vertx from 4.5.30 to 4.5.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -451,7 +451,7 @@
         <version.io.smallrye.smallrye-opentelemetry>2.11.2</version.io.smallrye.smallrye-opentelemetry>
         <version.io.smallrye.smallrye-stork>2.7.11</version.io.smallrye.smallrye-stork>
         <version.io.smallrye.smallrye-reactive-messaging>4.35.0</version.io.smallrye.smallrye-reactive-messaging>
-        <version.io.vertx.vertx>4.5.30</version.io.vertx.vertx>
+        <version.io.vertx.vertx>4.5.32</version.io.vertx.vertx>
         <version.io.vertx.vertx-kafka-client>4.4.9</version.io.vertx.vertx-kafka-client>
         <version.jakarta.activation.jakarta.activation-api>2.1.4</version.jakarta.activation.jakarta.activation-api>
         <version.jakarta.batch.jakarta.batch-api>2.1.1</version.jakarta.batch.jakarta.batch-api>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-22173

Upstream: https://github.com/wildfly/wildfly/pull/20311

Get Vert.x in sync with it's proton-j dep that we updated in WFLY-22151 to fix a CVE.
