### PR TITLE
WFLY-20566 - RBAC access control interfering with Micrometer metrics

### DIFF
--- a/observability/micrometer/src/main/java/org/wildfly/extension/micrometer/otlp/WildFlyOtlpRegistry.java
+++ b/observability/micrometer/src/main/java/org/wildfly/extension/micrometer/otlp/WildFlyOtlpRegistry.java
@@ -15,6 +15,7 @@ import io.micrometer.registry.otlp.AggregationTemporality;
 import io.micrometer.registry.otlp.HistogramFlavor;
 import io.micrometer.registry.otlp.OtlpConfig;
 import io.micrometer.registry.otlp.OtlpMeterRegistry;
+import org.jboss.as.controller.access.InVmAccess;
 import org.wildfly.extension.micrometer.WildFlyMicrometerConfig;
 import org.wildfly.extension.micrometer.registry.WildFlyRegistry;
 import org.wildfly.security.manager.WildFlySecurityManager;
@@ -22,6 +23,21 @@ import org.wildfly.security.manager.WildFlySecurityManager;
 public class WildFlyOtlpRegistry extends OtlpMeterRegistry implements WildFlyRegistry {
     public WildFlyOtlpRegistry(WildFlyMicrometerOtlpConfig config) {
         super(config, Clock.SYSTEM);
+    }
+
+    /**
+     * [WFLY-20566] The OTLP export runs on a background scheduler thread that carries no caller identity. The model
+     * metrics are read through the same per-caller client the pull endpoint uses, so here they would resolve to the
+     * anonymous identity and be filtered to 0 under RBAC. Unlike a scrape, a server-initiated push has no caller to
+     * filter by, so the reads are performed as an in-VM call, which the management layer authorizes as SuperUser - the
+     * same mechanism {@code ModelControllerClientFactory} uses for its SuperUser clients. The pull path is unaffected.
+     */
+    @Override
+    protected void publish() {
+        InVmAccess.runInVm((PrivilegedAction<Void>) () -> {
+            super.publish();
+            return null;
+        });
     }
 
     public static class WildFlyMicrometerOtlpConfig extends WildFlyMicrometerConfig implements OtlpConfig {

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/metrics/MetricsRbacTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/metrics/MetricsRbacTestCase.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.test.integration.metrics;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROVIDER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.test.integration.management.api.expression.Utils.executeOp;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.List;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.config.AuthSchemes;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.test.shared.observability.setuptasks.RbacRealmSetupTask;
+import org.jboss.as.test.shared.observability.signals.PrometheusMetric;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.test.integration.metrics.application.TestApplication;
+import org.wildfly.test.integration.metrics.application.TestResource;
+import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({
+        StabilityServerSetupSnapshotRestoreTasks.Community.class,
+        RbacRealmSetupTask.class
+})
+public class MetricsRbacTestCase {
+    // Model-sourced (RBAC-affected) Undertow metric that must be non-zero once the deployment has served requests.
+    private static final String UNDERTOW_MODEL_METRIC = "wildfly_undertow_bytes_sent";
+    private static final int REQUEST_COUNT = 10;
+    private static Boolean isMetricsEnabled;
+
+    @ArquillianResource
+    protected URL url;
+    @ContainerResource
+    protected ManagementClient managementClient;
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(WebArchive.class).addClasses(TestApplication.class, TestResource.class);
+    }
+
+    // In some CI scenarios, the WildFly Metrics subsystem may not be enabled. In those scenarios, we need to ignore
+    // this test rather than failing the build.
+    @Before
+    public void before() throws Exception {
+        if (isMetricsEnabled == null) {
+            try {
+                executeOp(Util.getReadResourceDescriptionOperation(PathAddress.pathAddress(SUBSYSTEM, "metrics")),
+                        managementClient.getControllerClient());
+                isMetricsEnabled = true;
+            } catch (Exception e) {
+                isMetricsEnabled = false;
+            }
+        }
+        Assume.assumeTrue("WildFly Metrics must be enabled for this test to run.", isMetricsEnabled);
+    }
+
+    @Test
+    public void testWildFlyMetricsWithAuthentication() throws Exception {
+        verifyMetricsAccess(true);
+    }
+
+    @Test
+    public void testWildFlyMetricsWithoutAuthentication() throws Exception {
+        verifyMetricsAccess(false);
+    }
+
+    /**
+     * Negative test: with RBAC and endpoint security enabled, an unauthenticated scrape of the metrics endpoint
+     * must be rejected outright rather than served zeroed-out (anonymous) metrics.
+     */
+    @Test
+    public void testWildFlyMetricsUnauthenticatedRejected() throws Exception {
+        setAuthenticationEnabled(true);
+
+        Assert.assertEquals("Unauthenticated scrape of the secured metrics endpoint should be rejected",
+                401, fetchMetricsStatus(null, null));
+    }
+
+    /**
+     * Negative test: an authenticated management user without at least the Monitor role must not see the
+     * RBAC-protected model metrics. The scrape authenticates, but the Undertow model metric is read under the
+     * caller's identity and, lacking read access, comes back absent or zeroed rather than carrying a real value.
+     */
+    @Test
+    public void testWildFlyMetricsWithoutMonitorRole() throws Exception {
+        setAuthenticationEnabled(true);
+        makeRequests();
+
+        List<PrometheusMetric> metrics =
+                fetchMetrics(RbacRealmSetupTask.USER_NOROLE, RbacRealmSetupTask.TEST_RBAC_PASSWORD);
+
+        double value = metrics.stream()
+                .filter(metric -> metric.getKey().startsWith(UNDERTOW_MODEL_METRIC))
+                .findFirst()
+                .map(metric -> Double.parseDouble(metric.getValue()))
+                .orElse(0.0);
+
+        Assert.assertEquals("The Undertow model metric '" + UNDERTOW_MODEL_METRIC +
+                "' must not be visible to a user without the Monitor role, but was " + value, 0.0, value, 0.0);
+    }
+
+    private void verifyMetricsAccess(boolean authenticationEnabled) throws Exception {
+        setAuthenticationEnabled(authenticationEnabled);
+        makeRequests();
+
+        List<PrometheusMetric> metrics = authenticationEnabled
+                ? fetchMetrics(RbacRealmSetupTask.USER_MONITOR, RbacRealmSetupTask.TEST_RBAC_PASSWORD)
+                : fetchMetrics(null, null);
+
+        PrometheusMetric undertowMetric = metrics.stream().filter(metric ->
+                        metric.getKey().startsWith(UNDERTOW_MODEL_METRIC)).findFirst()
+                .orElseThrow(() -> new AssertionError("Undertow model metric not found"));
+
+        double value = Double.parseDouble(undertowMetric.getValue());
+
+        Assert.assertTrue("The Undertow model metric '" + UNDERTOW_MODEL_METRIC +
+                "' should be non-zero (authentication " + (authenticationEnabled ? "enabled" : "disabled") +
+                "), but was " + value, value > 0);
+    }
+
+    protected void makeRequests() throws URISyntaxException {
+        try (Client client = ClientBuilder.newClient()) {
+            WebTarget target = client.target(url.toURI() + "metrics-app/hello");
+            for (int i = 0; i < REQUEST_COUNT; i++) {
+                Response response = target.request().get();
+                Assert.assertEquals(200, response.getStatus());
+            }
+        }
+    }
+
+    /**
+     * Scrapes the management metrics endpoint.
+     */
+    protected List<PrometheusMetric> fetchMetrics(String username, String password) throws IOException {
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            CloseableHttpResponse resp = scrapeManagement(client, username, password);
+            return PrometheusMetric.buildPrometheusMetrics(EntityUtils.toString(resp.getEntity()));
+        }
+    }
+
+    /**
+     * Scrapes the management metrics endpoint and returns only the HTTP status code. Used by negative tests that
+     * assert an unauthenticated scrape is rejected before any metric body is produced.
+     */
+    protected int fetchMetricsStatus(String username, String password) throws IOException {
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            return scrapeManagement(client, username, password).getStatusLine().getStatusCode();
+        }
+    }
+
+    /**
+     * Issues a GET against {@code http://<mgmt-host>:<mgmt-port>/metrics}. When {@code username} is non-null the request
+     * carries the given credentials and is authenticated via DIGEST.
+     */
+    private CloseableHttpResponse scrapeManagement(CloseableHttpClient client, String username,
+                                                   String password) throws IOException {
+        HttpClientContext hcContext = HttpClientContext.create();
+        HttpGet get = new HttpGet(String.format("http://%s:%d/metrics", managementClient.getMgmtAddress(),
+                managementClient.getMgmtPort()));
+
+        if (username != null) {
+            CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(username, password));
+            hcContext.setCredentialsProvider(credentialsProvider);
+            get.setConfig(RequestConfig.custom()
+                    .setTargetPreferredAuthSchemes(List.of(AuthSchemes.DIGEST))
+                    .build());
+        }
+
+        return client.execute(get, hcContext);
+    }
+
+    /**
+     * Enables or disables RBAC and, in lockstep, the security of the WildFly Metrics endpoints, then reloads.
+     * With authentication enabled, scrapes must present a management-realm identity with at least Monitor access.
+     * With it disabled, the endpoints are open.
+     */
+    private void setAuthenticationEnabled(boolean enabled) throws Exception {
+        executeOp(Util.createCompositeOperation(
+                        List.of(
+                                // /core-service=management/access=authorization:write-attribute(name=provider,value=rbac|simple)
+                                Util.getWriteAttributeOperation(RbacRealmSetupTask.authorization, PROVIDER, enabled ? "rbac" : "simple"),
+                                // /subsystem=metrics:write-attribute(name=security-enabled,value=...)
+                                Util.getWriteAttributeOperation(PathAddress.pathAddress(SUBSYSTEM, "metrics"), "security-enabled", enabled)
+                        )),
+                managementClient.getControllerClient());
+
+        ServerReload.reloadIfRequired(managementClient);
+    }
+
+}

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/BaseMicrometerTest.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/BaseMicrometerTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.test.integration.observability.micrometer;
+
+import static org.wildfly.test.integration.observability.setuptask.PrometheusSetupTask.PROMETHEUS_CONTEXT;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.List;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.config.AuthSchemes;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.arquillian.testcontainers.api.Testcontainer;
+import org.arquillian.testcontainers.api.TestcontainersRequired;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.test.shared.observability.containers.OpenTelemetryCollectorContainer;
+import org.jboss.as.test.shared.observability.signals.PrometheusMetric;
+import org.jboss.dmr.ModelNode;
+import org.junit.runner.RunWith;
+
+/**
+ * Common scaffolding for the client-side Micrometer tests: a deployment URL, a management client, the OpenTelemetry
+ * collector container, and the helpers used to drive traffic and scrape the Prometheus endpoint. Subclasses supply their
+ * own {@code @ServerSetup} since the required setup tasks differ per test.
+ */
+@RunWith(Arquillian.class)
+@TestcontainersRequired
+@RunAsClient
+public abstract class BaseMicrometerTest {
+    protected static final int REQUEST_COUNT = 5;
+
+    @ArquillianResource
+    protected URL url;
+
+    @ContainerResource
+    protected ManagementClient managementClient;
+
+    @Testcontainer
+    protected OpenTelemetryCollectorContainer otelCollector;
+
+    protected void executeOperation(final ModelNode op) throws IOException {
+        final ModelNode result = managementClient.getControllerClient().execute(Operation.Factory.create(op));
+        if (!Operations.isSuccessfulOutcome(result)) {
+            throw new RuntimeException("Failed to execute operation: " + Operations.getFailureDescription(result)
+                    .asString());
+        }
+    }
+
+    protected void makeRequests() throws URISyntaxException {
+        try (Client client = ClientBuilder.newClient()) {
+            WebTarget target = client.target(url.toURI());
+            for (int i = 0; i < REQUEST_COUNT; i++) {
+                target.request().get();
+            }
+        }
+    }
+
+    protected List<PrometheusMetric> fetchPrometheusMetrics(boolean authenticate) throws IOException {
+        return authenticate
+                ? fetchPrometheusMetrics("testSuite", "testSuitePassword")
+                : fetchPrometheusMetrics(null, null);
+    }
+
+    /**
+     * Scrapes the management Prometheus endpoint. When {@code username} is non-null the request is authenticated with the
+     * supplied credentials; otherwise it is sent unauthenticated.
+     */
+    protected List<PrometheusMetric> fetchPrometheusMetrics(String username, String password) throws IOException {
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            CloseableHttpResponse resp = scrapeManagement(client, PROMETHEUS_CONTEXT, username, password);
+            return PrometheusMetric.buildPrometheusMetrics(EntityUtils.toString(resp.getEntity()));
+        }
+    }
+
+    /**
+     * Scrapes the management Prometheus endpoint and returns only the HTTP status code. Used by negative tests that
+     * assert an unauthenticated scrape is rejected before any metric body is produced.
+     */
+    protected int fetchPrometheusStatus(String username, String password) throws IOException {
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            return scrapeManagement(client, PROMETHEUS_CONTEXT, username, password).getStatusLine().getStatusCode();
+        }
+    }
+
+    /**
+     * Issues a GET against {@code http://<mgmt-host>:<mgmt-port><context>}. When {@code username} is non-null the request
+     * carries the given credentials and is forced to the DIGEST scheme - the one the management HTTP interface challenges
+     * with - rather than falling back to (and leaking) Basic.
+     */
+    private CloseableHttpResponse scrapeManagement(CloseableHttpClient client, String context, String username,
+                                                   String password) throws IOException {
+        HttpClientContext hcContext = HttpClientContext.create();
+        HttpGet get = new HttpGet(String.format("http://%s:%d/%s", managementClient.getMgmtAddress(),
+                managementClient.getMgmtPort(), context));
+
+        if (username != null) {
+            CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(username, password));
+            hcContext.setCredentialsProvider(credentialsProvider);
+            get.setConfig(RequestConfig.custom()
+                    .setTargetPreferredAuthSchemes(List.of(AuthSchemes.DIGEST))
+                    .build());
+        }
+
+        return client.execute(get, hcContext);
+    }
+}

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/MicrometerPrometheusTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/MicrometerPrometheusTestCase.java
@@ -4,68 +4,27 @@
  */
 package org.wildfly.test.integration.observability.micrometer;
 
