### PR TITLE
[WFLY-20876] Remove low-value and fix misleading {wildflyVersion} references in docs

### DIFF
--- a/docs/src/main/asciidoc/Different_Flavors_of_WildFly.adoc
+++ b/docs/src/main/asciidoc/Different_Flavors_of_WildFly.adoc
@@ -82,7 +82,7 @@ For standard WildFly we also provide BOMs for developing applications that act a
 
 Standard WildFly 40 and later *do not support running with the Java SecurityManager enabled*. If you attempt to start a standard WildFly {wildflyVersion} process with the SecurityManager enabled, the process will fail to start, even if you are using a Java SE version that still supports the SecurityManager.
 
-Standard WildFly {wildflyVersion} supports the EE 11 versions of the Jakarta specifications, and the specifications that were updated for EE 11 removed any requirement to support the SecurityManager. The specification API artifacts that WildFly integrates removed the logic that allowed them to work properly with a SecurityManager enabled, and a number of libraries we integrate that implement those APIs removed their SecurityManager logic as well. As a result, standard WildFly can no longer function properly with a SecurityManager enabled, so we ensured that it will fail to start if it is.
+Standard WildFly supports the EE 11 versions of the Jakarta specifications, and the specifications that were updated for EE 11 removed any requirement to support the SecurityManager. The specification API artifacts that WildFly integrates removed the logic that allowed them to work properly with a SecurityManager enabled, and a number of libraries we integrate that implement those APIs removed their SecurityManager logic as well. As a result, standard WildFly can no longer function properly with a SecurityManager enabled, so we ensured that it will fail to start if it is.
 
 [[standard-wildfly-security-manager-subsystem]]
 ==== The `security-manager` subsystem
@@ -171,7 +171,7 @@ If you are using Jakarta Data with WildFly EE 10, be sure to use a version 6.6 r
 
 ==== Security Manager
 
-A WildFly EE 10 {wildflyVersion} process can still run with the Java SecurityManager enabled, xref:#security-manager-removed[unlike a standard WildFly {wildflyVersion} process].
+A WildFly EE 10 process can still run with the Java SecurityManager enabled, xref:#security-manager-removed[unlike a standard WildFly process].
 
 Accordingly, the out-of-the-box configuration files in an unslimmed WildFly EE 10 installation still include the `security-manager` subsystem.
 
@@ -235,7 +235,7 @@ Formally certifying WildFly Preview as a compatible implementation of EE is not 
 for the WildFly project and may not happen at the time of a release, or ever.
 ====
 
-==== EE Support in WildFly Preview {wildflyVersion}
+==== EE Support in WildFly Preview
 
 WildFly Preview 40 provides support for xref:Getting_Started_Guide{outfilesuffix}#standards_support[the same specification versions as standard WildFly 40].
 

--- a/docs/src/main/asciidoc/Getting_Started_Guide.adoc
+++ b/docs/src/main/asciidoc/Getting_Started_Guide.adoc
@@ -27,7 +27,7 @@ ifdef::basebackend-html[toc::[]]
 == Getting Started with WildFly {wildflyVersion}
 
 This document provides a quick overview on how to download and get
-started using WildFly {wildflyVersion}.
+started using WildFly.
 For in-depth
 content on administrative features, refer to the link:Admin_Guide{outfilesuffix}[Admin Guide].
 The link:Application_Development_Guide{outfilesuffix}[Application Development Guide] shows you how to build WildFly
@@ -49,7 +49,7 @@ The table below lists the versions of the Jakarta technologies available in Wild
 
 [cols=",,,,",options="header"]
 |=======================================================================
-|Jakarta Specification |Version in Standard WildFly |Version in WildFly EE 10 |WildFly {wildflyVersion} Full Configuration |WildFly {wildflyVersion} Default Configuration
+|Jakarta Specification |Version in Standard WildFly |Version in WildFly EE 10 |WildFly Full Configuration |WildFly Default Configuration
 
 |Jakarta Activation |2.1 |2.1 |X |X
 
@@ -139,11 +139,11 @@ want to use messaging, make sure you
 link:#starting-wildfly-with-an-alternate-configuration[start the server using an alternate configuration]
 that provides the EE Full Platform.
 
-WildFly {wildflyVersion} also provides support for MicroProfile technologies. The same versions of these are provided in both the standard WildFly and WildFly EE 10 variants.
+WildFly also provides support for MicroProfile technologies. The same versions of these are provided in both the standard WildFly and WildFly EE 10 variants.
 
 [cols=",,",options="header"]
 |=======================================================================
