### PR TITLE
WIP: Add Hibernate Search `hibernate-search-backend-elasticsearch-client-rest5` client integration to the preview server

### DIFF
--- a/boms/common-ee/pom.xml
+++ b/boms/common-ee/pom.xml
@@ -68,6 +68,17 @@
             </dependency>
             <dependency>
                 <groupId>${ee.maven.groupId}</groupId>
+                <artifactId>jipijapa-hibernatesearch-elasticsearch-rest5</artifactId>
+                <version>${ee.maven.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>${ee.maven.groupId}</groupId>
                 <artifactId>jipijapa-spi</artifactId>
                 <version>${ee.maven.version}</version>
                 <exclusions>

--- a/boms/standard-preview-ee/pom.xml
+++ b/boms/standard-preview-ee/pom.xml
@@ -53,9 +53,12 @@
         <version.jakarta.websocket.jakarta-websocket-api>2.2.0</version.jakarta.websocket.jakarta-websocket-api>
         <version.jakarta.ws.rs.jakarta-ws-rs-api>4.0.0</version.jakarta.ws.rs.jakarta-ws-rs-api>
         <version.org.antlr>4.13.2</version.org.antlr>
+        <version.org.apache.httpcomponents.client5>5.6</version.org.apache.httpcomponents.client5>
+        <version.org.apache.httpcomponents.core5>5.4</version.org.apache.httpcomponents.core5>
         <version.org.apache.lucene>9.12.3</version.org.apache.lucene>
         <version.org.bytebuddy>1.18.8</version.org.bytebuddy>
         <version.org.elasticsearch.client.rest-client>9.3.1</version.org.elasticsearch.client.rest-client>
+        <version.co.elastic.clients.elasticsearch-rest5-client>9.3.1</version.co.elastic.clients.elasticsearch-rest5-client>
         <version.org.glassfish.expressly>6.0.0</version.org.glassfish.expressly>
         <version.org.glassfish.jakarta.faces>4.1.13</version.org.glassfish.jakarta.faces>
         <version.org.glassfish.soteria>4.0.2</version.org.glassfish.soteria>
@@ -383,6 +386,40 @@
             </dependency>
 
             <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>${version.org.apache.httpcomponents.client5}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5</artifactId>
+                <version>${version.org.apache.httpcomponents.core5}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5-h2</artifactId>
+                <version>${version.org.apache.httpcomponents.core5}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-analysis-common</artifactId>
                 <version>${version.org.apache.lucene}</version>
@@ -475,6 +512,17 @@
                 <groupId>org.elasticsearch.client</groupId>
                 <artifactId>elasticsearch-rest-client-sniffer</artifactId>
                 <version>${version.org.elasticsearch.client.rest-client}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>co.elastic.clients</groupId>
+                <artifactId>elasticsearch-rest5-client</artifactId>
+                <version>${version.co.elastic.clients.elasticsearch-rest5-client}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -614,6 +662,17 @@
             <dependency>
                 <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-backend-elasticsearch-client-rest4</artifactId>
+                <version>${version.org.hibernate.search}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-backend-elasticsearch-client-rest5</artifactId>
                 <version>${version.org.hibernate.search}</version>
                 <exclusions>
                     <exclusion>

--- a/jpa/hibernatesearch-elasticsearch-rest5/pom.xml
+++ b/jpa/hibernatesearch-elasticsearch-rest5/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-jpa-parent</artifactId>
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
+        <version>42.0.0.Beta1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jipijapa-hibernatesearch-elasticsearch-rest5</artifactId>
+
+    <name>WildFly: Jipijapa Hibernate Search Elasticsearch rest5 client default (WildFly Preview)</name>
+    <description>
+        Additional Hibernate Search integrator adaptor, shipped only by WildFly Preview, that defaults every
+        Elasticsearch backend to the Apache HttpClient 5 based "rest5" client unless the application selected a
+        client explicitly. Standard WildFly does not ship this artifact and keeps Hibernate Search's own default.
+    </description>
+
+    <dependencies>
+        <!-- Internal -->
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jipijapa-spi</artifactId>
+        </dependency>
+
+        <!-- External -->
+
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>jandex</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-engine</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/jpa/hibernatesearch-elasticsearch-rest5/src/main/java/org/jipijapa/hibernate/search/elasticsearch/HibernateSearchElasticsearchRest5IntegratorAdaptor.java
+++ b/jpa/hibernatesearch-elasticsearch-rest5/src/main/java/org/jipijapa/hibernate/search/elasticsearch/HibernateSearchElasticsearchRest5IntegratorAdaptor.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jipijapa.hibernate.search.elasticsearch;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.hibernate.search.engine.cfg.BackendSettings;
+import org.hibernate.search.engine.cfg.EngineSettings;
+import org.jboss.jandex.Index;
+import org.jipijapa.plugin.spi.PersistenceProviderIntegratorAdaptor;
+import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
+
+/**
+ * Additional {@link PersistenceProviderIntegratorAdaptor} shipped only by WildFly Preview.
+ * <p>
+ * WildFly Preview provisions the Apache HttpClient 5 based "rest5" Elasticsearch client and
+ * makes it the default for every Elasticsearch backend.This adaptor selects the rest5 client
+ * unless the application already chose a client explicitly.
+ */
+public class HibernateSearchElasticsearchRest5IntegratorAdaptor implements PersistenceProviderIntegratorAdaptor {
+
+    // Value of the Hibernate Search backend "type" property (org.hibernate.search.engine.cfg.BackendSettings.TYPE)
+    // selecting the Elasticsearch backend.
+    private static final String ELASTICSEARCH_BACKEND_TYPE = "elasticsearch";
+    // Namespace prefix for named backends: hibernate.search.backends.<name>.* (the default backend uses the
+    // singular hibernate.search.backend.*). EngineSettings.BACKENDS is "hibernate.search.backends" (no trailing dot).
+    private static final String NAMED_BACKENDS_PREFIX = EngineSettings.BACKENDS + ".";
+    // Backend property radical selecting the pluggable Elasticsearch REST client;
+    // see org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings#CLIENT_FACTORY.
+    private static final String CLIENT_FACTORY = "client_factory";
+    // The Apache HttpClient 5 based "rest5" Elasticsearch client, the only one WildFly Preview provisions.
+    private static final String DEFAULT_ELASTICSEARCH_CLIENT_FACTORY = "elasticsearch-rest5";
+
+    @Override
+    public void injectIndexes(Collection<Index> indexes) {
+        // Nothing to do: index handling is owned by the core Hibernate Search integrator adaptor.
+    }
+
+    @Override
+    public void addIntegratorProperties(Map<String, Object> properties, PersistenceUnitMetadata pu) {
+        // Default every Elasticsearch backend to the rest5 client provisioned by WildFly Preview.
+        Properties puProperties = pu.getProperties();
+        for (String backendName : elasticsearchBackendNames(puProperties)) {
+            String clientFactoryKey = BackendSettings.backendKey(backendName, CLIENT_FACTORY);
+            // Respect an explicit application choice, whether set in the persistence unit or by another integrator.
+            if (!puProperties.containsKey(clientFactoryKey) && !properties.containsKey(clientFactoryKey)) {
+                properties.put(clientFactoryKey, DEFAULT_ELASTICSEARCH_CLIENT_FACTORY);
+            }
+        }
+    }
+
+    @Override
+    public void afterCreateContainerEntityManagerFactory(PersistenceUnitMetadata pu) {
+        // Nothing to clean up.
+    }
+
+    /**
+     * @return the names of all Elasticsearch backends configured in the persistence unit, using {@code null} for the
+     * default (unnamed) backend.
+     */
+    private static List<String> elasticsearchBackendNames(Properties puProperties) {
+        List<String> backendNames = new ArrayList<>();
+        // Default backend: hibernate.search.backend.type
+        if (isElasticsearch(puProperties.getProperty(BackendSettings.backendKey(BackendSettings.TYPE)))) {
+            backendNames.add(null);
+        }
+        // Named backends: hibernate.search.backends.<name>.type
+        String typeSuffix = "." + BackendSettings.TYPE;
+        for (String key : puProperties.stringPropertyNames()) {
+            if (key.startsWith(NAMED_BACKENDS_PREFIX) && key.endsWith(typeSuffix)) {
+                String backendName = key.substring(NAMED_BACKENDS_PREFIX.length(), key.length() - typeSuffix.length());
+                // A backend name never contains a dot; this guards against deeper keys such as index-level properties.
+                if (!backendName.isEmpty() && backendName.indexOf('.') < 0 && isElasticsearch(puProperties.getProperty(key))) {
+                    backendNames.add(backendName);
+                }
+            }
+        }
+        return backendNames;
+    }
+
+    private static boolean isElasticsearch(String backendType) {
+        return backendType != null && ELASTICSEARCH_BACKEND_TYPE.equals(backendType.trim());
+    }
+}

--- a/jpa/hibernatesearch-elasticsearch-rest5/src/main/resources/META-INF/services/org.jipijapa.plugin.spi.PersistenceProviderIntegratorAdaptor
+++ b/jpa/hibernatesearch-elasticsearch-rest5/src/main/resources/META-INF/services/org.jipijapa.plugin.spi.PersistenceProviderIntegratorAdaptor
@@ -1,0 +1,1 @@
+org.jipijapa.hibernate.search.elasticsearch.HibernateSearchElasticsearchRest5IntegratorAdaptor

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -40,6 +40,7 @@
     <modules>
         <module>hibernate7</module>
         <module>hibernatesearch</module>
+        <module>hibernatesearch-elasticsearch-rest5</module>
         <module>persistence-cdi-extension</module>
         <module>persistence32</module>
         <module>subsystem</module>

--- a/preview/galleon-local/pom.xml
+++ b/preview/galleon-local/pom.xml
@@ -41,6 +41,36 @@
         </dependency>
 
         <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-backend-elasticsearch-client-rest5</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>co.elastic.clients</groupId>
+            <artifactId>elasticsearch-rest5-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5-h2</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>jipijapa-hibernatesearch-elasticsearch-rest5</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.wildfly.deployment</groupId>
             <artifactId>wildfly-ee-9-deployment-transformer</artifactId>
         </dependency>

--- a/preview/galleon-local/src/main/resources/modules/system/layers/base/co/elastic/clients/elasticsearch-rest5-client/main/module.xml
+++ b/preview/galleon-local/src/main/resources/modules/system/layers/base/co/elastic/clients/elasticsearch-rest5-client/main/module.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="co.elastic.clients.elasticsearch-rest5-client">
+
+    <properties>
+        <!-- Direct access to the Elasticsearch client is allowed in WildFly,
+             though it may not be supported by product vendors
+             (because its APIs could change without prior notice). -->
+        <property name="jboss.api" value="public"/>
+    </properties>
+
+    <resources>
+        <artifact name="${co.elastic.clients:elasticsearch-rest5-client}"/>
+    </resources>
+
+    <dependencies>
+        <module name="org.apache.httpcomponents.client5" export="true" services="export"/>
+        <module name="org.apache.commons.logging"/>
+        <module name="jakarta.json.api"/>
+    </dependencies>
+</module>

--- a/preview/galleon-local/src/main/resources/modules/system/layers/base/org/apache/httpcomponents/client5/main/module.xml
+++ b/preview/galleon-local/src/main/resources/modules/system/layers/base/org/apache/httpcomponents/client5/main/module.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<!-- Apache HttpComponents Client 5 (HttpClient 5 / HttpCore 5). Used by the
+     Hibernate Search Elasticsearch rest5 client. -->
+<module xmlns="urn:jboss:module:1.9" name="org.apache.httpcomponents.client5">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.apache.httpcomponents.client5:httpclient5}"/>
+        <artifact name="${org.apache.httpcomponents.core5:httpcore5}"/>
+        <artifact name="${org.apache.httpcomponents.core5:httpcore5-h2}"/>
+    </resources>
+
+    <dependencies>
+        <module name="java.naming"/>
+        <module name="java.security.jgss"/>
+        <!-- HttpClient 5 logs via SLF4J rather than commons-logging -->
+        <module name="org.slf4j"/>
+    </dependencies>
+</module>

