### PR TITLE
[WFLY-22194] Upgrade the JSoup test dep to 1.23.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -358,7 +358,7 @@
         <version.io.rest-assured>5.5.7</version.io.rest-assured>
         <version.jakarta.mvc>2.1.0</version.jakarta.mvc>
         <version.jaxen>1.1.6</version.jaxen>
-        <version.jsoup>1.15.4</version.jsoup>
+        <version.jsoup>1.23.2</version.jsoup>
         <version.junit>4.13.2</version.junit>
         <version.org.apache.ds>2.0.0.AM26</version.org.apache.ds>
         <version.org.apache.groovy>4.0.33</version.org.apache.groovy>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-22194

Test only upgrade for a few tests. The lib has a CVE so this is to clear CVE report noise.

I'll ask for a review from Darran and Jason because the tests relate to JSF and elytron-oidc-client, but the use of this lib is very simple so if it passes CI I think an approval from anyone is enough to merge. (The tests pass locally so I'm sure it's fine.)