-|MicroProfile Technology |WildFly {wildflyVersion} Default Configuration |WildFly {wildflyVersion} MicroProfile Configuration
+|MicroProfile Technology |WildFly Default Configuration |WildFly MicroProfile Configuration
 |MicroProfile Config 3.1 |X |X
 |MicroProfile Fault Tolerance 4.1 |-- |X
 |MicroProfile Health 4.0 |-- |X
@@ -175,21 +175,21 @@ we'll focus on the common approach of installing the download zip of standard Wi
 [[download]]
 === Download
 
-WildFly {wildflyVersion} distributions can be obtained from https://www.wildfly.org/downloads/[wildfly.org/downloads].
+WildFly distributions can be obtained from https://www.wildfly.org/downloads/[wildfly.org/downloads].
 
-Standard WildFly {wildflyVersion} provides a single distribution available in zip or tar file
+Standard WildFly provides a single distribution available in zip or tar file
 formats.
 
 * *wildfly-{wildflyVersion}.0.0.Final.zip*
 * *wildfly-{wildflyVersion}.0.0.Final.tar.gz*
 
-WildFly EE 10 {wildflyVersion} also provides a single distribution available in zip or tar file
+WildFly EE 10 also provides a single distribution available in zip or tar file
 formats.
 
 * *wildfly-ee-10-{wildflyVersion}.0.0.Final.zip*
 * *wildfly-ee-10-{wildflyVersion}.0.0.Final.tar.gz*
 
-WildFly Preview {wildflyVersion} also provides a single distribution available in zip or tar file
+WildFly Preview also provides a single distribution available in zip or tar file
 formats.
 
 * *wildfly-preview-{wildflyVersion}.0.0.Final.zip*
@@ -199,14 +199,14 @@ formats.
 === Installation
 
 Simply extract your chosen download to the directory of your choice. You
-can install WildFly {wildflyVersion} on any operating system that supports the zip or
+can install WildFly on any operating system that supports the zip or
 tar formats. Refer to the Release Notes for additional information
 related to the release.
 
 [[installation_as_a_linux_service]]
 ==== Installation as a Linux Service
 
-Once you have installed WildFly {wildflyVersion} from a Zip archive, you can create a Linux service so it can be started/stopped automatically when your system boots up or is shut down.
+Once you have installed WildFly from a Zip archive, you can create a Linux service so it can be started/stopped automatically when your system boots up or is shut down.
 
 The following steps describe the process to configure WildFly as a systemd service. WildFly is shipped with a default systemd unit file configuration for Standalone and Domain mode. These wildfly-[standalone,domain].service files are located at the `$JBOSS_HOME/bin/systemd` directory and assume that by default WildFly was installed at `/opt/wildfly` directory and would be launched with the `wildfly:wildfly` user:group. These files can be adjusted by you to cover your needs, for example, you can change the user that runs the service, the location of the WildFly installation you want to launch, the locations of the logs, and so on.
 
@@ -252,7 +252,7 @@ If you want to remove the service, revert the above changes in an inverse order.
 [[wildfly---a-quick-tour]]
 == WildFly - A Quick Tour
 
-Now that you've downloaded WildFly {wildflyVersion}, the next thing to discuss is the
+Now that you've downloaded WildFly, the next thing to discuss is the
 layout of the distribution and explore the server directory structure,
 key configuration files, log files, user deployments and so on. It's
 worth familiarizing yourself with the layout so that you'll be able to
@@ -294,7 +294,7 @@ used by the single standalone server run from this installation.
 [[standalone-directory-structure]]
 ==== Standalone Directory Structure
 
-In " *_standalone_* " mode each WildFly {wildflyVersion} server instance is an
+In " *_standalone_* " mode each WildFly server instance is an
 independent process (similar to previous JBoss AS versions; e.g., 3, 4,
 5, or 6). The configuration files, deployment content and writable areas
 used by the single standalone server run from a WildFly installation are
@@ -334,7 +334,7 @@ process.
 [[domain-directory-structure]]
 ==== Domain Directory Structure
 
-A key feature of WildFly {wildflyVersion} is the managing multiple servers from a
+A key feature of WildFly is the managing multiple servers from a
 single control point. A collection of multiple servers are referred to
 as a " *_domain_* ". Domains can span multiple physical (or virtual)
 machines with all WildFly instances on a given host under the control of
@@ -420,9 +420,9 @@ determine how the servers are managed, not what capabilities they
 provide.
 
 [[starting-wildfly-10]]
-== Starting WildFly {wildflyVersion}
+== Starting WildFly
 
-To start WildFly {wildflyVersion} using the default web profile configuration in "
+To start WildFly using the default web profile configuration in "
 _standalone_" mode, change directory to $JBOSS_HOME/bin.
 
 [source,options="nowrap"]
