### PR TITLE
[WFLY-22185] Fix IronJacamar 3.0.23.Final compatibility

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceModelNodeUtil.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceModelNodeUtil.java
@@ -187,7 +187,7 @@ class DataSourceModelNodeUtil {
         final Long useTryLock = ModelNodeUtil.getLongIfSetOrGetDefault(operationContext, dataSourceNode, USE_TRY_LOCK);
         final boolean setTxQueryTimeout = ModelNodeUtil.getBooleanIfSetOrGetDefault(operationContext, dataSourceNode, SET_TX_QUERY_TIMEOUT);
         final TimeOut timeOut = new TimeOutImpl(blockingTimeoutMillis, idleTimeoutMinutes, allocationRetry,
-                allocationRetryWaitMillis, xaResourceTimeout, setTxQueryTimeout, queryTimeout, useTryLock);
+                allocationRetryWaitMillis, xaResourceTimeout, setTxQueryTimeout, queryTimeout, useTryLock, null);
         final String transactionIsolationString = ModelNodeUtil.getResolvedStringIfSetOrGetDefault(operationContext, dataSourceNode, TRANSACTION_ISOLATION);
         TransactionIsolation transactionIsolation = null;
         if (transactionIsolationString != null) {
@@ -289,7 +289,7 @@ class DataSourceModelNodeUtil {
         final Long useTryLock = ModelNodeUtil.getLongIfSetOrGetDefault(operationContext, dataSourceNode, USE_TRY_LOCK);
         final Boolean setTxQueryTimeout = ModelNodeUtil.getBooleanIfSetOrGetDefault(operationContext, dataSourceNode, SET_TX_QUERY_TIMEOUT);
         final TimeOut timeOut = new TimeOutImpl(blockingTimeoutMillis, idleTimeoutMinutes, allocationRetry,
-                allocationRetryWaitMillis, xaResourceTimeout, setTxQueryTimeout, queryTimeout, useTryLock);
+                allocationRetryWaitMillis, xaResourceTimeout, setTxQueryTimeout, queryTimeout, useTryLock, null);
         final String transactionIsolationString = ModelNodeUtil.getResolvedStringIfSetOrGetDefault(operationContext, dataSourceNode, TRANSACTION_ISOLATION);
         TransactionIsolation transactionIsolation = null;
         if (transactionIsolationString != null) {


### PR DESCRIPTION
## Summary

- adapt both datasource timeout construction paths to IronJacamar 3.0.23.Final's new `validationTimeoutSeconds` parameter
- pass `null` because WildFly does not expose that setting, preserving the previous behavior

This fixes the compilation failure in #20352 while keeping the Dependabot upgrade intact.

JIRA: https://redhat.atlassian.net/browse/WFLY-22185

## Verification

- exact #20352 bot head: `./mvnw -pl connector -am -DskipTests install` fails with the two `TimeOutImpl` constructor errors
- fixed branch: the same 10-module command passes
- behavior parity: `./mvnw -pl connector -am clean verify` passes on both the pre-upgrade base and fixed branch; the connector runs 37 tests with 0 failures/errors and 1 skip
- full JDK 17 repository gate: `./mvnw -B clean && ./mvnw -U -B -Dquickly` passes all 212 modules
- dependency audit confirms the connector resolves the IronJacamar 3.0.23.Final artifacts

The commit includes the required DCO sign-off.