--- a/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/search/backend/elasticsearch/main/module.xml
+++ b/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/search/backend/elasticsearch/main/module.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<!-- Hibernate Search Elasticsearch backend: provides the ability to index into a remote Elasticsearch index.
+     WildFly Preview ships the Apache HttpClient 5 based "rest5" client instead of the rest4 client used by
+     standard WildFly; see the org.hibernate.search.jipijapa-hibernatesearch module override that defaults
+     newly deployed Elasticsearch backends to it. -->
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate.search.backend.elasticsearch">
+
+    <resources>
+        <artifact name="${org.hibernate.search:hibernate-search-backend-elasticsearch}"/>
+        <artifact name="${org.hibernate.search:hibernate-search-backend-elasticsearch-client-rest5}"/>
+    </resources>
+
+    <dependencies>
+        <module name="org.jboss.logging"/>
+        <module name="org.hibernate.search.engine" export="true"/>
+        <!-- This is not exported on purpose: users wanting to use the REST client or Gson directly
+             need to explicitly opt in by adding a dependency to that module -->
+        <module name="co.elastic.clients.elasticsearch-rest5-client" />
+        <module name="com.google.code.gson" />
+    </dependencies>
+</module>

--- a/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/search/jipijapa-hibernatesearch/main/module.xml
+++ b/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/search/jipijapa-hibernatesearch/main/module.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<!-- WildFly Preview override of org.hibernate.search.jipijapa-hibernatesearch: in addition to the core Hibernate
+     Search integrator adaptor it also ships jipijapa-hibernatesearch-elasticsearch-rest5, whose adaptor defaults every
+     Elasticsearch backend to the Apache HttpClient 5 based "rest5" client that WildFly Preview provisions (unless the
+     application selected a client explicitly). Standard WildFly ships neither this override nor that jar. -->
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate.search.jipijapa-hibernatesearch">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.wildfly:jipijapa-hibernatesearch}"/>
+        <artifact name="${org.wildfly:jipijapa-hibernatesearch-elasticsearch-rest5}"/>
+    </resources>
+
+    <dependencies>
+        <module name="jakarta.persistence.api"/>
+        <module name="io.smallrye.jandex"/>
+        <module name="org.jboss.as.jpa.spi"/>
+        <module name="org.hibernate.search.mapper.orm"/>
+    </dependencies>
+</module>


### PR DESCRIPTION
Hey 👋🏻 🙂 

with Hibernate Search 8.2 came the pluggable REST clients for the Elasticsearch backend: https://docs.hibernate.org/search/8.2/whats-new/en-US/html_single/#pluggable-clients, by deafult this backend still brings the same rest4 client but in ~ 9.0 there will be no default and users would need to pick one they want explicitly. 
Also, the general recommendation (from the Search side) is to go with the rest5 client even on 8.x.

What I've tried to do in this draft is to make the preview switch to the rest5 client. 

It would need someone with better knowledge of WildFly than me, to have a look to see if I haven't missed anything 🫣 🙂 

And if others agree that we should do this switch for the preview, I'll go open a Jira ticket.

cc: @scottmarlow 