@@ -504,12 +504,12 @@ discussion in the user forum and access the enhanced web-based
 Administration Console. Or, if you uncover a defect while using WildFly,
 report an issue to inform us (attached patches will be reviewed). This
 landing page is recommended for convenient access to information about
-WildFly {wildflyVersion} but can easily be replaced with your own if desired.
+WildFly but can easily be replaced with your own if desired.
 
 [[managing-your-wildfly]]
-== Managing your WildFly {wildflyVersion}
+== Managing your WildFly
 
-WildFly {wildflyVersion} offers two administrative mechanisms for managing your
+WildFly offers two administrative mechanisms for managing your
 running instance:
 
 * a web-based Administration Console
@@ -520,7 +520,7 @@ installation. Here we'll just touch on some of the basics.
 
 === Authentication
 
-By default WildFly {wildflyVersion} is distributed with security enabled for the
+By default WildFly is distributed with security enabled for the
 management interfaces. This means that before you connect using the
 administration console or remotely using the CLI you will need to add a
 new user. This can be achieved simply by using the _add-user.sh_ script

--- a/docs/src/main/asciidoc/_admin-guide/CLI_Recipes.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/CLI_Recipes.adoc
@@ -329,7 +329,7 @@ script (e.g. 'bin/jboss-admin.bat --connect command=:shutdown').
 
 To avoid "Press any key to continue ..." message you need to specify
 NOPAUSE variable. Call 'set NOPAUSE=true' in command line before running
-any WildFly {wildflyVersion} .bat script or include it in your custom script before
+any WildFly .bat script or include it in your custom script before
 invoking scripts from WildFly.
 
 [[statistics]]

--- a/docs/src/main/asciidoc/_admin-guide/Management_resources.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Management_resources.adoc
@@ -65,7 +65,7 @@ when invoked via the CLI, the text representation of a `ModelNode`; when
 invoked via the HTTP API, the JSON representation of a `ModelNode`.)
 
 Every resource except the root resource will have an `add` operation and
-should have a `remove` operation ("should" because in WildFly {wildflyVersion} many do
+should have a `remove` operation ("should" because in WildFly many do
 not). The parameters for the `add` operation vary depending on the
 resource. The `remove` operation has no parameters.
 

--- a/docs/src/main/asciidoc/_admin-guide/management-api/The_native_management_API.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-api/The_native_management_API.adoc
@@ -249,7 +249,7 @@ client.close();
 [[format-of-a-detyped-operation-request]]
 == Format of a Detyped Operation Request
 
-The basic method a user of the WildFly {wildflyVersion} programmatic management API
+The basic method a user of the WildFly programmatic management API
 would use is very simple:
 
 [source,java,options="nowrap"]
@@ -671,7 +671,7 @@ deploy /quickstart/ejb-in-war/target/wildfly-ejb-in-war.war --all-server-groups 
 [[format-of-a-detyped-operation-response]]
 == Format of a Detyped Operation Response
 
-As noted previously, the basic method a user of the WildFly {wildflyVersion}
+As noted previously, the basic method a user of the WildFly
 programmatic management API would use is very simple:
 
 [source,java,options="nowrap"]

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/DataSource.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/DataSource.adoc
@@ -17,7 +17,7 @@ you installed.
 [[jdbc-driver-installation]]
 == JDBC Driver Installation
 
-The recommended way to install a JDBC driver into WildFly {wildflyVersion} is to deploy
+The recommended way to install a JDBC driver into WildFly is to deploy
 it as a regular JAR deployment. The reason for this is that when you run
 WildFly in domain mode, deployments are automatically propagated to all
 servers to which the deployment applies; thus distribution of the driver

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging.adoc
@@ -234,7 +234,7 @@ down.
         "2014-02-14 14:16:49,189 INFO  [org.jboss.as.server] (Controller Boot Thread) JBAS018559: Deployed \"simple-servlet.war\" (runtime-name : \"simple-servlet.war\")",
         "2014-02-14 14:16:49,224 INFO  [org.jboss.as] (Controller Boot Thread) JBAS015961: Http management interface listening on http://127.0.0.1:9990/management",
         "2014-02-14 14:16:49,224 INFO  [org.jboss.as] (Controller Boot Thread) JBAS015951: Admin console listening on http://127.0.0.1:9990",
-        "2014-02-14 14:16:49,225 INFO  [org.jboss.as] (Controller Boot Thread) JBAS015874: WildFly {wildflyVersion}.0.0.Final \"WildFly\" started in 1906ms - Started 258 of 312 services (90 services are lazy, passive or on-demand)"
+        "2014-02-14 14:16:49,225 INFO  [org.jboss.as] (Controller Boot Thread) JBAS015874: WildFly {wildflyVersion}.0.0.Final started in 1906ms - Started 258 of 312 services (90 services are lazy, passive or on-demand)"
     ]
 }
 ----

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging_Backward_and_Forward_Compatibility.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging_Backward_and_Forward_Compatibility.adoc
@@ -18,7 +18,7 @@ project that supports HornetQ's CORE protocol:
 * backward compatibility: WildFly messaging clients (using Artemis) can
 connect to a legacy app server (running HornetQ)
 * forward compatibility: legacy messaging clients (using HornetQ) can connect
