### PR TITLE
WFLY-22198 Fix mod_cluster startup race where STOP-APP can be sent be…

### DIFF
--- a/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowEventHandlerAdapterService.java
+++ b/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowEventHandlerAdapterService.java
@@ -72,12 +72,13 @@ public class UndertowEventHandlerAdapterService implements UndertowEventListener
         this.serverName = this.configuration.getServer().getName();
         this.server = new UndertowServer(this.serverName, service, this.connector);
 
-        // Register ourselves as a listener to the container events
-        service.registerListener(this);
-
         // Initialize mod_cluster and start it now
         eventHandler.init(this.server);
         eventHandler.start(this.server);
+
+        // Register listener after init/start so that deployment events cannot fire before CONFIG has been sent to the proxy (WFLY-22198)
+        service.registerListener(this);
+
         for (Engine engine : this.server.getEngines()) {
             for (org.jboss.modcluster.container.Host host : engine.getHosts()) {
                 host.getContexts().forEach(contexts::add);


### PR DESCRIPTION
…fore CONFIG

During startup of UndertowEventHandlerAdapterService, the Undertow event listener was registered before eventHandler.init()/start() sent CONFIG to the proxy. A paralell deployment event could thus trigger STOP-APP before the proxy knew about the node, causing:

`MODCLUSTER000042: Error MEM sending STOP-APP command ... Can't read node`

Fix by moving service.registerListener() after init()/start() so that no deployment events can fire before CONFIG has been sent.

Adding a test for this race condition is impractical as it would require Byteman to trigger the specific thread actions ordering.

Resolves
https://redhat.atlassian.net/browse/WFLY-22198