### PR TITLE
Fix for WFLY-22205, Upgrade Galleon Plugins to 8.2.0.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,7 @@
         <version.org.wildfly.bom-builder-plugin>2.0.11.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.galleon-plugins>8.2.0.Beta1</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>8.2.0.Beta2</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.glow>2.1.0.Final</version.org.wildfly.glow>
         <version.org.wildfly.licenses.plugin>2.4.6.Final</version.org.wildfly.licenses.plugin>
         <version.org.wildfly.plugin>6.0.1.Final</version.org.wildfly.plugin>


### PR DESCRIPTION
ISSUE: https://redhat.atlassian.net/browse/WFLY-22205

SBOM files are generated and added to all WildFly provisioned server installation that occurs at build time.