-to a WildFly {wildflyVersion} app server (running Artemis).
+to a WildFly app server (running Artemis).
 
 [[forward-compatibility]]
 == Forward Compatibility
@@ -58,7 +58,7 @@ providing a `legacy-entries` attribute to the `jms-queue` and
 ----
 
 The `legacy-entries` must be used by legacy clients (using HornetQ)
-while the regular `entries` are for WildFly {wildflyVersion} Jakarta Messaging clients (using
+while the regular `entries` are for WildFly Jakarta Messaging clients (using
 Artemis).
 
 The legacy client will then lookup these `legacy` messaging resources to
@@ -79,15 +79,14 @@ in the legacy `messaging` subsystem and the regular entries will be
 created with a `-new` suffix. +
 If `add-legacy-entries` is set to `false` during migration, no legacy
 resources will be created in the `messaging-activemq` subsystem and
-legacy messaging clients will not be able to communicate with WildFly {wildflyVersion}
-servers.
+legacy messaging clients will not be able to communicate with WildFly servers.
 
 [[backward-compatibility]]
 == Backward Compatibility
 
 Backward compatibility requires no configuration change in the legacy
 server. +
-WildFly {wildflyVersion} clients do not look up resources on the legacy server but
+WildFly clients do not look up resources on the legacy server but
 use client-side JNDI to create their Jakarta Messaging resources. WildFly's Artemis client
 can then use these resources to communicate with the legacy server
 using the HornetQ CORE protocol.
@@ -96,7 +95,7 @@ Artemis supports
 http://activemq.apache.org/artemis/docs/1.1.0/using-jms.html#jndi-configuration[Client-side
 JNDI] to create Jakarta Messaging resources ( `ConnectionFactory` and `Destination`).
 
-For example, if a WildFly {wildflyVersion} messaging client wants to communicate with a
+For example, if a WildFly messaging client wants to communicate with a
 legacy server using a queue named `myQueue`, it must use the
 following properties to configure its JNDI `InitialContext`:
 

--- a/docs/src/main/asciidoc/_developer-guide/Application_Client_Reference.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Application_Client_Reference.adoc
@@ -9,7 +9,7 @@ ifdef::env-github[]
 :warning-caption: :warning:
 endif::[]
 
-As a server implementing the EE Platform specification, WildFly {wildflyVersion} contains an application
+As a server implementing the EE Platform specification, WildFly contains an application
 client. An application client is essentially a cut down server instance,
 that allows you to use EE features such as injection in a client side
 program.

--- a/docs/src/main/asciidoc/_developer-guide/Implicit_module_dependencies_for_deployments.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Implicit_module_dependencies_for_deployments.adoc
@@ -10,7 +10,7 @@ ifdef::env-github[]
 endif::[]
 
 As explained in the <<Class_Loading_in_WildFly,Class Loading in WildFly>> article,
-WildFly {wildflyVersion} is based on module classloading. A class within a module B
+WildFly is based on module classloading. A class within a module B
 isn't visible to a class within a module A, unless module B adds a
 dependency on module A. Module dependencies can be explicitly (as
 explained in that classloading article) or can be "implicit". This

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_Contexts_and_Dependency_Injection_Reference.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_Contexts_and_Dependency_Injection_Reference.adoc
@@ -25,7 +25,7 @@ https://docs.wildfly.org/quickstart[The WildFly Quickstarts]
 [[using-cdi-beans-from-outside-the-deployment]]
 == Using CDI Beans from outside the deployment
 
-For WildFly {wildflyVersion} onwards, it is now possible to have classes outside the
+For WildFly 8 onwards, it is now possible to have classes outside the
 deployment be picked up as CDI beans. In order for this to work, you must
 add a dependency on the external deployment that your beans are coming
 from, and make sure the META-INF directory of this deployment is

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_Enterprise_Beans_3_Reference_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_Enterprise_Beans_3_Reference_Guide.adoc
@@ -10,7 +10,7 @@ ifdef::env-github[]
 endif::[]
 
 This chapter details the extensions that are available when developing
