### PR TITLE
[WFLY-22165] PowerShell scripts do not process JAVA_OPTS from the environment as the .bat counteparts

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/content/bin/appclient.conf.ps1
+++ b/ee-feature-pack/galleon-shared/src/main/resources/content/bin/appclient.conf.ps1
@@ -38,31 +38,37 @@ if (-Not(test-path env:JBOSS_MODULES_SYSTEM_PKGS )) {
 
 $JAVA_OPTS = @()
 
-# JVM memory allocation pool parameters - modify as appropriate.
-$JAVA_OPTS += '-Xms64M'
-$JAVA_OPTS += '-Xmx512M'
+# initialize JAVA_OPTS from the environment
+$JAVA_OPTS = String-To-Array -value $env:JAVA_OPTS
 
-# Reduce the RMI GCs to once per hour for Sun JVMs.
-$JAVA_OPTS += '-Dsun.rmi.dgc.client.gcInterval=3600000'
-$JAVA_OPTS += '-Dsun.rmi.dgc.server.gcInterval=3600000'
-$JAVA_OPTS += '-Djava.net.preferIPv4Stack=true'
+if (!$JAVA_OPTS) {
+    # JVM memory allocation pool parameters - modify as appropriate.
+    $JAVA_OPTS += '-Xms64M'
+    $JAVA_OPTS += '-Xmx512M'
 
-# Warn when resolving remote XML DTDs or schemas.
-$JAVA_OPTS += '-Dorg.jboss.resolver.warning=true'
+    # Reduce the RMI GCs to once per hour for Sun JVMs.
+    $JAVA_OPTS += '-Dsun.rmi.dgc.client.gcInterval=3600000'
+    $JAVA_OPTS += '-Dsun.rmi.dgc.server.gcInterval=3600000'
+    $JAVA_OPTS += '-Djava.net.preferIPv4Stack=true'
 
-# Make Byteman classes visible in all module loaders
-# This is necessary to inject Byteman rules into AS7 deployments
-$JAVA_OPTS += "-Djboss.modules.system.pkgs=$JBOSS_MODULES_SYSTEM_PKGS"
+    # Warn when resolving remote XML DTDs or schemas.
+    $JAVA_OPTS += '-Dorg.jboss.resolver.warning=true'
 
-# Sample JPDA settings for remote socket debugging
-# $JAVA_OPTS += '-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n'
+    # Make Byteman classes visible in all module loaders
+    # This is necessary to inject Byteman rules into AS7 deployments
+    $JAVA_OPTS += "-Djboss.modules.system.pkgs=$JBOSS_MODULES_SYSTEM_PKGS"
 
-# Sample JPDA settings for shared memory debugging
-# $JAVA_OPTS += '-Xrunjdwp:transport=dt_shmem,address=jboss,server=y,suspend=n'
+    # Sample JPDA settings for remote socket debugging
+    # $JAVA_OPTS += '-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n'
 
-# Use JBoss Modules lockless mode
-# $JAVA_OPTS += '-Djboss.modules.lockless=true'
+    # Sample JPDA settings for shared memory debugging
+    # $JAVA_OPTS += '-Xrunjdwp:transport=dt_shmem,address=jboss,server=y,suspend=n'
+
+    # Use JBoss Modules lockless mode
+    # $JAVA_OPTS += '-Djboss.modules.lockless=true'
+}
 
 # Uncomment this to run with a security manager enabled
 # $SECMGR=$true
+
 

--- a/ee-feature-pack/galleon-shared/src/main/resources/content/bin/appclient.conf.ps1
+++ b/ee-feature-pack/galleon-shared/src/main/resources/content/bin/appclient.conf.ps1
@@ -1,6 +1,6 @@
 ### -*- Power Shell file -*- ################################################
 #                                                                          ##
-#  Applicent bootstrap Script Configuration                                    ##
+#  AppClient bootstrap Script Configuration                                ##
 #                                                                          ##
 #############################################################################
 
@@ -35,11 +35,10 @@ if (-Not(test-path env:JBOSS_MODULES_SYSTEM_PKGS )) {
   $JBOSS_MODULES_SYSTEM_PKGS="org.jboss.byteman"
 }
 
-
-$JAVA_OPTS = @()
-
 # initialize JAVA_OPTS from the environment
-$JAVA_OPTS = String-To-Array -value $env:JAVA_OPTS
+# @(...) keeps the result an array; PowerShell unrolls the value returned by String-To-Array,
+# so an empty or single valued JAVA_OPTS would otherwise be assigned as $null or a String
+$JAVA_OPTS = @(String-To-Array -value $env:JAVA_OPTS)
 
 if (!$JAVA_OPTS) {
     # JVM memory allocation pool parameters - modify as appropriate.

--- a/ee-feature-pack/galleon-shared/src/main/resources/content/bin/appclient.ps1
+++ b/ee-feature-pack/galleon-shared/src/main/resources/content/bin/appclient.ps1
@@ -13,8 +13,10 @@ $APPCLIENT_CONF_FILE = "$scripts\appclient.conf.ps1"
 $APPCLIENT_CONF_FILE = Get-Env RUN_CONF $APPCLIENT_CONF_FILE
 . $APPCLIENT_CONF_FILE
 
-$JAVA_OPTS = Get-Java-Opts
-$MODULE_OPTS = String-To-Array -value $env:MODULE_OPTS
+
+# @(...) keeps the results arrays; PowerShell unrolls the values returned by these functions,
+# so empty or single valued options would otherwise be assigned as $null or a String
+$MODULE_OPTS = @(String-To-Array -value $env:MODULE_OPTS)
 if ($global:SECMGR) {
     $MODULE_OPTS +="-secmgr";
 }

--- a/ee-feature-pack/galleon-shared/src/main/resources/content/bin/jdr.ps1
+++ b/ee-feature-pack/galleon-shared/src/main/resources/content/bin/jdr.ps1
@@ -6,10 +6,10 @@
 $scripts = (Get-ChildItem $MyInvocation.MyCommand.Path).Directory.FullName;
 . "$scripts\common.ps1"
 
-$JAVA_OPTS = @()
-
 # initialize JAVA_OPTS from the environment
-$JAVA_OPTS = String-To-Array -value $env:JAVA_OPTS
+# @(...) keeps the result an array; PowerShell unrolls the value returned by String-To-Array,
+# so an empty or single valued JAVA_OPTS would otherwise be assigned as $null or a String
+$JAVA_OPTS = @(String-To-Array -value $env:JAVA_OPTS)
 
 $PROG_ARGS = Get-Java-Arguments -entryModule "org.jboss.as.jdr" -serverOpts $ARGS -logFileProperties $null
 

--- a/ee-feature-pack/galleon-shared/src/main/resources/content/bin/jdr.ps1
+++ b/ee-feature-pack/galleon-shared/src/main/resources/content/bin/jdr.ps1
@@ -8,6 +8,9 @@ $scripts = (Get-ChildItem $MyInvocation.MyCommand.Path).Directory.FullName;
 
 $JAVA_OPTS = @()
 
+# initialize JAVA_OPTS from the environment
+$JAVA_OPTS = String-To-Array -value $env:JAVA_OPTS
+
 $PROG_ARGS = Get-Java-Arguments -entryModule "org.jboss.as.jdr" -serverOpts $ARGS -logFileProperties $null
 
 try{

--- a/ee-feature-pack/galleon-shared/src/main/resources/content/bin/wsconsume.ps1
+++ b/ee-feature-pack/galleon-shared/src/main/resources/content/bin/wsconsume.ps1
@@ -6,10 +6,10 @@
 $scripts = (Get-ChildItem $MyInvocation.MyCommand.Path).Directory.FullName;
 . "$scripts\common.ps1"
 
-$JAVA_OPTS = @()
-
 # initialize JAVA_OPTS from the environment
-$JAVA_OPTS = String-To-Array -value $env:JAVA_OPTS
+# @(...) keeps the result an array; PowerShell unrolls the value returned by String-To-Array,
+# so an empty or single valued JAVA_OPTS would otherwise be assigned as $null or a String
+$JAVA_OPTS = @(String-To-Array -value $env:JAVA_OPTS)
 
 # Sample JPDA settings for remote socket debugging
 #$JAVA_OPTS+="-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y"

--- a/ee-feature-pack/galleon-shared/src/main/resources/content/bin/wsconsume.ps1
+++ b/ee-feature-pack/galleon-shared/src/main/resources/content/bin/wsconsume.ps1
@@ -8,6 +8,9 @@ $scripts = (Get-ChildItem $MyInvocation.MyCommand.Path).Directory.FullName;
 
 $JAVA_OPTS = @()
 
+# initialize JAVA_OPTS from the environment
+$JAVA_OPTS = String-To-Array -value $env:JAVA_OPTS
+
 # Sample JPDA settings for remote socket debugging
 #$JAVA_OPTS+="-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y"
 

--- a/ee-feature-pack/galleon-shared/src/main/resources/content/bin/wsprovide.ps1
+++ b/ee-feature-pack/galleon-shared/src/main/resources/content/bin/wsprovide.ps1
@@ -6,10 +6,10 @@
 $scripts = (Get-ChildItem $MyInvocation.MyCommand.Path).Directory.FullName;
 . "$scripts\common.ps1"
 
-$JAVA_OPTS = @()
-
 # initialize JAVA_OPTS from the environment
-$JAVA_OPTS = String-To-Array -value $env:JAVA_OPTS
+# @(...) keeps the result an array; PowerShell unrolls the value returned by String-To-Array,
+# so an empty or single valued JAVA_OPTS would otherwise be assigned as $null or a String
+$JAVA_OPTS = @(String-To-Array -value $env:JAVA_OPTS)
 
 # Sample JPDA settings for remote socket debugging
 #$JAVA_OPTS+="-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y"

--- a/ee-feature-pack/galleon-shared/src/main/resources/content/bin/wsprovide.ps1
+++ b/ee-feature-pack/galleon-shared/src/main/resources/content/bin/wsprovide.ps1
@@ -8,6 +8,9 @@ $scripts = (Get-ChildItem $MyInvocation.MyCommand.Path).Directory.FullName;
 
 $JAVA_OPTS = @()
 
+# initialize JAVA_OPTS from the environment
+$JAVA_OPTS = String-To-Array -value $env:JAVA_OPTS
+
 # Sample JPDA settings for remote socket debugging
 #$JAVA_OPTS+="-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y"
 

--- a/testsuite/scripts/src/test/java/org/wildfly/test/scripts/ScriptProcess.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/test/scripts/ScriptProcess.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -63,6 +64,7 @@ public class ScriptProcess implements AutoCloseable, ProcessHandle {
     private ProcessHandle handleDelegate;
     private Path stdoutLog;
     private String lastExecutedCmd;
+    private final Map<String, String> lastEnv;
 
     ScriptProcess(final Path containerHome, final String scriptBaseName, final Shell shell, final long timeout) {
         this.containerHome = containerHome;
@@ -71,7 +73,8 @@ public class ScriptProcess implements AutoCloseable, ProcessHandle {
         this.script = containerHome.resolve("bin").resolve(scriptName);
         this.timeout = timeout;
         this.prefixCmds = Arrays.asList(shell.getPrefix());
-        lastExecutedCmd = "";
+        this.lastExecutedCmd = "";
+        this.lastEnv = new HashMap<>();
     }
 
     void start(final Map<String, String> env, final String... arguments) throws IOException, TimeoutException, InterruptedException {
@@ -104,6 +107,9 @@ public class ScriptProcess implements AutoCloseable, ProcessHandle {
         if (env != null && !env.isEmpty()) {
             builder.environment().putAll(env);
         }
+        // Capture the final environment state for error reporting
+        lastEnv.clear();
+        lastEnv.putAll(builder.environment());
         final Process process = builder.start();
         if (check != null) {
             waitFor(process, check);
@@ -132,8 +138,15 @@ public class ScriptProcess implements AutoCloseable, ProcessHandle {
                 .append(lastExecutedCmd)
                 .append(System.lineSeparator())
                 .append("Environment:")
-                .append(System.lineSeparator())
-                .append("Output:")
+                .append(System.lineSeparator());
+        for (Map.Entry<String, String> entry : lastEnv.entrySet()) {
+            errorMessage.append("  ")
+                    .append(entry.getKey())
+                    .append("=")
+                    .append(entry.getValue())
+                    .append(System.lineSeparator());
+        }
+        errorMessage.append("Output:")
                 .append(System.lineSeparator());
         try {
             for (String line : getStdout()) {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-22165
Upstream: https://github.com/wildfly/wildfly/pull/20330 (merged)

My impression is this is needed to allow clean CI of WFCORE-7670 (once there's a 33.x PR) and WFCORE-7670 is a WF 41.0.1 blocker, so this PR is too.