-import static org.wildfly.test.integration.observability.setuptask.PrometheusSetupTask.PROMETHEUS_CONTEXT;
 import static org.wildfly.test.integration.observability.setuptask.PrometheusSetupTask.PROMETHEUS_REGISTRY_ADDRESS;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.List;
 
-import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
-import jakarta.ws.rs.client.WebTarget;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.CredentialsProvider;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.util.EntityUtils;
-import org.arquillian.testcontainers.api.Testcontainer;
-import org.arquillian.testcontainers.api.TestcontainersRequired;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.container.ManagementClient;
-import org.jboss.as.controller.client.Operation;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.test.shared.CdiUtils;
 import org.jboss.as.test.shared.ServerReload;
-import org.jboss.as.test.shared.observability.containers.OpenTelemetryCollectorContainer;
 import org.jboss.as.test.shared.observability.signals.PrometheusMetric;
-import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.wildfly.test.integration.observability.JaxRsActivator;
 import org.wildfly.test.integration.observability.setuptask.PrometheusSetupTask;
 import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
 
-@RunWith(Arquillian.class)
 @ServerSetup({StabilityServerSetupSnapshotRestoreTasks.Community.class, PrometheusSetupTask.class})
-@TestcontainersRequired
-@RunAsClient
-public class MicrometerPrometheusTestCase {
-    private static final int REQUEST_COUNT = 5;
-
-    @ArquillianResource
-    private URL url;
-
-    @ContainerResource
-    protected ManagementClient managementClient;
-
-    @Testcontainer
-    protected OpenTelemetryCollectorContainer otelCollector;
+public class MicrometerPrometheusTestCase extends BaseMicrometerTest {
 
     @Deployment
     public static Archive<?> deploy() {
@@ -93,57 +52,23 @@ public class MicrometerPrometheusTestCase {
         setPrometheusSecurity(true);
         makeRequests();
 
-        String metrics = fetchPrometheusMetrics(false);
-        Assert.assertTrue("'401 - Unauthorized' message is expected", metrics.contains("401 - Unauthorized"));
+        List<PrometheusMetric> metrics = fetchPrometheusMetrics(false);
+        Assert.assertTrue("Metrics should not be exposed without authentication",
+                metrics.stream().noneMatch(m -> m.getKey().equals("demo_counter_total")));
 
         metrics = fetchPrometheusMetrics(true);
-        Assert.assertTrue("'demo_counter_total' is expected", metrics.contains("demo_counter_total"));
+        Assert.assertTrue("'demo_counter_total' is expected",
+                metrics.stream().anyMatch(m -> m.getKey().equals("demo_counter_total")));
 
         setPrometheusSecurity(false);
         makeRequests();
         metrics = fetchPrometheusMetrics(false);
-        Assert.assertTrue("'demo_counter_total' is expected", metrics.contains("demo_counter_total"));
+        Assert.assertTrue("'demo_counter_total' is expected",
+                metrics.stream().anyMatch(m -> m.getKey().equals("demo_counter_total")));
     }
 
     private void setPrometheusSecurity(boolean enabled) throws Exception {
-        executeOp(managementClient,
-                Operations.createWriteAttributeOperation(PROMETHEUS_REGISTRY_ADDRESS, "security-enabled",
-                        enabled));
+        executeOperation(Operations.createWriteAttributeOperation(PROMETHEUS_REGISTRY_ADDRESS, "security-enabled", enabled));
         ServerReload.reloadIfRequired(managementClient);
-    }
-
-    private void executeOp(final ManagementClient client, final ModelNode op) throws IOException {
-        final ModelNode result = client.getControllerClient().execute(Operation.Factory.create(op));
-        if (!Operations.isSuccessfulOutcome(result)) {
-            throw new RuntimeException("Failed to execute operation: " + Operations.getFailureDescription(result)
-                .asString());
-        }
-    }
-
-    private void makeRequests() throws URISyntaxException {
-        try (Client client = ClientBuilder.newClient()) {
-            WebTarget target = client.target(url.toURI());
-            for (int i = 0; i < REQUEST_COUNT; i++) {
-                target.request().get();
-            }
-        }
-    }
-
-    private String fetchPrometheusMetrics(boolean authenticate) throws IOException {
-        try (CloseableHttpClient client = HttpClients.createDefault()) {
-            HttpClientContext hcContext = HttpClientContext.create();
-
-            if (authenticate) {
-                CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-                credentialsProvider.setCredentials(AuthScope.ANY,
-                        new UsernamePasswordCredentials("testSuite", "testSuitePassword"));
-                hcContext.setCredentialsProvider(credentialsProvider);
-            }
-
-            CloseableHttpResponse resp = client.execute(
-                    new HttpGet("http://" + managementClient.getMgmtAddress() + ":" +
-                            managementClient.getMgmtPort() + PROMETHEUS_CONTEXT), hcContext);
-            return EntityUtils.toString(resp.getEntity());
-        }
     }
 }

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/rbac/MicrometerRbacTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/rbac/MicrometerRbacTestCase.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.test.integration.observability.micrometer.rbac;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROVIDER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import java.util.List;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.shared.CdiUtils;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.test.shared.observability.setuptasks.RbacRealmSetupTask;
+import org.jboss.as.test.shared.observability.signals.PrometheusMetric;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.test.integration.observability.JaxRsActivator;
+import org.wildfly.test.integration.observability.micrometer.BaseMicrometerTest;
+import org.wildfly.test.integration.observability.micrometer.MicrometerResource;
+import org.wildfly.test.integration.observability.setuptask.PrometheusSetupTask;
+import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
+
+@ServerSetup({
+        StabilityServerSetupSnapshotRestoreTasks.Community.class,
+        PrometheusSetupTask.class,
+        RbacRealmSetupTask.class
+})
+public class MicrometerRbacTestCase extends BaseMicrometerTest {
+    private static final String UNDERTOW_MODEL_METRIC = "undertow_bytes_sent";
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(WebArchive.class, "micrometer-rbac.war")
+                .addClasses(JaxRsActivator.class, MicrometerResource.class)
+                .addAsWebInfResource(CdiUtils.createBeansXml(), "beans.xml");
+    }
+
+    @Test
+    public void testPullMicrometerWithAuthentication() throws Exception {
+        verifyPullMetrics(true);
+    }
+
+    @Test
+    public void testPullMicrometerWithoutAuthentication() throws Exception {
+        verifyPullMetrics(false);
+    }
+
+    /**
+     * Negative test: with RBAC and endpoint security enabled, an unauthenticated scrape of the Prometheus pull
+     * endpoint must be rejected outright rather than served zeroed-out (anonymous) metrics.
+     */
+    @Test
+    public void testPullMicrometerUnauthenticatedRejected() throws Exception {
+        setAuthenticationEnabled(true);
+
+        Assert.assertEquals("Unauthenticated scrape of the secured Prometheus endpoint should be rejected",
+                401, fetchPrometheusStatus(null, null));
+    }
+
+    /**
+     * Negative test: an authenticated management user without at least the Monitor role must not see the
+     * RBAC-protected model metrics. The scrape authenticates, but the Undertow model metric is read under the
+     * caller's identity and, lacking read access, comes back absent or zeroed rather than carrying a real value.
+     */
+    @Test
+    public void testPullMicrometerWithoutMonitorRole() throws Exception {
+        setAuthenticationEnabled(true);
+        makeRequests();
+
+        List<PrometheusMetric> metrics =
+                fetchPrometheusMetrics(RbacRealmSetupTask.USER_NOROLE, RbacRealmSetupTask.TEST_RBAC_PASSWORD);
+
+        double value = metrics.stream()
+                .filter(metric -> metric.getKey().startsWith(UNDERTOW_MODEL_METRIC))
+                .findFirst()
+                .map(metric -> Double.parseDouble(metric.getValue()))
+                .orElse(0.0);
+
+        Assert.assertEquals("The Undertow model metric '" + UNDERTOW_MODEL_METRIC +
+                "' must not be visible to a user without the Monitor role, but was " + value, 0.0, value, 0.0);
+    }
+
+    /**
+     * Verifies the push path: metrics exported over OTLP to the OpenTelemetry Collector carry real model values under
+     * RBAC. This exercises the background push scheduler, which - unlike a scrape - has no caller identity to filter by,
+     * so {@code WildFlyOtlpRegistry.publish()} reads the model as an in-VM (SuperUser) call. Without that the model
+     * metrics would be read as the anonymous identity and zeroed out under RBAC.
+     */
+    @Test
+    public void testPushMicrometer() throws Exception {
+        setAuthenticationEnabled(true);
+
+        // The collector's exported series is cumulative and retains the last value it received for several minutes.
+        // Asserting merely value>0 would therefore pass on model metrics pushed before RBAC was enabled - i.e. even
+        // if publish() now read the model as the anonymous identity and stopped pushing real values. Baseline the
+        // metric with RBAC already on, drive fresh traffic, then require a strict increase: that can only happen if a
+        // post-RBAC in-VM (SuperUser) push actually lands a real model value.
+        final double baseline = currentPushedUndertowValue();
+
+        makeRequests();
+
+        otelCollector.assertMetrics(metrics -> {
+            PrometheusMetric undertowMetric = metrics.stream()
+                    .filter(metric -> metric.getKey().startsWith(UNDERTOW_MODEL_METRIC))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("The Undertow model metric '" + UNDERTOW_MODEL_METRIC +
+                            "' was not pushed to the collector under RBAC"));
+            double value = Double.parseDouble(undertowMetric.getValue());
+            Assert.assertTrue("The Undertow model metric '" + UNDERTOW_MODEL_METRIC + "' must increase after RBAC is " +
+                    "enabled (baseline " + baseline + "), but the collector still shows " + value, value > baseline);
+        });
+    }
+
+    /**
+     * Current value the collector holds for the Undertow model metric, or {@code 0.0} if it has not been pushed yet.
+     * Used to baseline {@link #testPushMicrometer()} against stale, pre-RBAC values retained by the collector.
+     */
+    private double currentPushedUndertowValue() {
+        return otelCollector.fetchMetrics().stream()
+                .filter(metric -> metric.getKey().startsWith(UNDERTOW_MODEL_METRIC))
+                .findFirst()
+                .map(metric -> Double.parseDouble(metric.getValue()))
+                .orElse(0.0);
+    }
+
+    private void verifyPullMetrics(boolean authenticationEnabled) throws Exception {
+        setAuthenticationEnabled(authenticationEnabled);
+        makeRequests();
+
+        assertMetric(authenticationEnabled,
+                authenticationEnabled
+                        ? fetchPrometheusMetrics(RbacRealmSetupTask.USER_MONITOR, RbacRealmSetupTask.TEST_RBAC_PASSWORD)
+                        : fetchPrometheusMetrics(null, null));
+    }
+
+    private void assertMetric(boolean authenticationEnabled, List<PrometheusMetric> metrics) {
+        PrometheusMetric undertowMetric = metrics.stream().filter(metric ->
+                        metric.getKey().startsWith(UNDERTOW_MODEL_METRIC)).findFirst()
+                .orElseThrow(() -> new AssertionError("Undertow model metric not found"));
+
+        double value = Double.parseDouble(undertowMetric.getValue());
+
+        Assert.assertTrue("The Undertow model metric '" + UNDERTOW_MODEL_METRIC +
+                "' should be non-zero (authentication " + (authenticationEnabled ? "enabled" : "disabled") +
+                "), but was " + value, value > 0);
+    }
+
+    /**
+     * Enables or disables RBAC and, in lockstep, the security of the Micrometer Prometheus endpoints, then reloads.
+     * With authentication enabled, scrapes must present a management-realm identity with at least Monitor access.
+     * With it disabled, the endpoints are open.
+     */
+    private void setAuthenticationEnabled(boolean enabled) throws Exception {
+        executeOperation(Util.createCompositeOperation(
+            List.of(
+                // /core-service=management/access=authorization:write-attribute(name=provider,value=rbac|simple)
+                Util.getWriteAttributeOperation(RbacRealmSetupTask.authorization, PROVIDER, enabled ? "rbac" : "simple"),
+                // /subsystem=micrometer/registry=prometheus:write-attribute(name=security-enabled,value=...)
+                Util.getWriteAttributeOperation(PathAddress.pathAddress(SUBSYSTEM, "micrometer")
+                        .append("registry", "prometheus"), "security-enabled", enabled)
+            )));
+        ServerReload.reloadIfRequired(managementClient);
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/OpenTelemetryCollectorContainer.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/OpenTelemetryCollectorContainer.java
@@ -8,15 +8,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
@@ -244,7 +238,7 @@ public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetry
     public List<PrometheusMetric> fetchMetrics() {
         try (Client client = ClientBuilder.newClient()) {
             WebTarget target = client.target(getPrometheusUrl());
-            return buildPrometheusMetrics(target.request().get().readEntity(String.class));
+            return PrometheusMetric.buildPrometheusMetrics(target.request().get().readEntity(String.class));
         }
     }
 
@@ -260,40 +254,4 @@ public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetry
         });
     }
 