-Jakarta Enterprise Beans ^tm^ on WildFly {wildflyVersion}.
+Jakarta Enterprise Beans ^tm^ on WildFly.
 
 The chapter is divided into three main sections:
 

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_Persistence_Reference_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_Persistence_Reference_Guide.adoc
@@ -423,7 +423,7 @@ Dependencies: org.infinispan,org.hibernate
 http://infinispan.org/docs/9.4.x/user_guide/user_guide.html#integrations_jpa_hibernate[Infinispan
 Hibernate/JPA second level cache provider documentation] contains
 advanced configuration information but you should bear in mind that when
-Hibernate runs within WildFly {wildflyVersion}, some of those configuration options,
+Hibernate runs within WildFly, some of those configuration options,
 such as region factory, are not needed. Moreover, the application server
 providers you with option of selecting a different cache container for
 Infinispan via *hibernate.cache.infinispan.container* persistence

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_RESTful_Web_Services_Reference_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_RESTful_Web_Services_Reference_Guide.adoc
@@ -15,7 +15,7 @@ https://resteasy.dev/docs[RESTEasy {resteasyversion} documentation].
 == Jakarta RESTful Web Services Activation
 
 This section outlines the three options you have for deploying Jakarta RESTful Web Services
-applications in WildFly {wildflyVersion}. These three methods are specified in the
+applications in WildFly. These three methods are specified in the
 Jakarta RESTful Web Services 3.1 specification in section 2.3.2.
 
 [[subclassing-jakarta.ws.rs.core.application-and-using-applicationpath]]

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services_Reference_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services_Reference_Guide.adoc
@@ -16,7 +16,7 @@ The latest project documentation is available
 https://docs.jboss.org/author/display/JBWS[here].
 
 This section covers the most relevant topics for the JBossWS version
-available on WildFly {wildflyVersion}.
+available on WildFly.
 
 :leveloffset: +1
 

--- a/docs/src/main/asciidoc/_developer-guide/Migrated_to_WildFly_Example_Applications.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Migrated_to_WildFly_Example_Applications.adoc
@@ -50,7 +50,7 @@ about this migration, see <<Migrate_Order_Application_from_EAP5,Order Applicatio
 === Migrate example application
 
 A step by step work through of issues, and their solutions, that might
-crop up when migrating applications to WildFly {wildflyVersion}. See the following
+crop up when migrating applications to WildFly. See the following
 https://github.com/danbev/migrate[github project] for details.
 
 [[example-applications-based-on-ee6]]

--- a/docs/src/main/asciidoc/_developer-guide/Spring_applications_development_and_migration_guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Spring_applications_development_and_migration_guide.adoc
@@ -11,22 +11,22 @@ endif::[]
 
 This document details the main points that need to be considered by
 Spring developers that wish to develop new applications or to migrate
-existing applications to be run into WildFly {wildflyVersion}.
+existing applications to be run into WildFly.
 
 [[dependencies-and-modularity]]
 == Dependencies and Modularity
 
-WildFly {wildflyVersion} has a modular class loading strategy, different from previous
+WildFly has a modular class loading strategy, different from previous
 versions of JBoss AS, which enforces a better class loading isolation
 between deployments and the application server itself. A detailed
 description can be found in the documentation dedicated to
-<<Class_Loading_in_WildFly, class loading in WildFly {wildflyVersion}>>.
+<<Class_Loading_in_WildFly, class loading in WildFly>>.
 
 This reduces significantly the risk of running into a class loading
 conflict and allows applications to package their own dependencies if
 they choose to do so. This makes it easier for Spring applications that
 package their own dependencies - such as logging frameworks or
-persistence providers to run on WildFly {wildflyVersion}.
+persistence providers to run on WildFly.
 
 At the same time, this does not mean that duplications and conflicts
 cannot exist on the classpath. Some module dependencies are implicit,
@@ -115,7 +115,7 @@ JNDI binding via persistence.xml properties is not supported in WildFly
 [[using-spring-managed-persistence-units]]
 === Using Spring-managed persistence units
 
