### PR TITLE
WFLY-22189: clear registry supplier on service stop

### DIFF
--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalPooledConnectionFactoryService.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalPooledConnectionFactoryService.java
@@ -632,6 +632,7 @@ public class ExternalPooledConnectionFactoryService implements Service<ExternalP
 
     @Override
     public void stop(StopContext context) {
+        WildFlyRecoveryRegistry.clearSupplier();
         // Service context takes care of this
     }
     public BroadcastCommandDispatcherFactory getCommandDispatcherFactory(String name) {

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryService.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryService.java
@@ -574,6 +574,7 @@ public class PooledConnectionFactoryService implements Service<Void> {
 
 
     public void stop(StopContext context) {
+        WildFlyRecoveryRegistry.clearSupplier();
         // Service context takes care of this
     }
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeRemove.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeRemove.java
@@ -15,6 +15,7 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
+import org.wildfly.extension.messaging.activemq.jms.WildFlyRecoveryRegistry;
 
 /**
  * Removes a Jakarta Messaging Bridge.
@@ -31,6 +32,7 @@ class JMSBridgeRemove extends AbstractRemoveStepHandler {
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) {
         context.removeService(MessagingServices.getJMSBridgeServiceName(context.getCurrentAddressValue()));
+        WildFlyRecoveryRegistry.clearSupplier();
     }
 
     @Override


### PR DESCRIPTION
Issue: [WFLY-22189](https://redhat.atlassian.net/browse/WFLY-22189)

This stops the warning appearing on reload, however the warning still appears when you register multiple connection factories (you can see this in integration tests) and that feels kinda pointless since users can't do anything about it.