### PR TITLE
WFLY-22198 Fix mod_cluster startup race where STOP-APP can be sent before CONFIG - workaround for MODCLUSTER-876

### DIFF
--- a/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowEventHandlerAdapterService.java
+++ b/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowEventHandlerAdapterService.java
@@ -76,6 +76,9 @@ public class UndertowEventHandlerAdapterService implements UndertowEventListener
         eventHandler.init(this.server);
         eventHandler.start(this.server);
 
+        // Workaround for MODCLUSTER-876: establish the proxy connection and send CONFIG synchronously by calling ContainerEventHandler#status
+        this.run();
+
         // Register listener after init/start so that deployment events cannot fire before CONFIG has been sent to the proxy (WFLY-22198)
         service.registerListener(this);
 
@@ -86,7 +89,9 @@ public class UndertowEventHandlerAdapterService implements UndertowEventListener
         }
 
         // Start the periodic STATUS thread
-        this.executor.scheduleWithFixedDelay(this, 0, this.configuration.getStatusInterval().toMillis(), TimeUnit.MILLISECONDS);
+        // Workaround for MODCLUSTER-876: set initialDelay since we already called ContainerEventHandler#status above
+        long statusInterval = this.configuration.getStatusInterval().toMillis();
+        this.executor.scheduleWithFixedDelay(this, statusInterval, statusInterval, TimeUnit.MILLISECONDS);
     }
 
     @Override


### PR DESCRIPTION
Fix by calling run() synchronously before registering the Undertow event listener, establishing the proxy connection and sending CONFIG inline. The scheduled STATUS thread initial delay is staggered accordingly. This is a workaround for MODCLUSTER-876 where ContainerEventHandler.start(Server) does not send CONFIG when the proxy connection is not yet established.

Fixup https://redhat.atlassian.net/browse/WFLY-22198