-Spring applications running in WildFly {wildflyVersion} may also create persistence
+Spring applications running in WildFly may also create persistence
 units on their own, using the LocalContainerEntityManagerFactoryBean.
 This is what these applications need to consider:
 

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_invocations_from_a_remote_server_instance.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_invocations_from_a_remote_server_instance.adoc
@@ -81,7 +81,7 @@ public class GreeterBean implements Greeter {
 [[security]]
 == Security
 
-WildFly {wildflyVersion} is secure by default. What this means is that no communication
+WildFly is secure by default. What this means is that no communication
 can happen with an WildFly instance from a remote client (irrespective
 of whether it is a standalone client or another server instance) without
 passing the appropriate credentials. Remember that in this example, our

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/Remote_Jakarta_Enterprise_Beans_invocations_via_JNDI_-_Jakarta_Enterprise_Beans_client_API_or_wildfly-naming-client_project.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/Remote_Jakarta_Enterprise_Beans_invocations_via_JNDI_-_Jakarta_Enterprise_Beans_client_API_or_wildfly-naming-client_project.adoc
@@ -57,7 +57,7 @@ wildfly-naming-client project. The other property is the PROVIDER_URL.
 which is `remote+http://` for wildfly-naming-client. The rest
 of the PROVIDER_URL part is the server hostname or IP and the port on
 which the remoting connector is exposed on the server side. By default
-the http-remoting connector port in WildFly {wildflyVersion} is 8080. That's what we
+the http-remoting connector port in WildFly is 8080. That's what we
 have used in our example. The hostname we have used is localhost but
 that should point to the server IP or hostname where the server is
 running.

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/Scoped_Jakarta_Enterprise_Beans_client_contexts.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/Scoped_Jakarta_Enterprise_Beans_client_contexts.adoc
@@ -19,7 +19,7 @@ which is capable of handling the EJB invocation. Typically EJB remote
 applications can be classified into:
 
 * A remote client which runs as a standalone Java application
-* A remote client which runs within another WildFly {wildflyVersion} instance
+* A remote client which runs within another WildFly instance
 
 Depending on the kind of remote client, from an EJB client API point of
 view, there can potentially be more than 1 EJBClientContext(s) within a
@@ -31,7 +31,7 @@ mandatory. Certain standalone applications can potentially have more
 than one EJBClientContext(s) and an EJB client context selector will be
 responsible for returning the appropriate context.
 
-In case of remote clients which run within another WildFly {wildflyVersion} instance,
+In case of remote clients which run within another WildFly instance,
 each deployed application will have a corresponding EJB client context.
 Whenever that application invokes on another EJB, the corresponding EJB
 client context will be used for finding the right EJB receiver and
@@ -42,7 +42,7 @@ letting it handle the invocation.
 
 In the Overview section we briefly looked at the different types of
 remote clients. Let's focus on the standalone remote clients (the ones
-that don't run within another WildFly {wildflyVersion} instance) for some of the next
+that don't run within another WildFly instance) for some of the next
 sections. Like mentioned earlier, typically a remote standalone client
 has just one EJB client context backed by any number of EJB receivers.
 Consider this example:
@@ -74,7 +74,7 @@ invocation request. Since we just have a single EJB client context, that
 context is used by the above code to invoke the bean.
 
 Now let's consider a case where the user application wants to invoke on
-the bean more than once, but wants to connect to the WildFly {wildflyVersion} server
+the bean more than once, but wants to connect to the WildFly server
 using different security credentials. Let's take a look at the following
 code:
 
@@ -188,7 +188,7 @@ This scoping of the EJB client context helps the user applications to
 have more control over which JNDI context "talks to" which server and
 connects to that server in "what way". This gives the user applications
 the flexibility that was associated with the JNP based JNDI invocations
-prior to WildFly {wildflyVersion} versions.
+prior to WildFly versions.
 
 [NOTE]
 

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/Securing_Jakarta_Enterprise_Beans.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/Securing_Jakarta_Enterprise_Beans.adoc
@@ -22,7 +22,7 @@ specific extensions to the security configurations.
 
 The EE Platform specification doesn't mandate a specific way to configure security
 domain for a bean. It leaves it to the vendor implementations to allow
-such configurations, the way they wish. In WildFly {wildflyVersion}, the use of
+such configurations, the way they wish. In WildFly, the use of
 `@org.jboss.ejb3.annotation.SecurityDomain` annotation allows the
 developer to configure the security domain for a bean. Here's an
 example:
@@ -101,13 +101,13 @@ public class FooBean {
 
 As you can see the `doSomething` method is configured to be accessible
 for users with role "bar". However, the bean isn't configured for any
-specific security domain. Prior to WildFly {wildflyVersion}, the absence of an
+specific security domain. Prior to WildFly 8, the absence of an
 explicitly configured security domain on the bean would leave the bean
 unsecured, which meant that even if the `doSomething` method was
 configured with `@RolesAllowed("bar")` anyone even without the "bar"
 role could invoke on the bean.
 
-In WildFly {wildflyVersion}, the presence of any security metadata (like @RolesAllowed,
+In WildFly, the presence of any security metadata (like @RolesAllowed,
 @PermitAll, @DenyAll, @RunAs, @RunAsPrincipal) on the bean or any
 business method of the bean, makes the bean secure, even in the absence
 of an explicitly configured security domain. In such cases, the security
@@ -142,7 +142,7 @@ users with role "bar". That enables security on the bean (with security
 domain defaulted to "other"). However, notice that the method
 `helloWorld` doesn't have any specific security configurations.
 
-In WildFly {wildflyVersion}, such methods which have no explicit security
+In WildFly, such methods which have no explicit security
 configurations, in a secured bean, will be treated similar to a method
 with `@DenyAll` configuration. What that means is, no one is allowed
 access to the `helloWorld` method. This behaviour can be controlled via

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/jboss-ejb3.xml_Reference.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/jboss-ejb3.xml_Reference.adoc
@@ -142,7 +142,7 @@ defined in the server configuration (i.e. `standalone.xml` or
 [[the-clustering-namespace-urnclustering1.0]]
 ==== The clustering namespace urn:clustering:1.0
 
-This namespace is deprecated and as of WildFly {wildflyVersion} its use has no effect.
+This namespace is deprecated and its use has no effect.
 The clustering behavior of Jakarta Enterprise Beans are determined by the profile in use on
 the server.
 

--- a/docs/src/main/asciidoc/_extending-wildfly/Domain_Mode_Subsystem_Transformers.adoc
+++ b/docs/src/main/asciidoc/_extending-wildfly/Domain_Mode_Subsystem_Transformers.adoc
@@ -371,7 +371,7 @@ of 1.0.0, and its resource description was as follows:
                 },
 ----
 
-In WildFly {wildflyVersion}, it has a ModelVersion of 2.0.0 and has added two
+In WildFly, it has a ModelVersion of 2.0.0 and has two
 attributes, `require-bean-descriptor` and `non-portable` mode:
 
 [source,options="nowrap"]
@@ -436,7 +436,7 @@ attributes, `require-bean-descriptor` and `non-portable` mode:
 ----
 
 In the rest of this section we will assume that we are running a DC
-running WildFly {wildflyVersion} so it will have ModelVersion 2.0.0 of the weld
+running WildFly so it will have ModelVersion 2.0.0 of the weld
 subsystem, and that we are running a secondary HC using ModelVersion 1.0.0 of
 the weld subsystem.
 
@@ -575,7 +575,7 @@ This removal is fine since they have the values which would result in
 the behavior assumed on the legacy secondary HC.
 
 That way the older secondary HCs will work fine. However, we might also have
-WildFly {wildflyVersion} secondary HCs in our domain, and they are missing out on the new
+WildFly secondary HCs in our domain, and they are missing out on the new
 features introduced by the attributes introduced in ModelVersion 2.0.0.
 If we do
 
@@ -619,9 +619,9 @@ The solution is to put these in two different profiles in `domain.xml`
 </domain>
 ----
 
-Then have the HCs using WildFly {wildflyVersion} make their servers reference the
+Then have the HCs using WildFly make their servers reference the
 `main-server-group` server group, and the HCs using older versions of
-WildFly {wildflyVersion} make their servers reference the `main-server-group-legacy`
+WildFly make their servers reference the `main-server-group-legacy`
 server group.
 
 [[ignoring-resources-on-legacy-hosts]]
@@ -1973,7 +1973,7 @@ transformers>>
 [[the-old-way]]
 === The old way
 
-This is the way that has been used up to WildFly {wildflyVersion}.x. However, in
+This is the old way. However, in
 WildFly 9 and later, it is strongly recommended to migrate to what is
 mentioned in
 <<chained-transformers,#Chained
@@ -2420,7 +2420,7 @@ Missing parameters for operation 'add' in current: []; missing in legacy [protoc
 This difference also affects the `add` operation. Looking at the current
 model the valid values for the `protocol` attribute are `remote`,
 `http-remoting` and `https-remoting`. The last two are new protocols
-introduced in WildFly {wildflyVersion}, meaning that the _implied behaviour_ in JBoss
+introduced in WildFly, meaning that the _implied behaviour_ in JBoss
 7.2.0 and earlier is the `remote` protocol. Since this attribute does
 not exist in the legacy model we want to discard this attribute if it is
 `undefined` or if it has the value `remote`, both of which are in line

--- a/docs/src/main/asciidoc/_extending-wildfly/WildFly_JNDI_Implementation.adoc
+++ b/docs/src/main/asciidoc/_extending-wildfly/WildFly_JNDI_Implementation.adoc
@@ -17,7 +17,7 @@ new/updated APIs for WildFly subsystem and EE deployment processors
 developers to bind new resources easier.
 
 To support discussion in the community, the content includes a big focus
-on comparing WildFly {wildflyVersion} JNDI implementation with the new proposal, and
+on comparing WildFly JNDI implementation with the new proposal, and
 should later evolve to the prime guide for WildFly developers needing to
 interact with JNDI at subsystem level.
 

--- a/docs/src/main/asciidoc/_high-availability/Clustering_and_Domain_Setup_Walkthrough.adoc
+++ b/docs/src/main/asciidoc/_high-availability/Clustering_and_Domain_Setup_Walkthrough.adoc
@@ -106,7 +106,7 @@ wildfly-{wildflyVersion}.0.0.Final/bin$ ./domain.sh
 =========================================================================
 ...
 
-[Server:server-two] 14:46:12,375 INFO  [org.jboss.as] (Controller Boot Thread) JBAS015874: WildFly {wildflyVersion}.0.0.Final "Kenny" started in 8860ms - Started 210 of 258 services (8{wildflyVersion} services are lazy, passive or on-demand)
+[Server:server-two] 14:46:12,375 INFO  [org.jboss.as] (Controller Boot Thread) JBAS015874: WildFly 8.0.0.Final "Kenny" started in 8860ms - Started 210 of 258 services (48 services are lazy, passive or on-demand)
 ----
 
 Now exit from the primary host and let's repeat the same steps on the secondary host. Finally,

--- a/docs/src/main/asciidoc/_testsuite/WildFly_Integration_Testsuite_User_Guide.adoc
+++ b/docs/src/main/asciidoc/_testsuite/WildFly_Integration_Testsuite_User_Guide.adoc
@@ -228,7 +228,7 @@ Arquillian).
 [[running-against-a-running-jboss-as-instance]]
 ==== Running against a running JBoss AS instance
 
-Arquillian's WildFly {wildflyVersion} container adapter allows specifying
+Arquillian's WildFly container adapter allows specifying
 `allowConnectingToRunningServer` in `arquillian.xml`, which makes it
 check whether AS is listening at `managementAddress:managementPort`, and
 if so, it uses that server instead of launching a new one, and doesn't


### PR DESCRIPTION
JIRA Issue: [WFLY-20876](https://redhat.atlassian.net/browse/WFLY-20876)

**Description**

The docs use a dynamic `{wildflyVersion}` attribute (injected via Maven from `product.docs.server.version`) throughout the AsciiDoc sources. Many of these uses produce misleading or low-value text when the current version number is substituted. This PR addresses both aspects of WFLY-20876:

**Bug fixes (misleading version info):**
  - Fixed `8{wildflyVersion}` typo in `Clustering_and_Domain_Setup_Walkthrough.adoc:109` that rendered as "842 services", corrected to "48" (258 - 210) and hardcoded the version to `WildFly 8.0.0.Final` to match the JBAS log codes and 2014 timestamps in the example.
  - Fixed fake log example in `Logging.adoc:237` that paired 2014 timestamps and `JBAS` log codes with the current dynamic version hardcoded to `WildFly 8.0.0.Final` to match the era.
  - Removed misleading "as of WildFly {wildflyVersion}" in `jboss-ejb3.xml_Reference.adoc:145` that falsely implied deprecation happened in the current release ModelVersion 2.0.0 was from the current release, replaced with historically accurate `WildFly 8` references (current model version is actually 5.0.0, see `WeldExtension.java:38`)
    
  **Low-value removals:**
  - Removed `{wildflyVersion}` from generic statements across 20+ files where the version adds no value, e.g. "WildFly {wildflyVersion} is secure by default" or "install a JDBC driver into WildFly {wildflyVersion}"
  - These describe capabilities that have existed for many releases and are not version-specific
  
  **Intentional keeps (16 references):**
  - `Different_Flavors_of_WildFly.adoc:83,96` — version-specific SecurityManager behavior (WildFly 40+)
  - `Getting_Started_Guide.adoc:27,36` — release-identifying text in headings
  - `Getting_Started_Guide.adoc:183-196` — download filename literals
  - `Clustering_and_Domain_Setup_Walkthrough.adoc:85,86,95,100` — filename literals in shell commands
  - `index.adoc:2` — doc landing page title
  
  Discussed on Zulip: [link](https://wildfly.zulipchat.com/#narrow/channel/174184-wildfly-developers/topic/WFLY-20876/with/619651854) with @bstansberry before proceeding beyond the bug-fix portion.