-    private List<PrometheusMetric> buildPrometheusMetrics(String body) {
-        if (body.isEmpty()) {
-            return Collections.emptyList();
-        }
-        String[] entries = body.split("\n");
-        Map<String, String> help = new HashMap<>();
-        Map<String, String> type = new HashMap<>();
-        List<PrometheusMetric> metrics = new LinkedList<>();
-        Arrays.stream(entries).forEach(e -> {
-            if (e.startsWith("# HELP")) {
-                extractMetadata(help, e);
-            } else if (e.startsWith("# TYPE")) {
-                extractMetadata(type, e);
-            } else {
-                String[] parts = e.split("[{}]");
-                String key = parts[0];
-                Map<String, String> tags = Arrays.stream(parts[1].split(","))
-                        .map(t -> t.split("="))
-                        .collect(Collectors.toMap(i -> i[0],
-                                i -> i[1]
-                                        .replaceAll("^\"", "")
-                                        .replaceAll("\"$", "")
-                        ));
-                metrics.add(new PrometheusMetric(key, tags, parts[2].trim(), type.get(key), help.get(key)));
-            }
-        });
-
-        return metrics;
-    }
-
-    private void extractMetadata(Map<String, String> target, String source) {
-        String[] parts = source.split(" ");
-        target.put(parts[2],
-                Arrays.stream(Arrays.copyOfRange(parts, 3, parts.length))
-                        .reduce("", (total, element) -> total + " " + element));
-    }
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/setuptasks/RbacRealmSetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/setuptasks/RbacRealmSetupTask.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.shared.observability.setuptasks;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACCESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.AUTHORIZATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STATISTICS_ENABLED;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Maps the {@link #USER_MONITOR} management user to the Monitor role and enables Undertow
+ * statistics, then restores both to their pre-test state on tear-down. Each change is
+ * applied only when the current state differs from the target, and is reverted only if
+ * this task actually made it - so it does not clobber a value another setup task already
+ * owns. The {@code Monitor}/{@code norole} management users themselves are provisioned
+ * into the server by the build (shared {@code mgmt-users.properties}). Enabling RBAC and
+ * securing the endpoints is done per-test.
+ */
+public class RbacRealmSetupTask extends AbstractSetupTask {
+    public static final PathAddress authorization =
+            PathAddress.pathAddress(CORE_SERVICE, MANAGEMENT)
+                       .append(ACCESS, AUTHORIZATION);
+    // RBAC user mapped to the Monitor role, used to authenticate scrapes of the secured management endpoints.
+    public static final String USER_MONITOR = "Monitor";
+    // RBAC user in the management-realm that does not have any roles assigned.
+    public static final String USER_NOROLE = "norole";
+    public static final String TEST_RBAC_PASSWORD = "testSuitePassword";
+
+    private static final PathAddress MONITOR_ROLE_MAPPING =
+            authorization.append("role-mapping", USER_MONITOR);
+    private static final PathAddress UNDERTOW =
+            PathAddress.pathAddress("subsystem", "undertow");
+
+    private boolean roleMappingAdded;
+    private boolean statisticsEnabledChanged;
+
+    @Override
+    public void setup(ManagementClient managementClient,
+                      String containerId) throws Exception {
+        // Map the Monitor user to the Monitor role, but only if the mapping is not already present.
+        if (!Operations.isSuccessfulOutcome(
+                executeRead(managementClient, MONITOR_ROLE_MAPPING.toModelNode()))) {
+            List<ModelNode> operations = new ArrayList<>();
+            operations.add(Util.createAddOperation(MONITOR_ROLE_MAPPING));
+            ModelNode addInclude = Util.createAddOperation(
+                    MONITOR_ROLE_MAPPING.append("include", USER_MONITOR));
+            addInclude.get("name").set(USER_MONITOR);
+            addInclude.get("type").set("USER");
+            operations.add(addInclude);
+            executeOp(managementClient, Util.createCompositeOperation(operations));
+            roleMappingAdded = true;
+        }
+
+        // Enable Undertow statistics, but only if they are not already enabled. The default undertow config carries
+        // statistics-enabled as ${wildfly.undertow.statistics-enabled:false}, so it must be read with expressions
+        // resolved - asBoolean() throws on an unresolved expression node.
+        if (!isUndertowStatisticsEnabled(managementClient)) {
+            executeOp(managementClient,
+                      writeAttribute("undertow", STATISTICS_ENABLED, "true"));
+            statisticsEnabledChanged = true;
+        }
+
+        ServerReload.reloadIfRequired(managementClient);
+    }
+
+    @Override
+    public void tearDown(ManagementClient managementClient,
+                         String containerId) throws Exception {
+        if (statisticsEnabledChanged) {
+            executeOp(managementClient, clearAttribute("undertow", STATISTICS_ENABLED));
+        }
+        if (roleMappingAdded) {
+            List<ModelNode> operations = new ArrayList<>();
+            operations.add(Util.createRemoveOperation(
+                    MONITOR_ROLE_MAPPING.append("include", USER_MONITOR)));
+            operations.add(Util.createRemoveOperation(MONITOR_ROLE_MAPPING));
+            executeOp(managementClient, Util.createCompositeOperation(operations));
+        }
+
+        ServerReload.reloadIfRequired(managementClient);
+    }
+
+    private boolean isUndertowStatisticsEnabled(ManagementClient managementClient) throws IOException {
+        ModelNode op = Operations.createReadAttributeOperation(UNDERTOW.toModelNode(), STATISTICS_ENABLED);
+        op.get("resolve-expressions").set(true);
+        ModelNode result = managementClient.getControllerClient().execute(op);
+        if (!Operations.isSuccessfulOutcome(result)) {
+            throw new RuntimeException("Failed to read undertow " + STATISTICS_ENABLED + ": "
+                    + Operations.getFailureDescription(result).asString());
+        }
+        return result.get("result").asBoolean(false);
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/PrometheusMetric.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/PrometheusMetric.java
@@ -4,8 +4,13 @@
  */
 package org.jboss.as.test.shared.observability.signals;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class PrometheusMetric {
     private final String key;
@@ -55,5 +60,70 @@ public class PrometheusMetric {
                 ", type='" + type + '\'' +
                 ", help='" + help + '\'' +
                 '}';
+    }
+
+    /**
+     * Parses the text exposition returned from a Prometheus endpoint into a list of {@link PrometheusMetric} instances.
+     * {@code # HELP} and {@code # TYPE} lines are consumed as metadata, and other comment or blank lines are ignored.
+     * Lines that are not well-formed samples (for example an authentication error page returned in place of metrics)
+     * are skipped rather than causing a failure.
+     *
+     * @param body the raw response body from a Prometheus endpoint
+     * @return the parsed metrics, or an empty list if {@code body} is null or empty
+     */
+    public static List<PrometheusMetric> buildPrometheusMetrics(String body) {
+        List<PrometheusMetric> metrics = new LinkedList<>();
+        if (body == null || body.isEmpty()) {
+            return metrics;
+        }
+
+        Map<String, String> help = new HashMap<>();
+        Map<String, String> type = new HashMap<>();
+        for (String e : body.split("\\R")) {
+            if (e.startsWith("# HELP")) {
+                extractMetadata(help, e);
+            } else if (e.startsWith("# TYPE")) {
+                extractMetadata(type, e);
+            } else if (e.isBlank() || e.startsWith("#")) {
+                // Other comment or blank line - nothing to collect.
+            } else {
+                String[] parts = e.split("[{}]");
+                String key;
+                String value;
+                Map<String, String> tags;
+                if (parts.length >= 3) {
+                    // key{tag="value",...} value
+                    key = parts[0];
+                    tags = Arrays.stream(parts[1].split(","))
+                            .map(t -> t.split("="))
+                            .collect(Collectors.toMap(i -> i[0],
+                                    i -> i[1]
+                                            .replaceAll("^\"", "")
+                                            .replaceAll("\"$", "")
+                            ));
+                    value = parts[2].trim();
+                } else {
+                    // key value (metric without tags)
+                    int idx = e.lastIndexOf(' ');
+                    if (idx < 0) {
+                        // Not a sample line (e.g. an error page returned in place of metrics).
+                        continue;
+                    }
+                    key = e.substring(0, idx).trim();
+                    value = e.substring(idx + 1).trim();
+                    tags = Collections.emptyMap();
+                }
+                metrics.add(new PrometheusMetric(key, tags, value, type.get(key), help.get(key)));
+            }
+        }
+
+        return metrics;
+    }
+
+    private static void extractMetadata(Map<String, String> target, String source) {
+        String[] parts = source.split(" ");
+        target.put(parts[2],
+                Arrays.stream(Arrays.copyOfRange(parts, 3, parts.length))
+                        .reduce("", (total, element) -> total + " " + element));
     }
 }

--- a/testsuite/shared/src/main/resources/mgmt-users.properties
+++ b/testsuite/shared/src/main/resources/mgmt-users.properties
@@ -5,3 +5,5 @@
 
 #testSuite=testSuitePassword
 testSuite=29a64f8524f32269aa9b681efc347f96
+Monitor=b1b8f4d6896b644ad56aa0f870368c8e
+norole=a3506bb9c2b8bfb2fc393fbd98ab0365


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-20566

- Add an integration test to verify issue.
- Verify that pull-based prometheus requests succeed with and without auth
- Modify WildFlyOtlpRegistry to allow for elevated perms when pushing
- Add parallel test for WildFly Metrics to verify functionality
- Create a shared ServerSetupTask to set up the management realm